### PR TITLE
Handle an invalid login error case

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 
 import { cn } from "@/components/lib/utils";
 import { buttonVariants } from "@/components/ui/button";
-import { UserAuthForm } from "@/components/user-auth-form";
+import { UserAuthForm } from "@/components/ui/login/user-auth-form";
 import { siteConfig } from "@/site.config";
 import { Icons } from "@/components/ui/icons";
 

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,7 +1,101 @@
 import { DateTime } from "ts-luxon";
+import { AxiosError, AxiosResponse } from "axios";
+import axios from "axios";
 
 // A type alias for each entity's Id field
 export type Id = string;
+
+/**
+ * Enhanced error type for Entity API operations that preserves axios error information
+ * while providing a more user-friendly interface for error handling.
+ */
+export class EntityApiError extends Error {
+  public readonly method: string;
+  public readonly url: string;
+  public readonly status?: number;
+  public readonly statusText?: string;
+  public readonly response?: AxiosResponse;
+  public readonly request?: any;
+  public readonly data?: any;
+  public readonly originalError: AxiosError | Error;
+
+  constructor(
+    method: string,
+    url: string,
+    originalError: AxiosError | Error,
+    message?: string
+  ) {
+    // Create a descriptive error message
+    const errorMessage =
+      message || EntityApiError.createErrorMessage(method, url, originalError);
+    super(errorMessage);
+
+    this.name = "EntityApiError";
+    this.method = method.toUpperCase();
+    this.url = url;
+    this.originalError = originalError;
+
+    // Extract axios-specific properties if available
+    if (
+      originalError &&
+      "isAxiosError" in originalError &&
+      originalError.isAxiosError
+    ) {
+      const axiosError = originalError as AxiosError;
+      this.status = axiosError.response?.status;
+      this.statusText = axiosError.response?.statusText;
+      this.response = axiosError.response;
+      this.request = axiosError.request;
+      this.data = axiosError.response?.data;
+    }
+  }
+
+  /**
+   * Creates a user-friendly error message from the original error
+   */
+  private static createErrorMessage(
+    method: string,
+    url: string,
+    error: AxiosError | Error
+  ): string {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const statusText = error.response?.statusText;
+      const serverMessage = error.response?.data?.message;
+
+      if (serverMessage) {
+        return `${method.toUpperCase()} ${url} failed: ${serverMessage}`;
+      } else if (status && statusText) {
+        return `${method.toUpperCase()} ${url} failed: ${status} ${statusText}`;
+      } else {
+        return `${method.toUpperCase()} ${url} failed: ${error.message}`;
+      }
+    } else {
+      return `${method.toUpperCase()} ${url} failed: ${error.message}`;
+    }
+  }
+
+  /**
+   * Returns true if this error represents a client error (4xx status codes)
+   */
+  public isClientError(): boolean {
+    return this.status !== undefined && this.status >= 400 && this.status < 500;
+  }
+
+  /**
+   * Returns true if this error represents a server error (5xx status codes)
+   */
+  public isServerError(): boolean {
+    return this.status !== undefined && this.status >= 500;
+  }
+
+  /**
+   * Returns true if this error represents a network error (no response received)
+   */
+  public isNetworkError(): boolean {
+    return this.status === undefined && "isAxiosError" in this.originalError;
+  }
+}
 
 // A sorting type that can be used by any of our custom types when stored
 // as arrays


### PR DESCRIPTION
## Description
This PR fixes the issue where the login form wasn't displaying the correct error when passing an invalid credential. 


#### GitHub Issue: Fixes #122 

### Changes
* Moves `user-auth-form.tsx` under `components/ui/login` to be consistent with other component src tree layout
* Also adds a new error type EntityApiError that extends Error, because we weren't handling error conditions while using EntityApi otherwise. This was needed to successfully handle the invalid login error case 

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="1616" alt="Screenshot 2025-06-17 at 20 31 13" src="https://github.com/user-attachments/assets/f472aab5-3ea0-4c4b-9382-8001da6a01ce" />


### Testing Strategy
1. You need the [backend PR here first](https://github.com/refactor-group/refactor-platform-rs/pull/160)
2. Then, try logging in with any random credentials. You should see the "Invalid email or password. Please try again." error displayed in red on the login page.


### Concerns
None