### PR TITLE
Improve the size/styling of the CoachingSessionSelector and SelectCoachingSession components

### DIFF
--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -151,7 +151,7 @@ export default function CoachingSessionsPage() {
             style={siteConfig.titleStyle}
             onRender={handleTitleRender}
           ></CoachingSessionTitle>
-          <div className="ml-auto flex w-[28rem] space-x-2 sm:justify-end">
+          <div className="ml-auto flex w-full sm:max-w-sm md:max-w-md space-x-2 sm:justify-end md:justify-start">
             <CoachingSessionSelector
               relationshipId={currentCoachingRelationshipId}
               disabled={!currentCoachingRelationshipId}

--- a/src/components/ui/coaching-session-selector.tsx
+++ b/src/components/ui/coaching-session-selector.tsx
@@ -186,10 +186,10 @@ export default function CoachingSessionSelector({
 
   const displayValue = currentSession ? (
     <div className="flex flex-col w-full">
-      <span className="truncate overflow-hidden text-left">
+      <span className="truncate text-left">
         {currentGoal?.title || "No goal set"}
       </span>
-      <span className="text-sm text-gray-500 text-left truncate overflow-hidden">
+      <span className="text-sm text-gray-500 text-left truncate">
         {getDateTimeFromString(currentSession.date).toLocaleString(
           DateTime.DATETIME_FULL
         )}

--- a/src/components/ui/dashboard/select-coaching-session.tsx
+++ b/src/components/ui/dashboard/select-coaching-session.tsx
@@ -31,14 +31,14 @@ export default function SelectCoachingSession() {
   );
 
   return (
-    <Card>
+    <Card className="w-full min-w-0 sm:min-w-[320]">
       <CardHeader>
         <CardTitle>Join a Coaching Session</CardTitle>
         <CardDescription>
           Select current organization, relationship and session
         </CardDescription>
       </CardHeader>
-      <CardContent className="grid gap-6">
+      <CardContent className="grid gap-6 min-w-0">
         <div className="grid gap-2">
           <Label htmlFor="organization">Organization</Label>
           <OrganizationSelector userId={userId}></OrganizationSelector>


### PR DESCRIPTION
## Description
This PR improves the size/styling of the CoachingSessionSelector and SelectCoachingSession components with better padding, text truncation and dedupe repetitive TSX code.


#### GitHub Issue: None

### Changes
* Improves padding (vertically and on the right side)
* Ensures the CoachingSessionSelector never grows larger on the right side than its parent Card container component
* Truncates SelectItem text in a responsive way
* Dedupes repetitive SelectItem TSX code down into a single source

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="970" alt="Screenshot 2025-01-04 at 15 17 25" src="https://github.com/user-attachments/assets/118f0176-9d77-498f-bf9a-c9cf84f91352" />


### Testing Strategy
1. Visit the Dashboard page and play with the size of the browser window (horizontal size)
2. Observe that the coaching session selector truncates text and the select item never grows larger than the container Card component
3. Also observe this same behavior within the coaching session page.


### Concerns
1. Truncation of SelectItem text is not perfect and I'm not sure why yet. Nonetheless, this is a huge improvement and hopefully we can figure out perfect text truncation in the future.