### PR TITLE
Bump app version to 1.0.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "refactor-platform-fe",
-  "version": "1.0.0-rc2",
+  "version": "1.0.0-beta1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Description
This PR bumps the app version to 1.0.0-beta1 to match the backend.


#### GitHub Issue: None

### Changes
* Bumps app version to 1.0.0-beta1

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
None


### Concerns
None