### PR TITLE
Add tiptap with EditorProvider

### DIFF
--- a/src/components/ui/coaching-sessions/tiptap-editor.tsx
+++ b/src/components/ui/coaching-sessions/tiptap-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEditor, EditorContent } from "@tiptap/react";
+import { EditorProvider } from "@tiptap/react";
 import { TiptapCollabProvider } from "@hocuspocus/provider";
 import * as Y from "yjs";
 import { useEffect, useState } from "react";
@@ -12,7 +12,7 @@ import { Toolbar } from "@/components/ui/coaching-sessions/tiptap-editor/toolbar
 import { siteConfig } from "@/site.config";
 import "@/styles/styles.scss";
 
-const TipTapEditor = () => {
+const useCollaborationProvider = (doc: Y.Doc) => {
   const { currentCoachingSessionId } = useCoachingSessionStateStore(
     (state) => state
   );
@@ -22,20 +22,14 @@ const TipTapEditor = () => {
   const { jwt, isLoading, isError } = useCollaborationToken(
     currentCoachingSessionId
   );
-
-  const [provider, setProvider] = useState<TiptapCollabProvider | null>(null);
-
-  // Initialize the Yjs document
-  const [doc] = useState(() => new Y.Doc());
-
+  const [isSyncing, setIsSyncing] = useState(true);
   useEffect(() => {
     const tiptapAppId = siteConfig.env.tiptapAppId;
     if (!tiptapAppId) {
       console.error("TIPTAP_APP_ID not set");
-      return; // Optionally return early if the app ID is not set
+      return;
     }
 
-    // Only initialize the provider when JWT is available and there are no errors
     if (!isLoading && !isError && jwt) {
       const newProvider = new TiptapCollabProvider({
         name: jwt.sub,
@@ -45,48 +39,54 @@ const TipTapEditor = () => {
         user: userSession.display_name,
         connect: true,
         broadcast: true,
+        onSynced() {
+          if (!doc.getMap("config").get("initialContentLoaded")) {
+            doc.getMap("config").set("initialContentLoaded", true);
+          }
+        },
       });
 
-      setProvider(newProvider);
+      newProvider.on("synced", () => {
+        setIsSyncing(false);
+      });
 
-      // Cleanup function to disconnect the provider when the component unmounts
       return () => {
         newProvider.disconnect();
       };
     }
   }, [jwt, isLoading, isError, doc, userSession.display_name]);
 
-  const editor = useEditor({
-    extensions: Extensions(doc),
-    autofocus: false,
-    immediatelyRender: false,
-    onContentError: (error) => {
-      console.error("Editor content error:", error);
-    },
-    editorProps: {
-      attributes: {
-        class:
-          "tiptap ProseMirror shadow appearance-none lg:min-h-[440px] sm:min-h-[200px] md:min-h-[350px] rounded w-full py-2 px-3 bg-inherit text-black dark:text-white text-sm mt-0 md:mt-3 leading-tight focus:outline-none focus:shadow-outline",
-      },
-    },
-  });
+  return {
+    isLoading: isLoading || isSyncing,
+    isError,
+  };
+};
 
-  if (isLoading) {
-    return <div>Loading editor...</div>;
-  }
+const TipTapEditor = () => {
+  const [doc] = useState(() => new Y.Doc());
+  const { isLoading, isError } = useCollaborationProvider(doc);
 
-  if (isError) {
+  if (isLoading) return <div>Loading editor...</div>;
+  if (isError)
     return <div>Error initializing editor. Please try again later.</div>;
-  }
-
-  if (!editor || !provider) {
-    return null;
-  }
 
   return (
     <div className="border rounded">
-      <Toolbar editor={editor} />
-      <EditorContent editor={editor} />
+      <EditorProvider
+        extensions={Extensions(doc)}
+        autofocus={false}
+        immediatelyRender={false}
+        onContentError={(error: any) =>
+          console.error("Editor content error:", error)
+        }
+        editorProps={{
+          attributes: {
+            class:
+              "tiptap ProseMirror shadow appearance-none lg:min-h-[440px] sm:min-h-[200px] md:min-h-[350px] rounded w-full py-2 px-3 bg-inherit text-black dark:text-white text-sm mt-0 md:mt-3 leading-tight focus:outline-none focus:shadow-outline",
+          },
+        }}
+        slotBefore={<Toolbar />}
+      />
     </div>
   );
 };

--- a/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useCurrentEditor, type Editor } from "@tiptap/react";
+import { useCurrentEditor } from "@tiptap/react";
 import {
   Bold,
   Heading1,
@@ -15,12 +15,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-interface ToolbarProps {
-  editor: Editor | null;
-}
-
 export const Toolbar = () => {
-  // export const Toolbar = ({ editor }: ToolbarProps) => {
   const { editor } = useCurrentEditor();
 
   if (!editor) {

--- a/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import type { Editor } from "@tiptap/react";
+import { useCurrentEditor, type Editor } from "@tiptap/react";
 import {
   Bold,
   Heading1,
@@ -19,7 +19,11 @@ interface ToolbarProps {
   editor: Editor | null;
 }
 
-export const Toolbar = ({ editor }: ToolbarProps) => {
+export const Toolbar = () => {
+  // export const Toolbar = ({ editor }: ToolbarProps) => {
+  const { editor } = useCurrentEditor();
+
+  console.log("editor toolbar", editor);
   if (!editor) {
     return null;
   }

--- a/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/tiptap-editor/toolbar.tsx
@@ -23,7 +23,6 @@ export const Toolbar = () => {
   // export const Toolbar = ({ editor }: ToolbarProps) => {
   const { editor } = useCurrentEditor();
 
-  console.log("editor toolbar", editor);
   if (!editor) {
     return null;
   }

--- a/src/lib/api/collaborationToken.ts
+++ b/src/lib/api/collaborationToken.ts
@@ -3,10 +3,8 @@ import useSWR from "swr";
 import { Jwt, parseJwt } from "@/types/jwt";
 import { siteConfig } from "@/site.config";
 
-const fetcher = async (
-  url: string,
-  coachingSessionId: string
-): Promise<Jwt> => {
+type FetcherArgs = [string, string];
+const fetcher = async ([url, coachingSessionId]: FetcherArgs): Promise<Jwt> => {
   const response = await axios.get(url, {
     params: { coaching_session_id: coachingSessionId },
     withCredentials: true,
@@ -15,6 +13,7 @@ const fetcher = async (
       "X-Version": siteConfig.env.backendApiVersion,
     },
   });
+
   const data = response.data.data;
   return parseJwt(data);
 };
@@ -25,15 +24,14 @@ const fetcher = async (
  * @returns An object containing the token, loading state, and error state.
  */
 export const useCollaborationToken = (coachingSessionId: string) => {
-  const { data, error } = useSWR<Jwt>(
-    coachingSessionId
-      ? [
-          `${siteConfig.env.backendServiceURL}/jwt/generate_collab_token`,
-          coachingSessionId,
-        ]
-      : null,
-    ([url, id]) => fetcher(url, coachingSessionId)
-  );
+  const requestKey = coachingSessionId
+    ? [
+        `${siteConfig.env.backendServiceURL}/jwt/generate_collab_token`,
+        coachingSessionId,
+      ]
+    : null;
+
+  const { data, error } = useSWR<Jwt>(requestKey, fetcher);
 
   return {
     jwt: data,


### PR DESCRIPTION
## Description

Use `EditorProvider` rather than `useEditor` makes the editor object available to all its children (such as the toolbar) via a context hook `useCurrentEditor`: https://tiptap.dev/docs/editor/getting-started/install/react#integrate-tiptap. The docs have examples of both methods. The provider pattern is calling `useEditor` to get the content anyway, so this pattern is the same except we can now access the editor in toolbar without drilling it as a prop.

Also add the `CollaborationProvider` "syncing" step to our "loading" state for the coaching notes so we don't see a blank text area before we see it loaded with the collab doc content: https://tiptap.dev/docs/collaboration/provider/events#display-connection-status

Minor adjustment to the collaboration token fetcher and query hook. No-op change, just readability.

### Screenshots / Videos Showing UI Changes (if applicable)
https://www.loom.com/share/d394d0ecb7e74030807d1fc8bbc27fad

### Testing Strategy
Local dev testing
