### PR TITLE
Disable any current keyboard shortcut for toggling the sidebar

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -30,7 +30,7 @@ const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
-const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+const SIDEBAR_KEYBOARD_SHORTCUT = "" // Disabled - no keyboard shortcut for sidebar
 
 type SidebarContextProps = {
   state: "expanded" | "collapsed"
@@ -102,10 +102,13 @@ const SidebarProvider = React.forwardRef<
         : setOpen((open) => !open)
     }, [isMobile, setOpen, setOpenMobile])
 
-    // Adds a keyboard shortcut to toggle the sidebar.
+    // Keyboard shortcut for sidebar toggle is disabled to avoid conflicts with editor shortcuts
+    // Previously used Ctrl/Cmd+B which conflicts with TipTap bold formatting
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
+        // No keyboard shortcut assigned - sidebar can only be toggled via UI buttons
         if (
+          SIDEBAR_KEYBOARD_SHORTCUT && 
           event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
           (event.metaKey || event.ctrlKey)
         ) {


### PR DESCRIPTION
## Description
This PR disables any current keyboard shortcut for toggling the sidebar. Note that I'm leaving the infrastructure in place to assign a keyboard shortcut in case we want to add one in the future for toggling the sidebar open/closed.


#### GitHub Issue: Resolves #134 

### Changes
* Disable any current keyboard shortcut for toggling the sidebar

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

### Testing Strategy
1. Join a coaching session
2. Select some text in the coaching notes
3. Press CNTRL / CMD + b and notice that the text bolds instead of the sidebar toggling open/closed


### Concerns
None