### PR TITLE
Restores the code block style functionality for coaching Notes

### DIFF
--- a/src/styles/code-block.scss
+++ b/src/styles/code-block.scss
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@use "tailwindcss/base" as *;
+@use "tailwindcss/components" as *;
+@use "tailwindcss/utilities" as *;
 
 .tiptap {
   .code-block {

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,16 +1,12 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
-
-// Your custom SCSS styles here
+@use "tailwindcss/base" as *;
+@use "tailwindcss/components" as *;
+@use "tailwindcss/utilities" as *;
 
 /* Basic TipTap editor styles */
 .tiptap {
   :first-child {
     margin-top: 0;
   }
-
-
 
   /* List styles */
   ul,


### PR DESCRIPTION
## Description
This PR fixes the code block style bug and addresses the deprecation warning about the Sass @import statement.


#### GitHub Issue: Fixes #57 

### Changes
* Fixes the code block style bug and addresses the deprecation warning about the Sass @import statement

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1903" alt="Screenshot 2024-12-23 at 21 07 30" src="https://github.com/user-attachments/assets/8ce7574c-a160-44bf-82b0-8c0c66d3e6f2" />

### Testing Strategy
1. Go to a coaching session
2. Add a code block
3. Observe that syntax highlighting and a code block now appear as expected


### Concerns
None