### PR TITLE
Leverage default generic useEntityMutation function definition

### DIFF
--- a/src/lib/api/actions.ts
+++ b/src/lib/api/actions.ts
@@ -169,7 +169,7 @@ export const useActionBySession = (coachingSessionId: Id) => {
  * error: Error object if the last operation failed, null otherwise
  */
 export const useActionMutation = () => {
-  return EntityApi.useEntityMutation<Action, Action>(ACTIONS_BASEURL, {
+  return EntityApi.useEntityMutation<Action>(ACTIONS_BASEURL, {
     create: ActionApi.create,
     createNested: ActionApi.createNested,
     update: ActionApi.update,

--- a/src/lib/api/agreements.ts
+++ b/src/lib/api/agreements.ts
@@ -170,7 +170,7 @@ export const useAgreementBySession = (coachingSessionId: Id) => {
  * error: Error object if the last operation failed, null otherwise
  */
 export const useAgreementMutation = () => {
-  return EntityApi.useEntityMutation<Agreement, Agreement>(AGREEMENTS_BASEURL, {
+  return EntityApi.useEntityMutation<Agreement>(AGREEMENTS_BASEURL, {
     create: AgreementApi.create,
     createNested: AgreementApi.createNested,
     update: AgreementApi.update,

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -178,10 +178,7 @@ export const useCoachingRelationship = (
  * Provides methods to create, update, and delete coaching relationships.
  */
 export const useCoachingRelationshipMutation = (organizationId: Id) => {
-  return EntityApi.useEntityMutation<
-    CoachingRelationshipWithUserNames,
-    CoachingRelationshipWithUserNames
-  >(
+  return EntityApi.useEntityMutation<CoachingRelationshipWithUserNames>(
     `${ORGANIZATIONS_BASEURL}/${organizationId}/${COACHING_RELATIONSHIPS_BASEURL}`,
     {
       create: CoachingRelationshipApi.create,

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -188,7 +188,7 @@ export const useCoachingSession = (id: Id) => {
  * error: Error object if the last operation failed, null otherwise
  */
 export const useCoachingSessionMutation = () => {
-  return EntityApi.useEntityMutation<CoachingSession, CoachingSession>(
+  return EntityApi.useEntityMutation<CoachingSession>(
     COACHING_SESSIONS_BASEURL,
     {
       create: CoachingSessionApi.create,

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -367,7 +367,7 @@ export namespace EntityApi {
    * @param api Object containing CRUD operations for the entity
    * @returns Object with CRUD methods, loading state, and error state
    */
-  export const useEntityMutation = <T, U>(
+  export const useEntityMutation = <T, U = T>(
     baseUrl: string,
     api: {
       create: (entity: T) => Promise<U>;

--- a/src/lib/api/organizations.ts
+++ b/src/lib/api/organizations.ts
@@ -148,13 +148,10 @@ export const useOrganization = (id: Id) => {
  * Provides methods to create, update, and delete organizations.
  */
 export const useOrganizationMutation = () => {
-  return EntityApi.useEntityMutation<Organization, Organization>(
-    ORGANIZATIONS_BASEURL,
-    {
-      create: OrganizationApi.create,
-      createNested: OrganizationApi.createNested,
-      update: OrganizationApi.update,
-      delete: OrganizationApi.delete,
-    }
-  );
+  return EntityApi.useEntityMutation<Organization>(ORGANIZATIONS_BASEURL, {
+    create: OrganizationApi.create,
+    createNested: OrganizationApi.createNested,
+    update: OrganizationApi.update,
+    delete: OrganizationApi.delete,
+  });
 };

--- a/src/lib/api/overarching-goals.ts
+++ b/src/lib/api/overarching-goals.ts
@@ -190,7 +190,7 @@ export const useOverarchingGoalBySession = (coachingSessionId: Id) => {
  * Provides methods to create, update, and delete overarching-goal.
  */
 export const useOverarchingGoalMutation = () => {
-  return EntityApi.useEntityMutation<OverarchingGoal, OverarchingGoal>(
+  return EntityApi.useEntityMutation<OverarchingGoal>(
     OVERARCHING_GOALS_BASEURL,
     {
       create: OverarchingGoalApi.create,

--- a/src/lib/api/user-sessions.ts
+++ b/src/lib/api/user-sessions.ts
@@ -90,13 +90,10 @@ export const UserSessionApi = {
  * error: Error object if the last operation failed, null otherwise
  */
 export const useUserSessionMutation = () => {
-  return EntityApi.useEntityMutation<UserSession, UserSession>(
-    USER_SESSIONS_BASEURL,
-    {
-      create: UserSessionApi.create,
-      createNested: UserSessionApi.createNested,
-      update: UserSessionApi.update,
-      delete: UserSessionApi.delete,
-    }
-  );
+  return EntityApi.useEntityMutation<UserSession>(USER_SESSIONS_BASEURL, {
+    create: UserSessionApi.create,
+    createNested: UserSessionApi.createNested,
+    update: UserSessionApi.update,
+    delete: UserSessionApi.delete,
+  });
 };

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -90,7 +90,7 @@ export const useUser = (id: Id) => {
  * Provides methods to create, update, and delete users.
  */
 export const useUserMutation = () => {
-  return EntityApi.useEntityMutation<User, User>(USERS_BASEURL, {
+  return EntityApi.useEntityMutation<User>(USERS_BASEURL, {
     create: UserApi.create,
     createNested: UserApi.createNested,
     update: UserApi.update,


### PR DESCRIPTION
## Description
Implement a default generic type for the second argument of the `useEntityMutation` hook, makes it cleaner to use across the different entity specific-hooks which may or may not need the second type.



#### GitHub Issue: Closes #20

### Changes
* implement the type definition change
* update usages of this hook that were providing the extra duplicate arg.

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
_describe how you or someone else can test and verify the changes_


### Concerns
Not totally sure why this didn't work when Caleb tried - may have just been a typechecker hiccup that day.