### PR TITLE
Add link to coaching notes editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@tiptap/extension-collaboration-cursor": "^2.11.5",
         "@tiptap/extension-heading": "^2.10.4",
         "@tiptap/extension-highlight": "^2.10.4",
+        "@tiptap/extension-link": "^2.11.7",
         "@tiptap/extension-list-item": "^2.10.4",
         "@tiptap/extension-ordered-list": "^2.10.4",
         "@tiptap/extension-underline": "^2.10.4",
@@ -2555,6 +2556,23 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.11.7.tgz",
+      "integrity": "sha512-qKIowE73aAUrnQCIifYP34xXOHOsZw46cT/LBDlb0T60knVfQoKVE4ku08fJzAV+s6zqgsaaZ4HVOXkQYLoW7g==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
@@ -6207,6 +6225,12 @@
       "dependencies": {
         "uc.micro": "^2.0.0"
       }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.2.0.tgz",
+      "integrity": "sha512-pCj3PrQyATaoTYKHrgWRF3SJwsm61udVh+vuls/Rl6SptiDhgE7ziUIudAedRY9QEfynmM7/RmLEfPUyw1HPCw==",
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@tiptap/extension-collaboration-cursor": "^2.11.5",
     "@tiptap/extension-heading": "^2.10.4",
     "@tiptap/extension-highlight": "^2.10.4",
+    "@tiptap/extension-link": "^2.11.7",
     "@tiptap/extension-list-item": "^2.10.4",
     "@tiptap/extension-ordered-list": "^2.10.4",
     "@tiptap/extension-underline": "^2.10.4",

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -2,9 +2,7 @@
 
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 
-import { useState } from "react";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 
 import { siteConfig } from "@/site.config";
@@ -12,7 +10,6 @@ import { CoachingSessionTitle } from "@/components/ui/coaching-sessions/coaching
 import { OverarchingGoalContainer } from "@/components/ui/coaching-sessions/overarching-goal-container";
 import { CoachingNotes } from "@/components/ui/coaching-sessions/coaching-notes";
 
-import { LockClosedIcon } from "@radix-ui/react-icons";
 import CoachingSessionSelector from "@/components/ui/coaching-session-selector";
 import { useRouter } from "next/navigation";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";

--- a/src/components/ui/coaching-sessions/coaching-notes.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes.tsx
@@ -115,6 +115,21 @@ const CoachingNotes = () => {
             class:
               "tiptap ProseMirror shadow appearance-none lg:min-h-[440px] sm:min-h-[200px] md:min-h-[350px] rounded w-full py-2 px-3 bg-inherit text-black dark:text-white text-sm mt-0 md:mt-3 leading-tight focus:outline-none focus:shadow-outline",
           },
+          handleDOMEvents: {
+            click: (view, event) => {
+              const target = event.target as HTMLElement;
+
+              // Check if the clicked element is an <a> tag and Shift is pressed
+              if (target.tagName === "A" && event.shiftKey) {
+                event.preventDefault(); // Prevent default link behavior
+                window
+                  .open(target.getAttribute("href") || "", "_blank")
+                  ?.focus();
+                return true; // Stop event propagation
+              }
+              return false; // Allow other handlers to process the event
+            },
+          },
         }}
         slotBefore={<Toolbar />}
       />

