### PR TITLE
Coaching session page tweaks

### DIFF
--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -36,7 +36,7 @@ export default function CoachingSessionsPage() {
   return (
     // Never grow wider than the site-header
     <div className="max-w-screen-2xl">
-      <div className="flex-col h-full md:flex ">
+      <div className="flex-col h-full pl-4 md:flex ">
         <div className="flex flex-col items-start justify-between space-y-2 py-4 px-4 sm:flex-row sm:items-center sm:space-y-0 md:h-16">
           <CoachingSessionTitle
             locale={siteConfig.locale}
@@ -53,7 +53,9 @@ export default function CoachingSessionsPage() {
         </div>
       </div>
 
-      <Separator />
+      <div className="px-3">
+        <Separator />
+      </div>
 
       <OverarchingGoalContainer userId={userId} />
 

--- a/src/components/ui/coaching-sessions/overarching-goal-container.tsx
+++ b/src/components/ui/coaching-sessions/overarching-goal-container.tsx
@@ -15,6 +15,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { OverarchingGoalComponent } from "./overarching-goal";
 import {
   useOverarchingGoalBySession,
+  useOverarchingGoalList,
   useOverarchingGoalMutation,
 } from "@/lib/api/overarching-goals";
 import {

--- a/src/components/ui/site-header.tsx
+++ b/src/components/ui/site-header.tsx
@@ -7,7 +7,7 @@ import { UserNav } from "@/components/ui/user-nav";
 
 export function SiteHeader() {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+    <header className="sticky top-0 z-50 w-full max-w-screen-2xl border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex h-14 pl-4 pt-2 max-w-screen-2xl items-start">
         <MainNav />
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">


### PR DESCRIPTION
## Description
This PR tweaks the coaching session page layout padding and makes the CoachingSessionSelector use React API hooks instead of synchronous fetch calls.


#### GitHub Issue: None

### Changes
* Add some padding to the coaching session page title left side and from the main-nav header
* Restructure the CoachingSessionSelector to use the API hooks instead of useEffect blocks, which allows the list to be updated with a call to refresh() from the OverarchingGoalContainer

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1798" alt="Screenshot 2025-04-07 at 21 16 02" src="https://github.com/user-attachments/assets/c0565b1d-2382-4630-874e-e269af192573" />


### Testing Strategy
1. Observe the left padding shift to the right to the session title on the coaching session page
2. Update a coaching session overarching goal, observe that the coaching session selector now updates the overarching goal in the list and the selected one once you click on the drop down


### Concerns
* I still want to get it so that the coaching session selector will update without having to click on it, but I can't quite figure that out yet. This is a step in the right direction however.