### PR TITLE
Adds a copy coaching session link context menu item and button

### DIFF
--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -11,11 +11,13 @@ import { OverarchingGoalContainer } from "@/components/ui/coaching-sessions/over
 import { CoachingNotes } from "@/components/ui/coaching-sessions/coaching-notes";
 
 import CoachingSessionSelector from "@/components/ui/coaching-session-selector";
-import { useRouter } from "next/navigation";
+import { useRouter, useParams } from "next/navigation";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
+import ShareSessionLink from "@/components/ui/share-session-link";
 
 export default function CoachingSessionsPage() {
   const router = useRouter();
+  const params = useParams();
   const { userId } = useAuthStore((state) => ({ userId: state.userId }));
   const { currentCoachingRelationshipId } = useCoachingRelationshipStateStore(
     (state) => state
@@ -35,11 +37,14 @@ export default function CoachingSessionsPage() {
     <div className="max-w-screen-2xl">
       <div className="flex-col h-full pl-4 md:flex ">
         <div className="flex flex-col items-start justify-between space-y-2 py-4 px-4 sm:flex-row sm:items-center sm:space-y-0 md:h-16">
-          <CoachingSessionTitle
-            locale={siteConfig.locale}
-            style={siteConfig.titleStyle}
-            onRender={handleTitleRender}
-          ></CoachingSessionTitle>
+          <div className="flex items-center space-x-2">
+            <CoachingSessionTitle
+              locale={siteConfig.locale}
+              style={siteConfig.titleStyle}
+              onRender={handleTitleRender}
+            ></CoachingSessionTitle>
+            <ShareSessionLink sessionId={params.id as string} />
+          </div>
           <div className="ml-auto flex w-full sm:max-w-sm md:max-w-md space-x-2 sm:justify-end md:justify-start">
             <CoachingSessionSelector
               relationshipId={currentCoachingRelationshipId}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -5,6 +5,7 @@ import { siteConfig } from "@/site.config";
 import { SiteHeader } from "@/components/ui/site-header";
 import { AppSidebar } from "@/components/ui/app-sidebar";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { Toaster } from "@/components/ui/sonner";
 
 export const metadata: Metadata = {
   title: siteConfig.name,
@@ -23,6 +24,7 @@ export default function DashboardLayout({
         <SidebarInset>
           <SiteHeader />
           <main className="flex-1 p-6">{children}</main>
+          <Toaster />
         </SidebarInset>
       </div>
     </SidebarProvider>

--- a/src/components/ui/coaching-session.tsx
+++ b/src/components/ui/coaching-session.tsx
@@ -12,11 +12,13 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal, Share } from "lucide-react";
 import { CoachingSession as CoachingSessionType } from "@/types/coaching-session";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { copyCoachingSessionLink } from "@/lib/functions/copy-coaching-session-link";
 
 interface CoachingSessionProps {
   coachingSession: CoachingSessionType;
@@ -33,6 +35,10 @@ const CoachingSession: React.FC<CoachingSessionProps> = ({
     (state) => state
   );
   const { isCurrentCoach } = useAuthStore((state) => state);
+
+  const handleCopyLink = async () => {
+    await copyCoachingSessionLink(coachingSession.id);
+  };
 
   return (
     <Card>
@@ -61,11 +67,17 @@ const CoachingSession: React.FC<CoachingSessionProps> = ({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={onUpdate}>
-                  Edit
+                <DropdownMenuItem onClick={handleCopyLink}>
+                  <Share className="mr-2 h-4 w-4" />
+                  Copy link
                 </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={onUpdate}>Edit</DropdownMenuItem>
                 {isCurrentCoach && (
-                  <DropdownMenuItem onClick={onDelete} className="text-destructive">
+                  <DropdownMenuItem
+                    onClick={onDelete}
+                    className="text-destructive"
+                  >
                     Delete
                   </DropdownMenuItem>
                 )}

--- a/src/components/ui/share-session-link.tsx
+++ b/src/components/ui/share-session-link.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Share, Check } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { copyCoachingSessionLink } from "@/lib/functions/copy-coaching-session-link";
+
+interface ShareSessionLinkProps {
+  sessionId: string;
+  className?: string;
+}
+
+export default function ShareSessionLink({ sessionId, className }: ShareSessionLinkProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopyLink = async () => {
+    try {
+      await copyCoachingSessionLink(sessionId);
+      setIsCopied(true);
+      setTimeout(() => {
+        setIsCopied(false);
+      }, 2000);
+    } catch (error) {
+      console.error("Failed to copy link:", error);
+    }
+  };
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size={isCopied ? "sm" : "icon"}
+            onClick={handleCopyLink}
+            className={`${isCopied ? "px-3" : "h-8 w-8"} ${className || ""}`}
+          >
+            {isCopied ? (
+              <>
+                <Check className="h-4 w-4 mr-1" />
+                Copied
+              </>
+            ) : (
+              <Share className="h-4 w-4" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Click to share link to this coaching session</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/lib/functions/copy-coaching-session-link.ts
+++ b/src/lib/functions/copy-coaching-session-link.ts
@@ -1,0 +1,11 @@
+import { toast } from "sonner";
+
+export async function copyCoachingSessionLink(sessionId: string): Promise<void> {
+  const url = `${window.location.origin}/coaching-sessions/${sessionId}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    toast("Coaching session link copied successfully.");
+  } catch (error) {
+    console.error("Failed to copy link:", error);
+  }
+}


### PR DESCRIPTION
## Description
This PR adds a "Copy link" feature for coaching sessions that allows users to easily share links to specific coaching sessions. The feature includes both a context menu option in the coaching session list on the Dashboard page and a share button on individual coaching session pages, with visual feedback and toast notifications for successful copy operations.


#### GitHub Issue: Resolves #137 

### Changes
* Added "Copy link" context menu option to coaching session list items on Dashboard page with share icon and separator
* Created reusable ShareSessionLink component with ghost-style button that shows share icon by default and checkmark + "Copied" text when clicked
* Added share button to coaching session page header, positioned to the right of the session title with tooltip
* Implemented visual feedback with 2-second timer that shows success state before reverting to default
* Added sonner toast notification "Coaching session link copied successfully." for Dashboard copy operations
* Added Toaster component to Dashboard layout to enable toast notifications
* Created reusable copyCoachingSessionLink() utility function in src/lib/functions/ to consolidate duplicate copy logic
* All copy operations generate full URLs to coaching sessions using window.location.origin

### Screenshots / Videos Showing UI Changes (if applicable)
![image](https://github.com/user-attachments/assets/e73ef3fb-d3c2-4457-beff-fb3d1cbbc02a)

<img width="1985" alt="Screenshot 2025-06-29 at 11 53 38" src="https://github.com/user-attachments/assets/188883c0-8e0b-43fb-92bc-b4ae697fa896" />


### Testing Strategy
1. Navigate to Dashboard page and verify coaching session list items have "Copy link" option in dropdown menu
2. Click "Copy link" from context menu and verify toast notification appears and link is copied to clipboard
3. Navigate to individual coaching session page and verify share button appears to the right of session title
4. Hover over share button to verify tooltip displays "Click to share link to this coaching session"
5. Click share button and verify it shows checkmark + "Copied" text for 2 seconds, then reverts to share icon
6. Paste copied links in browser to verify they navigate to correct coaching session pages
7. Test error handling by blocking clipboard access and verify console errors are logged appropriately


### Concerns
* The copy functionality relies on the Clipboard API which may not work in all browsers or contexts (e.g., non-HTTPS environments)
* Toast notifications are only shown on the Dashboard page context menu, not on the individual session page share button (by design for different UX patterns)
* The share button temporarily changes size when showing "Copied" text which could cause minor layout shifts