### PR TITLE
Add the OverarchingGoal.title to the CoachingSessionSelector component

### DIFF
--- a/src/components/ui/coaching-session-selector.tsx
+++ b/src/components/ui/coaching-session-selector.tsx
@@ -12,9 +12,11 @@ import {
 } from "@/components/ui/select";
 import { getDateTimeFromString, Id } from "@/types/general";
 import { useCoachingSessions } from "@/lib/api/coaching-sessions";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { DateTime } from "ts-luxon";
 import { useCoachingSessionStateStore } from "@/lib/providers/coaching-session-state-store-provider";
+import { fetchOverarchingGoalsByCoachingSessionId } from "@/lib/api/overarching-goals";
+import { OverarchingGoal } from "@/types/overarching-goal";
 
 interface CoachingSessionsSelectorProps extends PopoverProps {
   /// The CoachingRelationship Id for which to get a list of associated CoachingSessions
@@ -30,25 +32,47 @@ function CoachingSessionsSelectItems({
 }: {
   relationshipId: Id;
 }) {
-  const { coachingSessions, isLoading, isError } =
-    useCoachingSessions(relationshipId);
+  const {
+    coachingSessions,
+    isLoading: isLoadingSessions,
+    isError: isErrorSessions,
+  } = useCoachingSessions(relationshipId);
+
   const { setCurrentCoachingSessions } = useCoachingSessionStateStore(
     (state) => state
   );
+  const [goals, setGoals] = useState<(OverarchingGoal[] | undefined)[]>([]);
+  const [isLoadingGoals, setIsLoadingGoals] = useState(false);
 
-  console.debug(`coachingSessions: ${JSON.stringify(coachingSessions)}`);
-
-  // Be sure to cache the list of current coaching sessions in the CoachingSessionStateStore
   useEffect(() => {
     if (!coachingSessions.length) return;
-    console.debug(
-      `coachingSessions (useEffect): ${JSON.stringify(coachingSessions)}`
-    );
     setCurrentCoachingSessions(coachingSessions);
   }, [coachingSessions]);
 
-  if (isLoading) return <div>Loading...</div>;
-  if (isError) return <div>Error loading coaching sessions</div>;
+  useEffect(() => {
+    const fetchGoals = async () => {
+      setIsLoadingGoals(true);
+      try {
+        const sessionIds = coachingSessions?.map((session) => session.id) || [];
+        const goalsPromises = sessionIds.map((id) =>
+          fetchOverarchingGoalsByCoachingSessionId(id)
+        );
+        const fetchedGoals = await Promise.all(goalsPromises);
+        setGoals(fetchedGoals);
+      } catch (error) {
+        console.error("Error fetching goals:", error);
+      } finally {
+        setIsLoadingGoals(false);
+      }
+    };
+
+    if (coachingSessions?.length) {
+      fetchGoals();
+    }
+  }, [coachingSessions]);
+
+  if (isLoadingSessions || isLoadingGoals) return <div>Loading...</div>;
+  if (isErrorSessions) return <div>Error loading coaching sessions</div>;
   if (!coachingSessions?.length) return <div>No coaching sessions found</div>;
 
   return (
@@ -62,13 +86,25 @@ function CoachingSessionsSelectItems({
             .filter(
               (session) => getDateTimeFromString(session.date) < DateTime.now()
             )
-            .map((session) => (
-              <SelectItem value={session.id} key={session.id}>
-                {getDateTimeFromString(session.date).toLocaleString(
-                  DateTime.DATETIME_FULL
-                )}
-              </SelectItem>
-            ))}
+            .map((session) => {
+              const sessionIndex = coachingSessions.findIndex(
+                (s) => s.id === session.id
+              );
+              return (
+                <SelectItem value={session.id} key={session.id}>
+                  <div className="flex flex-col w-full">
+                    <span className="text-left truncate overflow-hidden">
+                      {goals[sessionIndex]?.[0]?.title || "No goal set"}
+                    </span>
+                    <span className="text-sm text-gray-400">
+                      {getDateTimeFromString(session.date).toLocaleString(
+                        DateTime.DATETIME_FULL
+                      )}
+                    </span>
+                  </div>
+                </SelectItem>
+              );
+            })}
         </SelectGroup>
       )}
       {coachingSessions.some(
@@ -80,13 +116,25 @@ function CoachingSessionsSelectItems({
             .filter(
               (session) => getDateTimeFromString(session.date) >= DateTime.now()
             )
-            .map((session) => (
-              <SelectItem value={session.id} key={session.id}>
-                {getDateTimeFromString(session.date).toLocaleString(
-                  DateTime.DATETIME_FULL
-                )}
-              </SelectItem>
-            ))}
+            .map((session) => {
+              const sessionIndex = coachingSessions.findIndex(
+                (s) => s.id === session.id
+              );
+              return (
+                <SelectItem value={session.id} key={session.id}>
+                  <div className="flex flex-col w-full">
+                    <span className="text-left truncate overflow-hidden">
+                      {goals[sessionIndex]?.[0]?.title || "No goal set"}
+                    </span>
+                    <span className="text-sm text-gray-400">
+                      {getDateTimeFromString(session.date).toLocaleString(
+                        DateTime.DATETIME_FULL
+                      )}
+                    </span>
+                  </div>
+                </SelectItem>
+              );
+            })}
         </SelectGroup>
       )}
     </>
@@ -105,23 +153,51 @@ export default function CoachingSessionSelector({
     getCurrentCoachingSession,
   } = useCoachingSessionStateStore((state) => state);
 
-  const handleSetCoachingSession = (coachingSessionId: Id) => {
-    setCurrentCoachingSessionId(coachingSessionId);
-    if (onSelect) {
-      onSelect(relationshipId);
-    }
-  };
+  const [currentGoal, setCurrentGoal] = useState<OverarchingGoal | undefined>();
+  const [isLoadingGoal, setIsLoadingGoal] = useState(false);
 
   const currentSession = currentCoachingSessionId
     ? getCurrentCoachingSession(currentCoachingSessionId)
     : null;
 
+  useEffect(() => {
+    const fetchGoal = async () => {
+      if (!currentCoachingSessionId) return;
+
+      setIsLoadingGoal(true);
+      try {
+        const goals = await fetchOverarchingGoalsByCoachingSessionId(
+          currentCoachingSessionId
+        );
+        setCurrentGoal(goals[0]);
+      } catch (error) {
+        console.error("Error fetching goal:", error);
+      } finally {
+        setIsLoadingGoal(false);
+      }
+    };
+
+    fetchGoal();
+  }, [currentCoachingSessionId]);
+
+  const handleSetCoachingSession = (coachingSessionId: Id) => {
+    setCurrentCoachingSessionId(coachingSessionId);
+    if (onSelect) {
+      onSelect(coachingSessionId);
+    }
+  };
+
   const displayValue = currentSession ? (
-    <>
-      {getDateTimeFromString(currentSession.date).toLocaleString(
-        DateTime.DATETIME_FULL
-      )}
-    </>
+    <div className="flex flex-col w-[28rem]">
+      <span className="truncate overflow-hidden text-left">
+        {currentGoal?.title || "No goal set"}
+      </span>
+      <span className="text-sm text-gray-500 text-left">
+        {getDateTimeFromString(currentSession.date).toLocaleString(
+          DateTime.DATETIME_FULL
+        )}
+      </span>
+    </div>
   ) : undefined;
 
   return (

--- a/src/lib/providers/overarching-goal-state-store-provider.tsx
+++ b/src/lib/providers/overarching-goal-state-store-provider.tsx
@@ -1,0 +1,47 @@
+// The purpose of this provider is to provide compatibility with
+// Next.js re-rendering and component caching
+"use client";
+
+import { type ReactNode, createContext, useRef, useContext } from "react";
+import { type StoreApi, useStore } from "zustand";
+
+import {
+  type OverarchingGoalStateStore,
+  createOverarchingGoalStateStore,
+} from "@/lib/stores/overarching-goal-state-store";
+
+export const OverarchingGoalStateStoreContext =
+  createContext<StoreApi<OverarchingGoalStateStore> | null>(null);
+
+export interface OverarchingGoalStateStoreProviderProps {
+  children: ReactNode;
+}
+
+export const OverarchingGoalStateStoreProvider = ({
+  children,
+}: OverarchingGoalStateStoreProviderProps) => {
+  const storeRef = useRef<StoreApi<OverarchingGoalStateStore>>(undefined);
+  if (!storeRef.current) {
+    storeRef.current = createOverarchingGoalStateStore();
+  }
+
+  return (
+    <OverarchingGoalStateStoreContext.Provider value={storeRef.current}>
+      {children}
+    </OverarchingGoalStateStoreContext.Provider>
+  );
+};
+
+export const useOverarchingGoalStateStore = <T,>(
+  selector: (store: OverarchingGoalStateStore) => T
+): T => {
+  const oagStateStoreContext = useContext(OverarchingGoalStateStoreContext);
+
+  if (!oagStateStoreContext) {
+    throw new Error(
+      `useOverarchingGoalStateStore must be used within OverarchingGoalStateStoreProvider`
+    );
+  }
+
+  return useStore(oagStateStoreContext, selector);
+};

--- a/src/lib/providers/root-layout-providers.tsx
+++ b/src/lib/providers/root-layout-providers.tsx
@@ -6,6 +6,7 @@ import { SWRConfig } from "swr";
 import { OrganizationStateStoreProvider } from "./organization-state-store-provider";
 import { CoachingRelationshipStateStoreProvider } from "./coaching-relationship-state-store-provider";
 import { CoachingSessionStateStoreProvider } from "./coaching-session-state-store-provider";
+import { OverarchingGoalStateStoreProvider } from "./overarching-goal-state-store-provider";
 
 export function RootLayoutProviders({
   children,
@@ -24,15 +25,17 @@ export function RootLayoutProviders({
         <OrganizationStateStoreProvider>
           <CoachingRelationshipStateStoreProvider>
             <CoachingSessionStateStoreProvider>
-              <SWRConfig
-                value={{
-                  revalidateIfStale: true,
-                  focusThrottleInterval: 10000,
-                  provider: () => new Map(),
-                }}
-              >
-                {children}
-              </SWRConfig>
+              <OverarchingGoalStateStoreProvider>
+                <SWRConfig
+                  value={{
+                    revalidateIfStale: true,
+                    focusThrottleInterval: 10000,
+                    provider: () => new Map(),
+                  }}
+                >
+                  {children}
+                </SWRConfig>
+              </OverarchingGoalStateStoreProvider>
             </CoachingSessionStateStoreProvider>
           </CoachingRelationshipStateStoreProvider>
         </OrganizationStateStoreProvider>

--- a/src/lib/stores/coaching-session-state-store.ts
+++ b/src/lib/stores/coaching-session-state-store.ts
@@ -16,6 +16,7 @@ interface CoachingSessionState {
 
 interface CoachingSessionsStateActions {
   getCurrentCoachingSession: (coachingSessionId: Id) => CoachingSession;
+  getCurrentCoachingSessionId: () => Id;
   setCurrentCoachingSessionId: (newCoachingSessionId: Id) => void;
   setCurrentCoachingSession: (newCoachingSession: CoachingSession) => void;
   setCurrentCoachingSessions: (newCoachingSessions: CoachingSession[]) => void;
@@ -51,11 +52,17 @@ export const createCoachingSessionStateStore = (
                 )
               : defaultCoachingSession();
           },
+          getCurrentCoachingSessionId: () => {
+            return get().currentCoachingSessionId;
+          },
           setCurrentCoachingSessionId: (newCoachingSessionId) => {
             set({ currentCoachingSessionId: newCoachingSessionId });
           },
           setCurrentCoachingSession: (newCoachingSession) => {
-            set({ currentCoachingSession: newCoachingSession });
+            set({
+              currentCoachingSession: newCoachingSession,
+              currentCoachingSessionId: newCoachingSession.id,
+            });
           },
           setCurrentCoachingSessions: (
             newCoachingSessions: CoachingSession[]

--- a/src/lib/stores/overarching-goal-state-store.ts
+++ b/src/lib/stores/overarching-goal-state-store.ts
@@ -1,0 +1,75 @@
+import { Id } from "@/types/general";
+import {
+  defaultOverarchingGoal,
+  defaultOverarchingGoals,
+  getOverarchingGoalById,
+  OverarchingGoal,
+} from "@/types/overarching-goal";
+import { create } from "zustand";
+import { createJSONStorage, devtools, persist } from "zustand/middleware";
+
+interface OverarchingGoalState {
+  currentOverarchingGoalId: Id;
+  currentOverarchingGoal: OverarchingGoal;
+  currentOverarchingGoals: OverarchingGoal[];
+}
+
+interface OverarchingGoalStateActions {
+  getCurrentOverarchingGoal: (overarchingGoalId: Id) => OverarchingGoal;
+  setCurrentOverarchingGoalId: (newOverarchingGoalId: Id) => void;
+  setCurrentOverarchingGoal: (newOverarchingGoal: OverarchingGoal) => void;
+  setCurrentOverarchingGoals: (newOverarchingGoals: OverarchingGoal[]) => void;
+  resetOverarchingGoalState(): void;
+}
+
+export type OverarchingGoalStateStore = OverarchingGoalState &
+  OverarchingGoalStateActions;
+
+export const defaultInitState: OverarchingGoalState = {
+  currentOverarchingGoalId: "",
+  currentOverarchingGoal: defaultOverarchingGoal(),
+  currentOverarchingGoals: defaultOverarchingGoals(),
+};
+
+export const createOverarchingGoalStateStore = (
+  initState: OverarchingGoalState = defaultInitState
+) => {
+  const oagStateStore = create<OverarchingGoalStateStore>()(
+    devtools(
+      persist(
+        (set, get) => ({
+          ...initState,
+
+          // Expects the array of OverarchingGoals to be fetched and set
+          getCurrentOverarchingGoal: (
+            overarchingGoalId: Id
+          ): OverarchingGoal => {
+            return get().currentOverarchingGoals
+              ? getOverarchingGoalById(
+                  overarchingGoalId,
+                  get().currentOverarchingGoals
+                )
+              : defaultOverarchingGoal();
+          },
+          setCurrentOverarchingGoalId: (newOverarchingGoalId) => {
+            set({ currentOverarchingGoalId: newOverarchingGoalId });
+          },
+          setCurrentOverarchingGoal: (newOverarchingGoal) => {
+            set({ currentOverarchingGoal: newOverarchingGoal });
+          },
+          setCurrentOverarchingGoals(newOverarchingGoals: OverarchingGoal[]) {
+            set({ currentOverarchingGoals: newOverarchingGoals });
+          },
+          resetOverarchingGoalState(): void {
+            set(defaultInitState);
+          },
+        }),
+        {
+          name: "overarching-goal-state-store",
+          storage: createJSONStorage(() => sessionStorage),
+        }
+      )
+    )
+  );
+  return oagStateStore;
+};


### PR DESCRIPTION
## Description
This PR adds the OverarchingGoal.title to the CoachingSessionSelector component for more context in choosing the right session to join.


#### GitHub Issue: None

### Changes
* Adds the OverarchingGoal.title to the CoachingSessionSelector component
* Adds a new OverarchingGoalStateStore
* Adds SWR-based fetch hooks for working with OverarchingGoals

### Screenshots / Videos Showing UI Changes (if applicable)

<img width="860" alt="Screenshot 2024-12-29 at 15 43 25" src="https://github.com/user-attachments/assets/7ffe5233-44a2-4c57-8e3e-099d5c0d0a81" />

<img width="1088" alt="Screenshot 2024-12-29 at 15 44 21" src="https://github.com/user-attachments/assets/8ed085b9-f83f-4b83-b83b-ac3a14fbb434" />

### Testing Strategy
1. Login
2. Verify that the overarching goal for a session is display in the selector component
3. If it isn't, "No goal set" should display instead

### Concerns
None