### PR TITLE
Reduce the minimum width on the CoachingSessionList component

### DIFF
--- a/src/components/ui/dashboard/coaching-session-list.tsx
+++ b/src/components/ui/dashboard/coaching-session-list.tsx
@@ -93,7 +93,7 @@ export default function CoachingSessionList({
   );
 
   return (
-    <Card className={cn("min-w-96", className)}>
+    <Card className={cn("min-w-64", className)}>
       <CardHeader>
         <CardTitle>
           <div className="flex justify-between flex-col lg:flex-row">


### PR DESCRIPTION
## Description
This PR reduces the minimum width on the CoachingSessionList component on the Dashboard page so it fits better in mobile portrait screen sizes.


#### GitHub Issue: N/A

### Changes
* Reduce the minimum width on the CoachingSessionList component on the Dashboard page

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="370" alt="Screenshot 2025-06-15 at 13 31 57" src="https://github.com/user-attachments/assets/49ed2fd1-6021-4896-abbc-77e0f32d1d13" />

### Testing Strategy
1. Login with a mobile phone like an iPhone16 Pro, navigate to the Dashboard page
2. Observe that everything fits and is aligned


### Concerns
1. We could probably improve this further by creating a CSS class for cards, setting their minimum width automatically and make all cards consistently responsive to small screen sizes.