### PR TITLE
Cosmetic update for coaching session title 

### DIFF
--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -43,14 +43,14 @@ const CoachingSessionTitle: React.FC<{
 
   if (isLoading) {
     return (
-      <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
+      <h4 className="font-semibold break-words w-full md:text-clip">
         {defaultSessionTitle().title}
       </h4>
     );
   }
 
   return (
-    <h4 className="font-semibold break-words w-full px-2 md:px-4 lg:px-6 md:text-clip">
+    <h4 className="font-semibold break-words w-full md:text-clip">
       {sessionTitle ? sessionTitle.title : defaultSessionTitle().title}
     </h4>
   );

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -3,7 +3,7 @@ export const siteConfig = {
   url: "https://refactorcoach.com",
   ogImage: "https://ui.shadcn.com/og.jpg",
   locale: "us",
-  titleStyle: SessionTitleStyle.CoachFirstCoacheeFirstDate,
+  titleStyle: SessionTitleStyle.CoachFirstLastCoacheeFirstLast,
   description: "Coaching and mentorship done right.",
   links: {
     twitter: "https://twitter.com/shadcn",


### PR DESCRIPTION
## Description
Number 3 from https://docs.google.com/document/d/10gTCL0uNu1VHEFQl_PzPmnn07QOcDw89ta5C-UVh9vQ/edit?tab=t.0#heading=h.e3ubvzn7164k


#### GitHub Issue: None

### Changes
* Default to showing first and last names for coach and student
* Remove some extra padding that was inconsistent with the rest of the page layout.

### Screenshots / Videos Showing UI Changes (if applicable)
Spacing change
* new:
<img width="586" alt="Screenshot 2025-03-19 at 9 57 40 AM" src="https://github.com/user-attachments/assets/4b17fc47-26b6-470c-b78f-bfb79bef00ec" />

* old:
<img width="535" alt="Screenshot 2025-03-19 at 9 57 54 AM" src="https://github.com/user-attachments/assets/ddd6d384-89ae-4e63-bc0f-53600a10e052" />

### Testing Strategy
Nav to a coaching page and view

### Concerns
None