### PR TITLE
Conditionally show/hide the coaching-relationship-selector component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "refactor-platform-fe",
-  "version": "1.0.0-beta1",
+  "version": "1.0.0-beta2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "refactor-platform-fe",
-      "version": "1.0.0-beta1",
+      "version": "1.0.0-beta2",
       "dependencies": {
         "@hocuspocus/provider": "^2.15.2",
         "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -58,7 +58,7 @@
         "react-dom": "^19.0.0",
         "sass": "^1.81.0",
         "sonner": "^2.0.3",
-        "swr": "^2.2.6-beta.4",
+        "swr": "^2.3.4",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
         "ts-luxon": "^5.0.7-beta.0",
@@ -8365,9 +8365,10 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
-      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "react-dom": "^19.0.0",
     "sass": "^1.81.0",
     "sonner": "^2.0.3",
-    "swr": "^2.2.6-beta.4",
+    "swr": "^2.3.4",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "ts-luxon": "^5.0.7-beta.0",

--- a/src/components/ui/coaching-relationship-selector.tsx
+++ b/src/components/ui/coaching-relationship-selector.tsx
@@ -60,10 +60,15 @@ export default function CoachingRelationshipSelector({
     currentCoachingRelationshipId,
     currentCoachingRelationship,
     setCurrentCoachingRelationshipId,
+    resetCoachingRelationshipState,
   } = useCurrentCoachingRelationship();
-  
 
-  const { setIsCurrentCoach } = useAuthStore((state) => state);
+  const { relationships, isLoading: isLoadingRelationships } =
+    useCoachingRelationshipList(organizationId);
+
+  const { setIsCurrentCoach, isLoggedIn, userId } = useAuthStore(
+    (state) => state
+  );
 
   const handleSetCoachingRelationship = (relationshipId: Id) => {
     setCurrentCoachingRelationshipId(relationshipId);
@@ -77,6 +82,21 @@ export default function CoachingRelationshipSelector({
       setIsCurrentCoach(currentCoachingRelationship.coach_id);
     }
   }, [currentCoachingRelationship, setIsCurrentCoach]);
+
+  // Auto-select the relationship if the current user only has one coaching relationship
+  // and no prior relationship has already been selected
+  useEffect(() => {
+    if (
+      !isLoadingRelationships &&
+      relationships?.length === 1 &&
+      !currentCoachingRelationshipId
+    ) {
+      setCurrentCoachingRelationshipId(relationships[0].id);
+      if (onSelect) {
+        onSelect(relationships[0].id);
+      }
+    }
+  }, [relationships, currentCoachingRelationshipId, isLoadingRelationships]);
 
   const displayValue =
     currentCoachingRelationship && currentCoachingRelationship.id ? (

--- a/src/components/ui/dashboard/coaching-session-list.tsx
+++ b/src/components/ui/dashboard/coaching-session-list.tsx
@@ -5,6 +5,7 @@ import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 import { useCoachingSessionList } from "@/lib/api/coaching-sessions";
 import { useCoachingSessionMutation } from "@/lib/api/coaching-sessions";
+import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { CoachingSession as CoachingSessionComponent } from "@/components/ui/coaching-session";
 import { DateTime } from "ts-luxon";
 import {
@@ -27,6 +28,7 @@ export default function CoachingSessionList({
 }: CoachingSessionListProps) {
   const { currentOrganizationId } = useCurrentOrganization();
   const { currentCoachingRelationshipId } = useCurrentCoachingRelationship();
+  const { relationships } = useCoachingRelationshipList(currentOrganizationId || "");
   // TODO: for now we hardcode a 2 month window centered around now,
   // eventually we want to make this be configurable somewhere
   // (either on the page or elsewhere)
@@ -66,6 +68,9 @@ export default function CoachingSessionList({
       )
     : [];
 
+  // Hide the selector if there's only one coaching relationship (but still render it for auto-selection)
+  const shouldHideSelector = relationships && relationships.length === 1;
+
   let loadingCoachingSessions = (
     <div className="flex items-center justify-center py-8">
       <p className="text-lg text-muted-foreground">
@@ -97,7 +102,7 @@ export default function CoachingSessionList({
           <div className="flex justify-between flex-col lg:flex-row">
             <div>Coaching Sessions</div>
             <CoachingRelationshipSelector
-              className="pt-4 lg:min-w-64"
+              className={`pt-4 lg:min-w-64 ${shouldHideSelector ? 'hidden' : ''}`}
               organizationId={currentOrganizationId}
               disabled={!currentOrganizationId}
             />

--- a/src/components/ui/login/user-auth-form.tsx
+++ b/src/components/ui/login/user-auth-form.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/components/lib/utils";
 import { useUserSessionMutation } from "@/lib/api/user-sessions";
 import { EntityApiError } from "@/lib/api/entity-api";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { EntityApi } from "@/lib/api/entity-api";
 import { useRouter } from "next/navigation";
 import { Icons } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ interface UserAuthFormProps extends React.HTMLAttributes<HTMLDivElement> {}
 export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const router = useRouter();
   const { login } = useAuthStore((action) => action);
+  const clearCache = EntityApi.useClearCache();
 
   const { create: createUserSession } = useUserSessionMutation();
 
@@ -29,6 +31,11 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
   const [email, setEmail] = React.useState<string>("");
   const [password, setPassword] = React.useState<string>("");
   const [error, setError] = React.useState<string>("");
+
+  // Clear SWR cache when login page first renders
+  React.useEffect(() => {
+    clearCache();
+  }, []);
 
   async function loginUserSubmit(event: React.SyntheticEvent) {
     event.preventDefault();

--- a/src/lib/api/coaching-relationships.ts
+++ b/src/lib/api/coaching-relationships.ts
@@ -8,6 +8,7 @@ import {
   defaultCoachingRelationshipWithUserNames,
 } from "@/types/coaching_relationship";
 import { EntityApi } from "./entity-api";
+import { useSWRConfig } from "swr";
 
 const ORGANIZATIONS_BASEURL: string = `${siteConfig.env.backendServiceURL}/organizations`;
 const COACHING_RELATIONSHIPS_BASEURL: string = `coaching_relationships`;
@@ -204,3 +205,4 @@ export const useCoachingRelationshipMutation = (organizationId: Id) => {
     }
   );
 };
+

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -74,7 +74,7 @@ export namespace EntityApi {
       if (axios.isAxiosError(error)) {
         throw new EntityApiError("get", url, error);
       }
-      
+
       // Re-throw non-axios errors as-is
       throw error;
     }
@@ -137,7 +137,7 @@ export namespace EntityApi {
       if (axios.isAxiosError(error)) {
         throw new EntityApiError(method, url, error);
       }
-      
+
       // Re-throw non-axios errors as-is
       throw error;
     }
@@ -439,7 +439,8 @@ export namespace EntityApi {
         return result;
       } catch (err) {
         // Handle both EntityApiError and regular Error types
-        const error = err instanceof Error ? err : new Error("Unknown error occurred");
+        const error =
+          err instanceof Error ? err : new Error("Unknown error occurred");
         setError(error);
         throw err;
       } finally {
@@ -496,6 +497,37 @@ export namespace EntityApi {
       isLoading,
       /** Contains the error if the last operation failed, null otherwise */
       error,
+    };
+  };
+
+  /**
+   * Hook to clear the entire SWR cache.
+   * Useful for clearing stale data when switching users or on logout.
+   */
+  export const useClearCache = () => {
+    const { cache } = useSWRConfig();
+
+    return () => {
+      console.trace("🧹 CACHE-CLEAR: Starting full SWR cache clear");
+      console.trace(
+        "🧹 CACHE-CLEAR: Cache keys before clear:",
+        Array.from(cache.keys())
+      );
+
+      // Clear all SWR cached data to prevent any stale data issues
+      if ("clear" in cache && typeof (cache as any).clear === "function") {
+        (cache as any).clear();
+      } else {
+        // Fallback for cache implementations without clear method
+        for (const key of cache.keys()) {
+          cache.delete(key);
+        }
+      }
+
+      console.trace(
+        "🧹 CACHE-CLEAR: Cache cleared, remaining keys:",
+        Array.from(cache.keys())
+      );
     };
   };
 }

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -2,6 +2,7 @@ import { useUserSessionMutation } from "@/lib/api/user-sessions";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
+import { EntityApi } from "@/lib/api/entity-api";
 import { useRouter } from "next/navigation";
 
 export function useLogoutUser() {
@@ -14,20 +15,27 @@ export function useLogoutUser() {
   const { resetOrganizationState } = useOrganizationStateStore(
     (action) => action
   );
-  const { resetCoachingRelationshipState } = useCoachingRelationshipStateStore(
-    (action) => action
+  const { resetCoachingRelationshipState, currentCoachingRelationshipId } = useCoachingRelationshipStateStore(
+    (state) => state
   );
+  const clearCache = EntityApi.useClearCache();
 
   return async () => {
     try {
       // Reset auth store FIRST to prevent other components from re-initializing
-      console.trace("Resetting AuthStore state");
+      console.trace("🚪 LOGOUT: Resetting AuthStore state");
       logout();
 
-      console.trace("Resetting CoachingRelationshipStateStore state");
-      resetCoachingRelationshipState();
+      console.trace("🚪 LOGOUT: Clearing SWR cache");
+      clearCache();
 
-      console.trace("Resetting OrganizationStateStore state");
+      console.trace("🚪 LOGOUT: Resetting CoachingRelationshipStateStore state - BEFORE:", {
+        currentCoachingRelationshipId
+      });
+      resetCoachingRelationshipState();
+      console.trace("🚪 LOGOUT: Resetting CoachingRelationshipStateStore state - AFTER (will check in next render)");
+
+      console.trace("🚪 LOGOUT: Resetting OrganizationStateStore state");
       resetOrganizationState();
 
       console.trace(


### PR DESCRIPTION
## Description
Implement automatic coaching relationship selection and conditional display for users based on their available relationships. When a user has only one coaching relationship, automatically select it and hide the selector UI. When users have multiple
relationships, display the selector without auto-selection.

### Changes
* Auto-select coaching relationship when user has exactly one relationship and none is currently selected
* Hide coaching relationship selector UI when user only has one relationship (while still rendering for auto-selection logic)
* Add SWR cache clearing to general EntityApi (`useClearCache`)
* Add SWR cache clearing on login page render and logout to prevent stale relationship data from bleeding between user sessions
* Optimize useEffect dependencies by removing redundant checks for login state and organization ID
* Update package dependencies (SWR 2.3.4, version bump to 1.0.0-beta2)

### Testing Strategy
1. Test single relationship user flow:
   - Login as user with 1 coaching relationship
   - Verify relationship is auto-selected and selector is hidden
   - Logout and login as different single-relationship user
   - Verify no relationship ID bleeding occurs

2. Test multiple relationship user flow:
   - Login as user with 2+ coaching relationships
   - Verify selector is visible and no auto-selection occurs
   - Manually select a relationship and verify it persists

3. Test user switching scenarios:
   - Logout from single-relationship user, login as multi-relationship user
   - Verify no stale relationship IDs from previous user

### Concerns
The auto-selection logic relies on SWR cache being properly cleared between users. The implementation includes defensive cache clearing on both login page render and logout to ensure clean state transitions, but this should be monitored to ensure no edge cases
remain.