### PR TITLE
Add a middleware layer, handle optimistic auth check on basic routes

### DIFF
--- a/src/lib/api/user-session.ts
+++ b/src/lib/api/user-session.ts
@@ -20,7 +20,7 @@ export const loginUser = async (
   var userSession: UserSession = defaultUserSession();
   var err: string = "";
 
-  const data = await axios
+  await axios
     .post(
       `${siteConfig.env.backendServiceURL}/login`,
       {
@@ -45,8 +45,8 @@ export const loginUser = async (
         // deserialize successfully, then downstream operations will see the default
         // userSessionData in state and we will experience subtle Bugs. We should consider
         // how best we want to handle this. Ex. clear auth cookie?
-        console.debug("userSessionData: ", userSessionData)
-        throw { message: 'Login Failed to produce valid User Session data' }
+        console.debug("userSessionData: ", userSessionData);
+        throw { message: "Login Failed to produce valid User Session data" };
       }
     })
     .catch(function (error: AxiosError) {
@@ -73,7 +73,7 @@ export const logoutUser = async (): Promise<string> => {
   const data = await axios
     .get(`${siteConfig.env.backendServiceURL}/logout`, {
       withCredentials: true,
-      setTimeout: 5000, // 5 seconds before timing out trying to log in with the backend
+      setTimeout: 5000, // 5 seconds before timing out trying to log out with the backend
     })
     .then(function (response: AxiosResponse) {
       // handle success

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -16,7 +16,7 @@ export interface AuthStoreProviderProps {
 
 export const AuthStoreProvider = ({ children }: AuthStoreProviderProps) => {
   const storeRef = useRef<StoreApi<AuthStore>>(undefined);
-  const authStore = window.localStorage.getItem("auth-store");
+  const authStore = localStorage.getItem("auth-store");
 
   const persistedStoreOrNull = authStore ? JSON.parse(authStore).state : null;
 

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -16,8 +16,13 @@ export interface AuthStoreProviderProps {
 
 export const AuthStoreProvider = ({ children }: AuthStoreProviderProps) => {
   const storeRef = useRef<StoreApi<AuthStore>>(undefined);
+  const authStore = localStorage.getItem("auth-store");
+
+  const persistedStoreOrNull = authStore ? JSON.parse(authStore).state : null;
+
   if (!storeRef.current) {
-    storeRef.current = createAuthStore();
+    // storeRef.current = createAuthStore(authStore);
+    storeRef.current = createAuthStore(persistedStoreOrNull);
   }
 
   return (

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -1,8 +1,16 @@
+"use client";
 // The purpose of this provider is to provide compatibility with
 // Next.js re-rendering and component caching
-"use client";
 
-import { type ReactNode, createContext, useRef, useContext } from "react";
+import {
+  type ReactNode,
+  createContext,
+  useRef,
+  useContext,
+  useMemo,
+  useEffect,
+  useState,
+} from "react";
 import { type StoreApi, useStore } from "zustand";
 
 import { type AuthStore, createAuthStore } from "@/lib/stores/auth-store";
@@ -15,13 +23,22 @@ export interface AuthStoreProviderProps {
 }
 
 export const AuthStoreProvider = ({ children }: AuthStoreProviderProps) => {
-  const storeRef = useRef<StoreApi<AuthStore>>(undefined);
-  const authStore = localStorage.getItem("auth-store");
+  const storeRef = useRef<StoreApi<AuthStore> | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
-  const persistedStoreOrNull = authStore ? JSON.parse(authStore).state : null;
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      // Now safe to access localStorage
+      const storedValue = localStorage.getItem("auth-store");
+      const initialState = storedValue ? JSON.parse(storedValue).state : null;
+      storeRef.current = createAuthStore(initialState);
+      setIsInitialized(true);
+    }
+  }, []);
 
-  if (!storeRef.current) {
-    storeRef.current = createAuthStore(persistedStoreOrNull);
+  // Ensure store is initialized before rendering the provider
+  if (!isInitialized) {
+    return null; // or return a loading component
   }
 
   return (

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -16,7 +16,7 @@ export interface AuthStoreProviderProps {
 
 export const AuthStoreProvider = ({ children }: AuthStoreProviderProps) => {
   const storeRef = useRef<StoreApi<AuthStore>>(undefined);
-  const authStore = localStorage.getItem("auth-store");
+  const authStore = window.localStorage.getItem("auth-store");
 
   const persistedStoreOrNull = authStore ? JSON.parse(authStore).state : null;
 

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -21,7 +21,6 @@ export const AuthStoreProvider = ({ children }: AuthStoreProviderProps) => {
   const persistedStoreOrNull = authStore ? JSON.parse(authStore).state : null;
 
   if (!storeRef.current) {
-    // storeRef.current = createAuthStore(authStore);
     storeRef.current = createAuthStore(persistedStoreOrNull);
   }
 

--- a/src/lib/stores/auth-store.ts
+++ b/src/lib/stores/auth-store.ts
@@ -50,7 +50,7 @@ export const createAuthStore = (initState: AuthState = defaultInitState) => {
         }),
         {
           name: "auth-store",
-          storage: createJSONStorage(() => sessionStorage),
+          storage: createJSONStorage(() => localStorage),
         }
       )
     )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// 1. Specify protected and public routes
+const protectedRoutes = [
+  "/dashboard",
+  "/coaching-sessions",
+  "/settings",
+  "/profile",
+];
+const publicRoutes = ["/"];
+
+export default async function middleware(req: NextRequest) {
+  // 2. Check if the current route is protected or public
+  const path = req.nextUrl.pathname;
+  const isProtectedRoute = protectedRoutes.includes(path);
+  const isPublicRoute = publicRoutes.includes(path);
+
+  // 3. Decrypt the session from the cookie
+  const sessionCookie = req.cookies.get("id");
+  let session = sessionCookie?.value;
+
+  // 4. Redirect to / if the user is not authenticated
+  if (isProtectedRoute && !session) {
+    return NextResponse.redirect(new URL("/", req.nextUrl));
+  }
+
+  // 5. Redirect to /dashboard if the user is authenticated
+  if (
+    isPublicRoute &&
+    session &&
+    !req.nextUrl.pathname.startsWith("/dashboard")
+  ) {
+    return NextResponse.redirect(new URL("/dashboard", req.nextUrl));
+  }
+
+  return NextResponse.next();
+}
+
+// Routes Middleware should not run on
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,14 +12,17 @@ const publicRoutes = ["/"];
 export default async function middleware(req: NextRequest) {
   // 2. Check if the current route is protected or public
   const path = req.nextUrl.pathname;
-  const isProtectedRoute = protectedRoutes.includes(path);
-  const isPublicRoute = publicRoutes.includes(path);
+  const isProtectedRoute = protectedRoutes.some((route) =>
+    path.startsWith(route)
+  );
+  const isPublicRoute = publicRoutes.some((route) => path === route);
 
-  // 3. Decrypt the session from the cookie
+  // 3. Get the session from the cookie
   const sessionCookie = req.cookies.get("id");
   const session = sessionCookie?.value;
 
   // 4. Redirect to / if the user is not authenticated
+  // 4b. TODO: Check session validity/expiration?
   if (isProtectedRoute && !session) {
     return NextResponse.redirect(new URL("/", req.nextUrl));
   }
@@ -38,5 +41,5 @@ export default async function middleware(req: NextRequest) {
 
 // Routes Middleware should not run on
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|.*\\.png$).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\.png$).*)"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -17,7 +17,7 @@ export default async function middleware(req: NextRequest) {
 
   // 3. Decrypt the session from the cookie
   const sessionCookie = req.cookies.get("id");
-  let session = sessionCookie?.value;
+  const session = sessionCookie?.value;
 
   // 4. Redirect to / if the user is not authenticated
   if (isProtectedRoute && !session) {


### PR DESCRIPTION
## Description
NextJS has a [cool middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) feature we can leverage.

If I'm logged in and try to visit the login index page, redirect me to the dashboard. If I'm logged out and I try to access /dashboard or /coaching-session/... route, redirect me to the login index page.

This is not meant to be an all-encompassing route protection system. Just a simple "optimistic'  light weight check against the cookie set by our login/logout API.

This does log a user out if their session expires from the backend.

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
_describe how you or someone else can test and verify the changes_


### Concerns
Exposes bug #79 by the use of localStorage but not responsible for the bug.