### PR TITLE
Fix issue with link that is also strikethrough, and fix outdated link tooltip text

### DIFF
--- a/src/components/ui/coaching-sessions/coaching-notes.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes.tsx
@@ -118,9 +118,11 @@ const CoachingNotes = () => {
           handleDOMEvents: {
             click: (view, event) => {
               const target = event.target as HTMLElement;
-
               // Check if the clicked element is an <a> tag and Shift is pressed
-              if (target.tagName === "A" && event.shiftKey) {
+              if (
+                (target.tagName === "A" || target.parentElement?.tagName) &&
+                event.shiftKey
+              ) {
                 event.preventDefault(); // Prevent default link behavior
                 window
                   .open(target.getAttribute("href") || "", "_blank")

--- a/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/extended-link-extension.tsx
@@ -11,7 +11,7 @@ const LinkWithTitle = Link.extend({
             return {};
           }
           return {
-            title: `Right-click to open ${attributes.href}`,
+            title: `Shift + left-click to open ${attributes.href}`,
           };
         },
       },


### PR DESCRIPTION
## Description
Tooltip text was wrong

Also when text is both a link and has strikethrough styling, shift left click was not working

<img width="400" alt="Screenshot 2025-04-12 at 7 47 27 PM" src="https://github.com/user-attachments/assets/da5c8e81-d4ac-4fee-a800-259c18299403" />
