### PR TITLE
Allow for an empty NEXT_PUBLIC_BACKEND_SERVICE_API_PATH

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -9,7 +9,7 @@ export const siteConfig = {
     twitter: "https://www.linkedin.com/company/refactor-group/",
     github: "https://github.com/refactor-group/",
   },
-  // Configuration items set via environment variables
+  // Configuration items set via a mix of build-time and run-time environment variables
   env: {
     backendServicePort: process.env.NEXT_PUBLIC_BACKEND_SERVICE_PORT,
     backendServiceHost: process.env.NEXT_PUBLIC_BACKEND_SERVICE_HOST,
@@ -19,8 +19,9 @@ export const siteConfig = {
       process.env.NEXT_PUBLIC_BACKEND_SERVICE_HOST +
       ":" +
       process.env.NEXT_PUBLIC_BACKEND_SERVICE_PORT +
-      "/" +
-      process.env.NEXT_PUBLIC_BACKEND_SERVICE_API_PATH,
+      (process.env.NEXT_PUBLIC_BACKEND_SERVICE_API_PATH
+        ? "/" + process.env.NEXT_PUBLIC_BACKEND_SERVICE_API_PATH
+        : ""),
     backendApiVersion: process.env.NEXT_PUBLIC_BACKEND_API_VERSION,
     frontendServicePort: process.env.FRONTEND_SERVICE_PORT,
     frontendServiceInterface: process.env.FRONTEND_SERVICE_INTERFACE,


### PR DESCRIPTION
## Description
This PR allows for an empty NEXT_PUBLIC_BACKEND_SERVICE_API_PATH without breaking localhost dev flow. Without this, the localhost development / testing flow is broken.


#### GitHub Issue: None

### Changes
* Allow for an empty NEXT_PUBLIC_BACKEND_SERVICE_API_PATH without breaking localhost dev flow.

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

### Testing Strategy
1. Set the environment variable `NEXT_PUBLIC_BACKEND_SERVICE_API_PATH=""` in your .env.local
2. Verify that all requests to the backend still work as expected without trying to request http://localhost:4000/api/*


### Concerns
None