### PR TITLE
86 feature add an entity create component

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,7 +3,7 @@ import type * as React from "react";
 import { cn } from "@/components/lib/utils";
 import SelectCoachingRelationship from "@/components/ui/dashboard/select-coaching-relationship";
 import CoachingSessionList from "@/components/ui/dashboard/coaching-session-list";
-import CreateEntity from "@/components/ui/dashboard/create-entity";
+import AddEntities from "@/components/ui/dashboard/add-entities";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -39,7 +39,7 @@ export default function DashboardPage() {
     <>
       <div className="p-4 max-w-screen-2xl">
         <div className="mb-8 w-full">
-          <CreateEntity />
+          <AddEntities />
         </div>
       </div>
       <DashboardContainer>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import type * as React from "react";
 import { cn } from "@/components/lib/utils";
 import SelectCoachingRelationship from "@/components/ui/dashboard/select-coaching-relationship";
 import CoachingSessionList from "@/components/ui/dashboard/coaching-session-list";
+import CreateEntity from "@/components/ui/dashboard/create-entity";
 
 export const metadata: Metadata = {
   title: "Dashboard",
@@ -35,9 +36,16 @@ function DashboardContainer({
 
 export default function DashboardPage() {
   return (
-    <DashboardContainer>
-      <SelectCoachingRelationship />
-      <CoachingSessionList />
-    </DashboardContainer>
+    <>
+      <div className="p-4 max-w-screen-2xl">
+        <div className="mb-8 w-full">
+          <CreateEntity />
+        </div>
+      </div>
+      <DashboardContainer>
+        <SelectCoachingRelationship />
+        <CoachingSessionList />
+      </DashboardContainer>
+    </>
   );
 }

--- a/src/app/organizations/[id]/members/layout.tsx
+++ b/src/app/organizations/[id]/members/layout.tsx
@@ -3,6 +3,8 @@ import "@/styles/globals.css";
 import { siteConfig } from "@/site.config.ts";
 
 import { SiteHeader } from "@/components/ui/site-header";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/ui/app-sidebar";
 export const metadata: Metadata = {
   title: siteConfig.name,
   description: "Manage coaching members",
@@ -14,11 +16,14 @@ export default function MembersLayout({
   children: React.ReactNode;
 }>) {
   return (
-    // Ensure that SiteHeader has enough vertical space to stay sticky at the top
-    // of the page by using "min-h-screen" in the parent div
-    <div className="min-h-screen">
-      <SiteHeader />
-      <main>{children}</main>
-    </div>
+    <SidebarProvider>
+      <div className="flex min-h-screen min-w-full">
+        <AppSidebar />
+        <SidebarInset>
+          <SiteHeader />
+          <main className="flex-1 p-6">{children}</main>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
   );
 }

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { use, useEffect } from "react";
+import { use, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
@@ -14,6 +15,11 @@ export default function MembersPage({
 }: {
   params: Promise<{ id: Id }>;
 }) {
+  const searchParams = useSearchParams();
+  const [openAddMemberDialog] = useState(
+    searchParams.get("addMember") === "true"
+  );
+
   const organizationId = use(params).id;
   const setCurrentOrganizationId = useOrganizationStateStore(
     (state) => state.setCurrentOrganizationId
@@ -67,6 +73,7 @@ export default function MembersPage({
         userSession={userSession}
         onRefresh={handleRefresh}
         isLoading={isRelationshipsLoading || isUsersLoading}
+        openAddMemberDialog={openAddMemberDialog}
       />
     </div>
   );

--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   SidebarRail,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
+import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 
 // Custom styles for menu buttons to ensure consistent centering
 const menuButtonStyles = {
@@ -30,6 +31,8 @@ const menuButtonStyles = {
 };
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const { currentOrganizationId } = useOrganizationStateStore((state) => state);
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader className="h-16 flex flex-col justify-between pb-0">
@@ -101,7 +104,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     menuButtonStyles.buttonCollapsed
                   )}
                 >
-                  <a href="/members">
+                  <a href={`/organizations/${currentOrganizationId}/members`}>
                     <span className={menuButtonStyles.iconWrapper}>
                       <Users className="h-4 w-4" />
                     </span>

--- a/src/components/ui/dashboard/add-coaching-session-button.tsx
+++ b/src/components/ui/dashboard/add-coaching-session-button.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useState } from "react";
+import { Calendar, Plus } from "lucide-react";
+import { cn } from "@/components/lib/utils";
+
+interface AddCoachingSessionButtonProps {
+  onClick?: () => void;
+}
+
+export function AddCoachingSessionButton({
+  onClick,
+}: AddCoachingSessionButtonProps) {
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+
+  const handleMouseEnter = (item: string) => {
+    setHoveredItem(item);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredItem(null);
+  };
+
+  return (
+    <>
+      <button
+        className={cn(
+          "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
+          hoveredItem === "coaching" && "shadow-md"
+        )}
+        onMouseEnter={() => handleMouseEnter("coaching")}
+        onMouseLeave={handleMouseLeave}
+        onClick={onClick}
+      >
+        <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
+          <Calendar className="h-8 w-8 text-primary" />
+        </div>
+        <span className="ml-4 text-lg font-medium">Coaching Session</span>
+        {hoveredItem === "coaching" && (
+          <Plus className="ml-auto h-6 w-6 text-primary" />
+        )}
+      </button>
+    </>
+  );
+}

--- a/src/components/ui/dashboard/add-coaching-session-button.tsx
+++ b/src/components/ui/dashboard/add-coaching-session-button.tsx
@@ -1,16 +1,16 @@
-"use client";
-
-import { useState } from "react";
+import { useState, forwardRef } from "react";
 import { Calendar, Plus } from "lucide-react";
 import { cn } from "@/components/lib/utils";
 
-interface AddCoachingSessionButtonProps {
+interface AddCoachingSessionButtonProps
+  extends React.ComponentPropsWithoutRef<"button"> {
   onClick?: () => void;
 }
 
-export function AddCoachingSessionButton({
-  onClick,
-}: AddCoachingSessionButtonProps) {
+export const AddCoachingSessionButton = forwardRef<
+  HTMLButtonElement,
+  AddCoachingSessionButtonProps
+>(({ className, onClick, ...props }, ref) => {
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
 
   const handleMouseEnter = (item: string) => {
@@ -22,24 +22,27 @@ export function AddCoachingSessionButton({
   };
 
   return (
-    <>
-      <button
-        className={cn(
-          "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
-          hoveredItem === "coaching" && "shadow-md"
-        )}
-        onMouseEnter={() => handleMouseEnter("coaching")}
-        onMouseLeave={handleMouseLeave}
-        onClick={onClick}
-      >
-        <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
-          <Calendar className="h-8 w-8 text-primary" />
-        </div>
-        <span className="ml-4 text-lg font-medium">Coaching Session</span>
-        {hoveredItem === "coaching" && (
-          <Plus className="ml-auto h-6 w-6 text-primary" />
-        )}
-      </button>
-    </>
+    <button
+      ref={ref}
+      className={cn(
+        "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
+        hoveredItem === "coaching" && "shadow-md",
+        className // Merges passed className with existing classes
+      )}
+      onMouseEnter={() => handleMouseEnter("coaching")}
+      onMouseLeave={handleMouseLeave}
+      onClick={onClick}
+      {...props} // Spread remaining props
+    >
+      <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
+        <Calendar className="h-8 w-8 text-primary" />
+      </div>
+      <span className="ml-4 text-lg font-medium">Coaching Session</span>
+      {hoveredItem === "coaching" && (
+        <Plus className="ml-auto h-6 w-6 text-primary" />
+      )}
+    </button>
   );
-}
+});
+
+AddCoachingSessionButton.displayName = "AddCoachingSessionButton";

--- a/src/components/ui/dashboard/add-coaching-session-dialog.tsx
+++ b/src/components/ui/dashboard/add-coaching-session-dialog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import type React from "react";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Calendar } from "@/components/ui/calendar";
+import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
+import { getDateTimeFromString } from "@/types/general";
+import {
+  CoachingSession,
+  defaultCoachingSession,
+} from "@/types/coaching-session";
+import {
+  useCoachingSessionList,
+  useCoachingSessionMutation,
+} from "@/lib/api/coaching-sessions";
+import { DateTime } from "ts-luxon";
+
+interface AddCoachingSessionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCoachingSessionAdded: () => void;
+  dialogTrigger: React.ReactNode;
+}
+
+export function AddCoachingSessionDialog({
+  open,
+  onOpenChange,
+  onCoachingSessionAdded,
+  dialogTrigger,
+}: AddCoachingSessionDialogProps) {
+  const { currentCoachingRelationshipId } = useCoachingRelationshipStateStore(
+    (state) => state
+  );
+  // TODO: for now we hardcode a 2 month window centered around now,
+  // eventually we want to make this be configurable somewhere
+  // (either on the page or elsewhere). This needs to be centralized somewhere,
+  // maybe as a user config?
+  const fromDate = DateTime.now().minus({ month: 1 });
+  const toDate = DateTime.now().plus({ month: 1 });
+  // We just include this hook so we can manually call refresh() and update any other
+  // components that render a list of coaching sessions on the same page
+  const { refresh } = useCoachingSessionList(
+    currentCoachingRelationshipId,
+    fromDate,
+    toDate
+  );
+  const { create: createCoachingSession } = useCoachingSessionMutation();
+  const [newSessionDate, setNewSessionDate] = useState<Date | undefined>(
+    undefined
+  );
+  const [newSessionTime, setNewSessionTime] = useState<string>("");
+
+  const handleCreateSession = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!newSessionDate || !newSessionTime) return;
+
+    // Combine date and time
+    const [hours, minutes] = newSessionTime.split(":").map(Number);
+    const dateTime = getDateTimeFromString(newSessionDate.toISOString())
+      .set({ hour: hours, minute: minutes })
+      .toFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    const newCoachingSession: CoachingSession = {
+      ...defaultCoachingSession(),
+      coaching_relationship_id: currentCoachingRelationshipId,
+      date: dateTime,
+    };
+    createCoachingSession(newCoachingSession)
+      .then(() => {
+        // SWR refresh
+        refresh();
+        onCoachingSessionAdded();
+        setNewSessionDate(undefined);
+        setNewSessionTime("");
+      })
+      .catch((err: Error) => {
+        console.error("Failed to create new Coaching Session: " + err);
+        throw err;
+      });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>{dialogTrigger}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create New Coaching Session</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleCreateSession} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="session-date">Session Date</Label>
+            <Calendar
+              mode="single"
+              selected={newSessionDate}
+              onSelect={setNewSessionDate}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="session-time">Session Time</Label>
+            <input
+              type="time"
+              id="session-time"
+              value={newSessionTime}
+              onChange={(e) => setNewSessionTime(e.target.value)}
+              className="w-full border rounded p-2"
+              required
+            />
+          </div>
+          <Button type="submit">Create Session</Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/dashboard/add-entities.tsx
+++ b/src/components/ui/dashboard/add-entities.tsx
@@ -7,7 +7,7 @@ import { AddMemberButton } from "./add-member-button";
 import { useRouter } from "next/navigation";
 import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 
-export default function CreateEntity() {
+export default function AddEntities() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const { currentOrganizationId } = useOrganizationStateStore((state) => state);
@@ -22,7 +22,9 @@ export default function CreateEntity() {
 
   return (
     <div className="space-y-4">
-      <h2 className="text-2xl font-bold tracking-tight">Create</h2>
+      <h3 className="text-xl sm:text-2xl font-semibold tracking-tight">
+        Add New
+      </h3>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <AddCoachingSessionDialog
           open={open}

--- a/src/components/ui/dashboard/add-member-button.tsx
+++ b/src/components/ui/dashboard/add-member-button.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Users } from "lucide-react";
+import { cn } from "@/components/lib/utils";
+
+interface AddMemberButtonProps {
+  onClick?: () => void;
+}
+
+export function AddMemberButton({ onClick }: AddMemberButtonProps) {
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+
+  const handleMouseEnter = (item: string) => {
+    setHoveredItem(item);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredItem(null);
+  };
+
+  return (
+    <>
+      <button
+        className={cn(
+          "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
+          hoveredItem === "member" && "shadow-md"
+        )}
+        onMouseEnter={() => handleMouseEnter("member")}
+        onMouseLeave={handleMouseLeave}
+        onClick={onClick}
+      >
+        <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
+          <Users className="h-8 w-8 text-primary" />
+        </div>
+        <span className="ml-4 text-lg font-medium">Organization Member</span>
+        {hoveredItem === "member" && (
+          <Plus className="ml-auto h-6 w-6 text-primary" />
+        )}
+      </button>
+    </>
+  );
+}

--- a/src/components/ui/dashboard/add-member-button.tsx
+++ b/src/components/ui/dashboard/add-member-button.tsx
@@ -3,12 +3,16 @@
 import { useState } from "react";
 import { Plus, Users } from "lucide-react";
 import { cn } from "@/components/lib/utils";
+import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
+import { useRouter } from "next/navigation";
 
 interface AddMemberButtonProps {
   onClick?: () => void;
 }
 
 export function AddMemberButton({ onClick }: AddMemberButtonProps) {
+  const router = useRouter();
+  const { currentOrganizationId } = useOrganizationStateStore((state) => state);
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
 
   const handleMouseEnter = (item: string) => {
@@ -28,7 +32,13 @@ export function AddMemberButton({ onClick }: AddMemberButtonProps) {
         )}
         onMouseEnter={() => handleMouseEnter("member")}
         onMouseLeave={handleMouseLeave}
-        onClick={onClick}
+        onClick={() => {
+          // Navigate to the Members page and display the AddMemberDialog
+          router.push(
+            `/organizations/${currentOrganizationId}/members?addMember=true`
+          );
+          onClick;
+        }}
       >
         <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
           <Users className="h-8 w-8 text-primary" />

--- a/src/components/ui/dashboard/coaching-session-list.tsx
+++ b/src/components/ui/dashboard/coaching-session-list.tsx
@@ -4,34 +4,17 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArrowUpDown } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
-import {
-  useCoachingSessionMutation,
-  useCoachingSessionList,
-} from "@/lib/api/coaching-sessions";
-import { Calendar } from "@/components/ui/calendar";
-import { getDateTimeFromString } from "@/types/general";
-import {
-  CoachingSession,
-  defaultCoachingSession,
-} from "@/types/coaching-session";
+import { useCoachingSessionList } from "@/lib/api/coaching-sessions";
 import { CoachingSession as CoachingSessionComponent } from "@/components/ui/coaching-session";
 import { DateTime } from "ts-luxon";
+import { AddCoachingSessionDialog } from "./add-coaching-session-dialog";
 
 export default function CoachingSessionList() {
   const { currentCoachingRelationshipId } = useCoachingRelationshipStateStore(
     (state) => state
   );
-  const { isCoach } = useAuthStore((state) => state);
   // TODO: for now we hardcode a 2 month window centered around now,
   // eventually we want to make this be configurable somewhere
   // (either on the page or elsewhere)
@@ -44,51 +27,21 @@ export default function CoachingSessionList() {
     refresh,
   } = useCoachingSessionList(currentCoachingRelationshipId, fromDate, toDate);
 
-  const { create: createCoachingSession } = useCoachingSessionMutation();
-
   const [sortByDate, setSortByDate] = useState(true);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [newSessionDate, setNewSessionDate] = useState<Date | undefined>(
-    undefined
-  );
-  const [newSessionTime, setNewSessionTime] = useState<string>("");
-
-  const handleCreateSession = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!newSessionDate || !newSessionTime) return;
-
-    // Combine date and time
-    const [hours, minutes] = newSessionTime.split(":").map(Number);
-    const dateTime = getDateTimeFromString(newSessionDate.toISOString())
-      .set({ hour: hours, minute: minutes })
-      .toFormat("yyyy-MM-dd'T'HH:mm:ss");
-
-    const newCoachingSession: CoachingSession = {
-      ...defaultCoachingSession(),
-      coaching_relationship_id: currentCoachingRelationshipId,
-      date: dateTime,
-    };
-    createCoachingSession(newCoachingSession)
-      .then(() => {
-        setIsDialogOpen(false);
-        setNewSessionDate(undefined);
-        setNewSessionTime("");
-
-        // Trigger a re-fetch of coaching sessions
-        refresh();
-      })
-      .catch((err: Error) => {
-        console.error("Failed to create new Coaching Session: " + err);
-        throw err;
-      });
-  };
+  const [open, setOpen] = useState(false);
+  const { isCoach } = useAuthStore((state) => state);
 
   const sortedSessions = coachingSessions
     ? [...coachingSessions].sort((a, b) => {
         return new Date(b.date).getTime() - new Date(a.date).getTime();
       })
     : [];
+
+  const onCoachingSessionAdded = () => {
+    // SWR refresh
+    refresh();
+    setOpen(false);
+  };
 
   if (isLoadingCoachingSessions) return <div>Loading coaching sessions...</div>;
   if (isErrorCoachingSessions)
@@ -101,8 +54,11 @@ export default function CoachingSessionList() {
           <CardTitle className="text-xl sm:text-2xl">
             Coaching Sessions
           </CardTitle>
-          <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-            <DialogTrigger asChild>
+          <AddCoachingSessionDialog
+            open={open}
+            onOpenChange={setOpen}
+            onCoachingSessionAdded={onCoachingSessionAdded}
+            dialogTrigger={
               <Button
                 variant="outline"
                 size="sm"
@@ -111,35 +67,8 @@ export default function CoachingSessionList() {
               >
                 Create New Coaching Session
               </Button>
-            </DialogTrigger>
-            <DialogContent>
-              <DialogHeader>
-                <DialogTitle>Create New Coaching Session</DialogTitle>
-              </DialogHeader>
-              <form onSubmit={handleCreateSession} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="session-date">Session Date</Label>
-                  <Calendar
-                    mode="single"
-                    selected={newSessionDate}
-                    onSelect={setNewSessionDate}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="session-time">Session Time</Label>
-                  <input
-                    type="time"
-                    id="session-time"
-                    value={newSessionTime}
-                    onChange={(e) => setNewSessionTime(e.target.value)}
-                    className="w-full border rounded p-2"
-                    required
-                  />
-                </div>
-                <Button type="submit">Create Session</Button>
-              </form>
-            </DialogContent>
-          </Dialog>
+            }
+          />
         </div>
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
           <Button

--- a/src/components/ui/dashboard/create-entity.tsx
+++ b/src/components/ui/dashboard/create-entity.tsx
@@ -1,33 +1,14 @@
 "use client";
 
 import { useState } from "react";
-import { Plus, Users } from "lucide-react";
-import { cn } from "@/components/lib/utils";
 import { AddCoachingSessionDialog } from "./add-coaching-session-dialog";
 import { AddCoachingSessionButton } from "./add-coaching-session-button";
+import { AddMemberButton } from "./add-member-button";
 
-interface CreateEntityProps {
-  onCreateCoachingSession?: () => void;
-  onCreateMember?: () => void;
-}
-
-export default function CreateEntity({
-  onCreateCoachingSession,
-  onCreateMember,
-}: CreateEntityProps) {
-  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+export default function CreateEntity() {
   const [open, setOpen] = useState(false);
 
-  const handleMouseEnter = (item: string) => {
-    setHoveredItem(item);
-  };
-
-  const handleMouseLeave = () => {
-    setHoveredItem(null);
-  };
-
   const onCoachingSessionAdded = () => {
-    if (onCreateCoachingSession) onCreateCoachingSession();
     setOpen(false);
   };
 
@@ -42,23 +23,7 @@ export default function CreateEntity({
           dialogTrigger={<AddCoachingSessionButton />}
         />
 
-        <button
-          className={cn(
-            "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
-            hoveredItem === "member" && "shadow-md"
-          )}
-          onMouseEnter={() => handleMouseEnter("member")}
-          onMouseLeave={handleMouseLeave}
-          onClick={onCreateMember}
-        >
-          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
-            <Users className="h-8 w-8 text-primary" />
-          </div>
-          <span className="ml-4 text-lg font-medium">Organization Member</span>
-          {hoveredItem === "member" && (
-            <Plus className="ml-auto h-6 w-6 text-primary" />
-          )}
-        </button>
+        <AddMemberButton />
       </div>
     </div>
   );

--- a/src/components/ui/dashboard/create-entity.tsx
+++ b/src/components/ui/dashboard/create-entity.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+import { Plus, Users } from "lucide-react";
+import { cn } from "@/components/lib/utils";
+import { AddCoachingSessionDialog } from "./add-coaching-session-dialog";
+import { AddCoachingSessionButton } from "./add-coaching-session-button";
+
+interface CreateEntityProps {
+  onCreateCoachingSession?: () => void;
+  onCreateMember?: () => void;
+}
+
+export default function CreateEntity({
+  onCreateCoachingSession,
+  onCreateMember,
+}: CreateEntityProps) {
+  const [hoveredItem, setHoveredItem] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  const handleMouseEnter = (item: string) => {
+    setHoveredItem(item);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredItem(null);
+  };
+
+  const onCoachingSessionAdded = () => {
+    if (onCreateCoachingSession) onCreateCoachingSession();
+    setOpen(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-2xl font-bold tracking-tight">Create</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <AddCoachingSessionDialog
+          open={open}
+          onOpenChange={setOpen}
+          onCoachingSessionAdded={onCoachingSessionAdded}
+          dialogTrigger={<AddCoachingSessionButton />}
+        />
+
+        <button
+          className={cn(
+            "flex items-center rounded-lg border border-border bg-card p-4 text-left transition-all hover:shadow-md",
+            hoveredItem === "member" && "shadow-md"
+          )}
+          onMouseEnter={() => handleMouseEnter("member")}
+          onMouseLeave={handleMouseLeave}
+          onClick={onCreateMember}
+        >
+          <div className="flex h-16 w-16 items-center justify-center rounded-md bg-primary/10">
+            <Users className="h-8 w-8 text-primary" />
+          </div>
+          <span className="ml-4 text-lg font-medium">Organization Member</span>
+          {hoveredItem === "member" && (
+            <Plus className="ml-auto h-6 w-6 text-primary" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/dashboard/create-entity.tsx
+++ b/src/components/ui/dashboard/create-entity.tsx
@@ -4,12 +4,20 @@ import { useState } from "react";
 import { AddCoachingSessionDialog } from "./add-coaching-session-dialog";
 import { AddCoachingSessionButton } from "./add-coaching-session-button";
 import { AddMemberButton } from "./add-member-button";
+import { useRouter } from "next/navigation";
+import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 
 export default function CreateEntity() {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
+  const { currentOrganizationId } = useOrganizationStateStore((state) => state);
 
   const onCoachingSessionAdded = () => {
     setOpen(false);
+  };
+
+  const onMemberButtonClicked = () => {
+    router.push(`/organizations/${currentOrganizationId}/members`);
   };
 
   return (
@@ -23,7 +31,7 @@ export default function CreateEntity() {
           dialogTrigger={<AddCoachingSessionButton />}
         />
 
-        <AddMemberButton />
+        <AddMemberButton onClick={onMemberButtonClicked} />
       </div>
     </div>
   );

--- a/src/components/ui/members/add-member-button.tsx
+++ b/src/components/ui/members/add-member-button.tsx
@@ -1,16 +1,25 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { AddMemberDialog } from "./add-member-dialog";
 
 interface AddMemberButtonProps {
   onMemberAdded: () => void;
+  /// Force the AddMemberDialog to open
+  openAddMemberDialog: boolean;
 }
 
-export function AddMemberButton({ onMemberAdded }: AddMemberButtonProps) {
+export function AddMemberButton({
+  onMemberAdded,
+  openAddMemberDialog,
+}: AddMemberButtonProps) {
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(openAddMemberDialog);
+  }, [openAddMemberDialog]);
 
   return (
     <>

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { useUserMutation } from "@/lib/api/organizations/users";
-import { User, NewUser } from "@/types/user";
+import { NewUser } from "@/types/user";
 import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 
 interface AddMemberDialogProps {

--- a/src/components/ui/members/member-container.tsx
+++ b/src/components/ui/members/member-container.tsx
@@ -10,6 +10,7 @@ interface MemberContainerProps {
   userSession: UserSession;
   onRefresh: () => void;
   isLoading: boolean;
+  openAddMemberDialog: boolean;
 }
 
 export function MemberContainer({
@@ -18,6 +19,8 @@ export function MemberContainer({
   userSession,
   onRefresh,
   isLoading,
+  /// Force the AddMemberDialog to open
+  openAddMemberDialog,
 }: MemberContainerProps) {
   // Find relationships where current user is either coach or coachee
   const userRelationships = relationships.filter(
@@ -45,7 +48,10 @@ export function MemberContainer({
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h2 className="text-2xl font-semibold">Members</h2>
-        <AddMemberButton onMemberAdded={onRefresh} />
+        <AddMemberButton
+          onMemberAdded={onRefresh}
+          openAddMemberDialog={openAddMemberDialog}
+        />
       </div>
       <MemberList users={associatedUsers} />
     </div>


### PR DESCRIPTION
## Description
This PR adds a new component called AddEntities to the Dashboard page which, at this time, allows a coach to quickly and conveniently add a new coaching session and a new member to their organization.


#### GitHub Issue: Closes #86 

### Changes
* Add a new component AddEntities for quickly adding new entities, a coaching session and new member for now
* Clicking on the Coaching Session button displays the AddCoachingSessionDialog
* Clicking on the Organization Member button navigates to the Members page and requests that the AddMemberDialog be displayed

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1993" alt="Screenshot 2025-03-30 at 15 05 21" src="https://github.com/user-attachments/assets/c9bcc5ae-fa91-4da8-a2e7-74b5bdd9cf49" />


### Testing Strategy
1. From the Dashboard page, click on the "Coaching Session" button under "Add New"
2. You should see the AddCoachingSessionDialog window display and allow you to add a new coaching session
3. Click on the "Organization Member" button under "Add New"
4. You should be on the Members page now and the AddMemberDialog window should display and allow you to add a new Member to the currently selected Organization


### Concerns
 * I added a TODO item to refactor the existing code for the AddMemberButton and AddMemberDialog to match AddCoachingSessionDialog and AddCoachingSessionButton for consistently and to make the component hierarchy more logical. This is out of scope for this PR work.