### PR TITLE
Hide the search component for now

### DIFF
--- a/src/components/ui/site-header.tsx
+++ b/src/components/ui/site-header.tsx
@@ -11,9 +11,9 @@ export function SiteHeader() {
       <div className="flex h-14 pl-4 pt-2 max-w-screen-2xl items-start">
         <MainNav />
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
-          <div className="w-full flex-1 md:w-auto md:flex-none">
+          {/* <div className="w-full flex-1 md:w-auto md:flex-none">
             <CommandMenu />
-          </div>
+          </div> */}
           <nav className="flex items-center">
             <ModeToggle />
             <UserNav />


### PR DESCRIPTION
## Description
This PR hides the search component for now since it is not yet useful and steals the CTRL + K keystroke that we want to work for adding links on the coaching session page.


#### GitHub Issue: None

### Changes
* Hide the search component

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="2093" alt="Screenshot 2025-04-11 at 12 21 05" src="https://github.com/user-attachments/assets/3ff5efce-0d8f-427a-ba1d-c198022fe3ad" />


### Testing Strategy
Login, notice the search component in the upper righthand corner is no longer there


### Concerns
None