--- a/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
@@ -36,34 +36,6 @@ export const ConfiguredLink = LinkWithTitle.configure({
         return false;
       }
 
-      // Placeholder for future disallowed domains if we want to add any
-      // const disallowedProtocols = ["ftp", "file", "mailto"];
-      // const protocol = parsedUrl.protocol.replace(":", "");
-
-      // if (disallowedProtocols.includes(protocol)) {
-      //   return false;
-      // }
-
-      // // only allow protocols specified in ctx.protocols
-      // const allowedProtocols = ctx.protocols.map((p) =>
-      //   typeof p === "string" ? p : p.scheme
-      // );
-
-      // if (!allowedProtocols.includes(protocol)) {
-      //   return false;
-      // }
-
-      // Placeholder for future disallowed domains if we want to add any
-      // const disallowedDomains = [
-      //   "example-phishing.com",
-      //   "malicious-site.net",
-      // ];
-      // const domain = parsedUrl.hostname;
-
-      // if (disallowedDomains.includes(domain)) {
-      //   return false;
-      // }
-
       // all checks have passed
       return true;
     } catch {
@@ -77,14 +49,7 @@ export const ConfiguredLink = LinkWithTitle.configure({
         ? new URL(url)
         : new URL(`https://${url}`);
 
-      // only auto-link if the domain is not in the disallowed list
-      const disallowedDomains = [
-        "example-no-autolink.com",
-        "another-no-autolink.com",
-      ];
-      const domain = parsedUrl.hostname;
-
-      return !disallowedDomains.includes(domain);
+      return !!parsedUrl;
     } catch {
       return false;
     }

--- a/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
@@ -1,0 +1,92 @@
+import Link from "@tiptap/extension-link";
+
+const LinkWithTitle = Link.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      title: {
+        default: null,
+        renderHTML: (attributes) => {
+          if (!attributes.href) {
+            return {};
+          }
+          return {
+            title: `Right-click to open ${attributes.href}`,
+          };
+        },
+      },
+    };
+  },
+});
+
+export const ConfiguredLink = LinkWithTitle.configure({
+  openOnClick: false,
+  autolink: true,
+  defaultProtocol: "https",
+  protocols: ["http", "https"],
+  isAllowedUri: (url, ctx) => {
+    try {
+      // construct URL
+      const parsedUrl = url.includes(":")
+        ? new URL(url)
+        : new URL(`${ctx.defaultProtocol}://${url}`);
+
+      // use default validation
+      if (!ctx.defaultValidate(parsedUrl.href)) {
+        return false;
+      }
+
+      // Placeholder for future disallowed domains if we want to add any
+      // const disallowedProtocols = ["ftp", "file", "mailto"];
+      // const protocol = parsedUrl.protocol.replace(":", "");
+
+      // if (disallowedProtocols.includes(protocol)) {
+      //   return false;
+      // }
+
+      // // only allow protocols specified in ctx.protocols
+      // const allowedProtocols = ctx.protocols.map((p) =>
+      //   typeof p === "string" ? p : p.scheme
+      // );
+
+      // if (!allowedProtocols.includes(protocol)) {
+      //   return false;
+      // }
+
+      // Placeholder for future disallowed domains if we want to add any
+      // const disallowedDomains = [
+      //   "example-phishing.com",
+      //   "malicious-site.net",
+      // ];
+      // const domain = parsedUrl.hostname;
+
+      // if (disallowedDomains.includes(domain)) {
+      //   return false;
+      // }
+
+      // all checks have passed
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  shouldAutoLink: (url) => {
+    try {
+      // construct URL
+      const parsedUrl = url.includes(":")
+        ? new URL(url)
+        : new URL(`https://${url}`);
+
+      // only auto-link if the domain is not in the disallowed list
+      const disallowedDomains = [
+        "example-no-autolink.com",
+        "another-no-autolink.com",
+      ];
+      const domain = parsedUrl.hostname;
+
+      return !disallowedDomains.includes(domain);
+    } catch {
+      return false;
+    }
+  },
+});

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -45,7 +45,7 @@ export const Extensions = (
     Text,
     Underline,
     Link.configure({
-      openOnClick: false,
+      openOnClick: true,
       autolink: true,
       defaultProtocol: "https",
       protocols: ["http", "https"],
@@ -61,33 +61,33 @@ export const Extensions = (
             return false;
           }
 
-          // disallowed protocols
-          const disallowedProtocols = ["ftp", "file", "mailto"];
-          const protocol = parsedUrl.protocol.replace(":", "");
+          // Placeholder for future disallowed domains if we want to add any
+          // const disallowedProtocols = ["ftp", "file", "mailto"];
+          // const protocol = parsedUrl.protocol.replace(":", "");
 
-          if (disallowedProtocols.includes(protocol)) {
-            return false;
-          }
+          // if (disallowedProtocols.includes(protocol)) {
+          //   return false;
+          // }
 
-          // only allow protocols specified in ctx.protocols
-          const allowedProtocols = ctx.protocols.map((p) =>
-            typeof p === "string" ? p : p.scheme
-          );
+          // // only allow protocols specified in ctx.protocols
+          // const allowedProtocols = ctx.protocols.map((p) =>
+          //   typeof p === "string" ? p : p.scheme
+          // );
 
-          if (!allowedProtocols.includes(protocol)) {
-            return false;
-          }
+          // if (!allowedProtocols.includes(protocol)) {
+          //   return false;
+          // }
 
-          // disallowed domains
-          const disallowedDomains = [
-            "example-phishing.com",
-            "malicious-site.net",
-          ];
-          const domain = parsedUrl.hostname;
+          // Placeholder for future disallowed domains if we want to add any
+          // const disallowedDomains = [
+          //   "example-phishing.com",
+          //   "malicious-site.net",
+          // ];
+          // const domain = parsedUrl.hostname;
 
-          if (disallowedDomains.includes(domain)) {
-            return false;
-          }
+          // if (disallowedDomains.includes(domain)) {
+          //   return false;
+          // }
 
           // all checks have passed
           return true;

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -11,7 +11,6 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Strike from "@tiptap/extension-strike";
 import Text from "@tiptap/extension-text";
 import Underline from "@tiptap/extension-underline";
-import Link from "@tiptap/extension-link";
 import Collaboration from "@tiptap/extension-collaboration";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import CodeBlock from "@/components/ui/coaching-sessions/code-block";

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -45,7 +45,7 @@ export const Extensions = (
     Text,
     Underline,
     Link.configure({
-      openOnClick: true,
+      openOnClick: false,
       autolink: true,
       defaultProtocol: "https",
       protocols: ["http", "https"],

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -19,6 +19,7 @@ import { createLowlight } from "lowlight";
 import { all } from "lowlight";
 import CollaborationCursor from "@tiptap/extension-collaboration-cursor";
 import { TiptapCollabProvider } from "@hocuspocus/provider";
+import { ConfiguredLink } from "./extended-link-extension";
 // Initialize lowlight with all languages
 const lowlight = createLowlight(all);
 
@@ -44,77 +45,7 @@ export const Extensions = (
     Strike,
     Text,
     Underline,
-    Link.configure({
-      openOnClick: false,
-      autolink: true,
-      defaultProtocol: "https",
-      protocols: ["http", "https"],
-      isAllowedUri: (url, ctx) => {
-        try {
-          // construct URL
-          const parsedUrl = url.includes(":")
-            ? new URL(url)
-            : new URL(`${ctx.defaultProtocol}://${url}`);
-
-          // use default validation
-          if (!ctx.defaultValidate(parsedUrl.href)) {
-            return false;
-          }
-
-          // Placeholder for future disallowed domains if we want to add any
-          // const disallowedProtocols = ["ftp", "file", "mailto"];
-          // const protocol = parsedUrl.protocol.replace(":", "");
-
-          // if (disallowedProtocols.includes(protocol)) {
-          //   return false;
-          // }
-
-          // // only allow protocols specified in ctx.protocols
-          // const allowedProtocols = ctx.protocols.map((p) =>
-          //   typeof p === "string" ? p : p.scheme
-          // );
-
-          // if (!allowedProtocols.includes(protocol)) {
-          //   return false;
-          // }
-
-          // Placeholder for future disallowed domains if we want to add any
-          // const disallowedDomains = [
-          //   "example-phishing.com",
-          //   "malicious-site.net",
-          // ];
-          // const domain = parsedUrl.hostname;
-
-          // if (disallowedDomains.includes(domain)) {
-          //   return false;
-          // }
-
-          // all checks have passed
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      shouldAutoLink: (url) => {
-        try {
-          // construct URL
-          const parsedUrl = url.includes(":")
-            ? new URL(url)
-            : new URL(`https://${url}`);
-
-          // only auto-link if the domain is not in the disallowed list
-          const disallowedDomains = [
-            "example-no-autolink.com",
-            "another-no-autolink.com",
-          ];
-          const domain = parsedUrl.hostname;
-
-          return !disallowedDomains.includes(domain);
-        } catch {
-          return false;
-        }
-      },
-    }),
+    ConfiguredLink,
     Collaboration.configure({
       document: doc,
     }),

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -11,6 +11,7 @@ import Paragraph from "@tiptap/extension-paragraph";
 import Strike from "@tiptap/extension-strike";
 import Text from "@tiptap/extension-text";
 import Underline from "@tiptap/extension-underline";
+import Link from "@tiptap/extension-link";
 import Collaboration from "@tiptap/extension-collaboration";
 import { ReactNodeViewRenderer } from "@tiptap/react";
 import CodeBlock from "@/components/ui/coaching-sessions/code-block";
@@ -43,6 +44,7 @@ export const Extensions = (
     Strike,
     Text,
     Underline,
+    Link,
     Collaboration.configure({
       document: doc,
     }),

--- a/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extensions.tsx
@@ -44,7 +44,77 @@ export const Extensions = (
     Strike,
     Text,
     Underline,
-    Link,
+    Link.configure({
+      openOnClick: false,
+      autolink: true,
+      defaultProtocol: "https",
+      protocols: ["http", "https"],
+      isAllowedUri: (url, ctx) => {
+        try {
+          // construct URL
+          const parsedUrl = url.includes(":")
+            ? new URL(url)
+            : new URL(`${ctx.defaultProtocol}://${url}`);
+
+          // use default validation
+          if (!ctx.defaultValidate(parsedUrl.href)) {
+            return false;
+          }
+
+          // disallowed protocols
+          const disallowedProtocols = ["ftp", "file", "mailto"];
+          const protocol = parsedUrl.protocol.replace(":", "");
+
+          if (disallowedProtocols.includes(protocol)) {
+            return false;
+          }
+
+          // only allow protocols specified in ctx.protocols
+          const allowedProtocols = ctx.protocols.map((p) =>
+            typeof p === "string" ? p : p.scheme
+          );
+
+          if (!allowedProtocols.includes(protocol)) {
+            return false;
+          }
+
+          // disallowed domains
+          const disallowedDomains = [
+            "example-phishing.com",
+            "malicious-site.net",
+          ];
+          const domain = parsedUrl.hostname;
+
+          if (disallowedDomains.includes(domain)) {
+            return false;
+          }
+
+          // all checks have passed
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      shouldAutoLink: (url) => {
+        try {
+          // construct URL
+          const parsedUrl = url.includes(":")
+            ? new URL(url)
+            : new URL(`https://${url}`);
+
+          // only auto-link if the domain is not in the disallowed list
+          const disallowedDomains = [
+            "example-no-autolink.com",
+            "another-no-autolink.com",
+          ];
+          const domain = parsedUrl.hostname;
+
+          return !disallowedDomains.includes(domain);
+        } catch {
+          return false;
+        }
+      },
+    }),
     Collaboration.configure({
       document: doc,
     }),

--- a/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
@@ -46,12 +46,17 @@ export const LinkDialog = ({
 
     // update link
     try {
+      const linkWithProtocol = /^https?:\/\//.test(linkUrl)
+        ? linkUrl
+        : `https://${linkUrl}`;
+
+      // basic validation for a real url
+      const urlHref = new URL(linkWithProtocol).toString();
       editor
         .chain()
         .focus()
         .extendMarkRange("link")
-        .setLink({ href: linkUrl })
-        .updateAttributes("link", { title: linkUrl })
+        .setLink({ href: urlHref })
         .run();
       setLinkUrl("");
       onOpenChange(false);
@@ -65,9 +70,7 @@ export const LinkDialog = ({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Insert Link</DialogTitle>
-          <DialogDescription>
-            Insert a url for a link in your document.
-          </DialogDescription>
+          <DialogDescription>Insert URL for your link</DialogDescription>
         </DialogHeader>
         <div className="grid grid-cols-6 gap-4 items-center">
           <Label htmlFor="url" className="text-right">

--- a/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
@@ -51,6 +51,7 @@ export const LinkDialog = ({
         .focus()
         .extendMarkRange("link")
         .setLink({ href: linkUrl })
+        .updateAttributes("link", { title: linkUrl })
         .run();
       setLinkUrl("");
       onOpenChange(false);

--- a/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/link-dialog.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Editor } from "@tiptap/core";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface LinkDialogProps {
+  editor: Editor;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const LinkDialog = ({
+  editor,
+  isOpen,
+  onOpenChange,
+}: LinkDialogProps) => {
+  const [linkUrl, setLinkUrl] = React.useState("");
+
+  React.useEffect(() => {
+    if (isOpen) {
+      setLinkUrl(editor.getAttributes("link").href || "");
+    }
+  }, [isOpen, editor]);
+
+  const setLink = React.useCallback(() => {
+    // cancelled
+    if (linkUrl === null) {
+      return;
+    }
+
+    // empty
+    if (linkUrl === "") {
+      editor.chain().focus().extendMarkRange("link").unsetLink().run();
+      onOpenChange(false);
+      return;
+    }
+
+    // update link
+    try {
+      editor
+        .chain()
+        .focus()
+        .extendMarkRange("link")
+        .setLink({ href: linkUrl })
+        .run();
+      setLinkUrl("");
+      onOpenChange(false);
+    } catch (e) {
+      console.error("Error inserting link:", e);
+    }
+  }, [editor, linkUrl, onOpenChange]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Insert Link</DialogTitle>
+          <DialogDescription>
+            Insert a url for a link in your document.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid grid-cols-6 gap-4 items-center">
+          <Label htmlFor="url" className="text-right">
+            URL
+          </Label>
+          <Input
+            id="url"
+            value={linkUrl}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setLinkUrl(e.target.value)
+            }
+            className="col-span-5"
+          />
+        </div>
+        <DialogFooter>
+          <Button onClick={setLink}>Submit</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -12,85 +12,170 @@ import {
   ListOrdered,
   Strikethrough,
   Braces,
+  Link,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
 
 export const Toolbar = () => {
   const { editor } = useCurrentEditor();
+
+  const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkText, setLinkText] = useState("");
 
   if (!editor) {
     return null;
   }
 
+  const handleLinkButtonClick = () => {
+    editor.isActive("link")
+      ? editor.chain().focus().toggleLink({ href: linkUrl }).run()
+      : setIsLinkDialogOpen(true);
+  };
+
   return (
-    <div className="flex items-center gap-0 mt-1 mx-1 mb-0">
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBold().run()}
-        isActive={editor.isActive("bold")}
-        icon={<Bold className="h-4 w-4" />}
-        title="Bold (Ctrl+B)"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleItalic().run()}
-        isActive={editor.isActive("italic")}
-        icon={<Italic className="h-4 w-4" />}
-        title="Italic (Ctrl+I)"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleUnderline().run()}
-        isActive={editor.isActive("underline")}
-        icon={<Underline className="h-4 w-4" />}
-        title="Underline (Ctrl+U)"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleStrike().run()}
-        isActive={editor.isActive("strike")}
-        icon={<Strikethrough className="h-4 w-4" />}
-        title="Strike Through"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHighlight().run()}
-        isActive={editor.isActive("highlight")}
-        icon={<Highlighter className="h-4 w-4" />}
-        title="Highlight Text"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-        isActive={editor.isActive("heading", { level: 1 })}
-        icon={<Heading1 className="h-4 w-4" />}
-        title="Heading 1"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-        isActive={editor.isActive("heading", { level: 2 })}
-        icon={<Heading2 className="h-4 w-4" />}
-        title="Heading 2"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-        isActive={editor.isActive("heading", { level: 3 })}
-        icon={<Heading3 className="h-4 w-4" />}
-        title="Heading 3"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleBulletList().run()}
-        isActive={editor.isActive("bulletList")}
-        icon={<List className="h-4 w-4" />}
-        title="Bullet List"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleOrderedList().run()}
-        isActive={editor.isActive("orderedList")}
-        icon={<ListOrdered className="h-4 w-4" />}
-        title="Ordered List"
-      />
-      <ToolbarButton
-        onClick={() => editor.chain().focus().toggleCodeBlock().run()}
-        isActive={editor.isActive("codeBlock")}
-        icon={<Braces className="h-4 w-4" />}
-        title="Code Block"
-      />
-    </div>
+    <>
+      <div className="flex items-center gap-0 mt-1 mx-1 mb-0">
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          isActive={editor.isActive("bold")}
+          icon={<Bold className="h-4 w-4" />}
+          title="Bold (Ctrl+B)"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          isActive={editor.isActive("italic")}
+          icon={<Italic className="h-4 w-4" />}
+          title="Italic (Ctrl+I)"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          isActive={editor.isActive("underline")}
+          icon={<Underline className="h-4 w-4" />}
+          title="Underline (Ctrl+U)"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleStrike().run()}
+          isActive={editor.isActive("strike")}
+          icon={<Strikethrough className="h-4 w-4" />}
+          title="Strike Through"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleHighlight().run()}
+          isActive={editor.isActive("highlight")}
+          icon={<Highlighter className="h-4 w-4" />}
+          title="Highlight Text"
+        />
+        <ToolbarButton
+          onClick={() =>
+            editor.chain().focus().toggleHeading({ level: 1 }).run()
+          }
+          isActive={editor.isActive("heading", { level: 1 })}
+          icon={<Heading1 className="h-4 w-4" />}
+          title="Heading 1"
+        />
+        <ToolbarButton
+          onClick={() =>
+            editor.chain().focus().toggleHeading({ level: 2 }).run()
+          }
+          isActive={editor.isActive("heading", { level: 2 })}
+          icon={<Heading2 className="h-4 w-4" />}
+          title="Heading 2"
+        />
+        <ToolbarButton
+          onClick={() =>
+            editor.chain().focus().toggleHeading({ level: 3 }).run()
+          }
+          isActive={editor.isActive("heading", { level: 3 })}
+          icon={<Heading3 className="h-4 w-4" />}
+          title="Heading 3"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          isActive={editor.isActive("bulletList")}
+          icon={<List className="h-4 w-4" />}
+          title="Bullet List"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          isActive={editor.isActive("orderedList")}
+          icon={<ListOrdered className="h-4 w-4" />}
+          title="Ordered List"
+        />
+        <ToolbarButton
+          onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+          isActive={editor.isActive("codeBlock")}
+          icon={<Braces className="h-4 w-4" />}
+          title="Code Block"
+        />
+        <ToolbarButton
+          onClick={() => handleLinkButtonClick()}
+          isActive={editor.isActive("link")}
+          icon={<Link className="h-4 w-4" />}
+          title="Link"
+        />
+      </div>
+
+      <Dialog open={isLinkDialogOpen} onOpenChange={setIsLinkDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Insert Link</DialogTitle>
+          </DialogHeader>
+          <div className="grid gap-4 py-4">
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="linkText" className="text-right">
+                Text
+              </Label>
+              <Input
+                id="linkText"
+                value={linkText}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setLinkText(e.target.value)
+                }
+                className="col-span-3"
+              />
+            </div>
+            <div className="grid grid-cols-4 items-center gap-4">
+              <Label htmlFor="url" className="text-right">
+                URL
+              </Label>
+              <Input
+                id="url"
+                value={linkUrl}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setLinkUrl(e.target.value)
+                }
+                className="col-span-3"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={() => {
+                editor.chain().focus().insertContent(linkText).run();
+                editor.chain().focus().toggleLink({ href: linkUrl }).run();
+                setIsLinkDialogOpen(false);
+                setLinkUrl("");
+                setLinkText("");
+              }}
+            >
+              Insert Link
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -119,8 +119,8 @@ export const Toolbar = () => {
           icon={<Link className="h-4 w-4" />}
           title={
             editor.isActive("link")
-              ? "Update link (Ctrl + k)"
-              : "Insert link (Ctrl + k)"
+              ? "Update Link (Ctrl + k)"
+              : "Insert Link (Ctrl + k)"
           }
         />
       </div>

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -15,34 +15,16 @@ import {
   Link,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
 import { useState } from "react";
+import { LinkDialog } from "./link-dialog";
 
 export const Toolbar = () => {
   const { editor } = useCurrentEditor();
-
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
-  const [linkUrl, setLinkUrl] = useState("");
-  const [linkText, setLinkText] = useState("");
 
   if (!editor) {
     return null;
   }
-
-  const handleLinkButtonClick = () => {
-    editor.isActive("link")
-      ? editor.chain().focus().toggleLink({ href: linkUrl }).run()
-      : setIsLinkDialogOpen(true);
-  };
 
   return (
     <>
@@ -120,61 +102,18 @@ export const Toolbar = () => {
           title="Code Block"
         />
         <ToolbarButton
-          onClick={() => handleLinkButtonClick()}
+          onClick={() => setIsLinkDialogOpen(true)}
           isActive={editor.isActive("link")}
           icon={<Link className="h-4 w-4" />}
           title="Link"
         />
       </div>
 
-      <Dialog open={isLinkDialogOpen} onOpenChange={setIsLinkDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Insert Link</DialogTitle>
-          </DialogHeader>
-          <div className="grid gap-4 py-4">
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="linkText" className="text-right">
-                Text
-              </Label>
-              <Input
-                id="linkText"
-                value={linkText}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setLinkText(e.target.value)
-                }
-                className="col-span-3"
-              />
-            </div>
-            <div className="grid grid-cols-4 items-center gap-4">
-              <Label htmlFor="url" className="text-right">
-                URL
-              </Label>
-              <Input
-                id="url"
-                value={linkUrl}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setLinkUrl(e.target.value)
-                }
-                className="col-span-3"
-              />
-            </div>
-          </div>
-          <DialogFooter>
-            <Button
-              onClick={() => {
-                editor.chain().focus().insertContent(linkText).run();
-                editor.chain().focus().toggleLink({ href: linkUrl }).run();
-                setIsLinkDialogOpen(false);
-                setLinkUrl("");
-                setLinkText("");
-              }}
-            >
-              Insert Link
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <LinkDialog
+        editor={editor}
+        isOpen={isLinkDialogOpen}
+        onOpenChange={setIsLinkDialogOpen}
+      />
     </>
   );
 };

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React, { useEffect } from "react";
 import { useCurrentEditor } from "@tiptap/react";
 import {
   Bold,
@@ -25,6 +25,18 @@ export const Toolbar = () => {
   if (!editor) {
     return null;
   }
+  // Add keyboard shortcut handler
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setIsLinkDialogOpen(true);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   return (
     <>
@@ -105,7 +117,11 @@ export const Toolbar = () => {
           onClick={() => setIsLinkDialogOpen(true)}
           isActive={editor.isActive("link")}
           icon={<Link className="h-4 w-4" />}
-          title="Link"
+          title={
+            editor.isActive("link")
+              ? "Update link (Ctrl + k)"
+              : "Insert link (Ctrl + k)"
+          }
         />
       </div>
 

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -28,7 +28,7 @@ export const Toolbar = () => {
   // Add keyboard shortcut handler
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k" && editor?.isFocused) {
         e.preventDefault();
         setIsLinkDialogOpen(true);
       }
@@ -36,7 +36,7 @@ export const Toolbar = () => {
 
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
+  }, [editor]);
 
   return (
     <>

--- a/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/toolbar.tsx
@@ -22,10 +22,6 @@ export const Toolbar = () => {
   const { editor } = useCurrentEditor();
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
 
-  if (!editor) {
-    return null;
-  }
-  // Add keyboard shortcut handler
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key === "k" && editor?.isFocused) {
@@ -37,6 +33,11 @@ export const Toolbar = () => {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [editor]);
+
+  if (!editor) {
+    return null;
+  }
+  // Add keyboard shortcut handler
 
   return (
     <>

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -144,11 +144,7 @@
     margin: 2rem 0;
   }
 
-  a {
-    color: #0000EE;
-    text-decoration: underline;
-  }
-  /* Link styles */
+  /* Editor Link styles */
   a {
     text-decoration: underline;
     color: #0000EE;

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -143,6 +143,21 @@
     border-top: 1px solid var(--gray-2);
     margin: 2rem 0;
   }
+
+  a {
+    color: #0000EE;
+    text-decoration: underline;
+  }
+  /* Link styles */
+  a {
+    text-decoration: underline;
+    color: #0000EE;
+    cursor: pointer;
+
+    &:hover {
+      color: var(--purple-contrast);
+    }
+  }
 }
 
 /* Give a remote user a caret */


### PR DESCRIPTION
## Description
Editor feature for adding/removing links.

A user may now in the coaching notes editor incorporate hyperlink(s) into the editor content.

The toolbar button should open a dialog box with a field for the url.

Large part of this logic borrowed from [TipTap's example](https://github.com/ueberdosis/tiptap/blob/main/demos/src/Marks/Link/React/index.jsx)

Link text should be highlighted a standard blue.

Addresses: https://docs.google.com/document/d/10gTCL0uNu1VHEFQl_PzPmnn07QOcDw89ta5C-UVh9vQ/edit?tab=t.0#heading=h.r4v5w0aeykos

### Changes
* Install and add link extension to extensions groups
* Add toolbar button for link to toolbar
* Add link dialog component
* Logic for inserting/removing link

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1187" alt="Screenshot 2025-04-03 at 11 37 11 AM" src="https://github.com/user-attachments/assets/4be046dd-ed6a-40f6-8b7b-9f30890acc17" />
<img width="1290" alt="Screenshot 2025-04-03 at 11 37 08 AM" src="https://github.com/user-attachments/assets/a1c1a9d6-e4a9-47e8-9abc-d808eb100ab5" />


### Testing Strategy

- Navigate to a coaching session
- Click link button in toolbar
- Insert a link
- Insert another link
- Remove a link
- Update an existing link


### Concerns
@jhodapp We may want to review some specifics with how you want this to work - validating links, disallowing some domains, etc. Will leave this in draft until we chat about that