### PR TITLE
Sort relationship selector's dropdown contents alphabetically

### DIFF
--- a/src/components/ui/coaching-relationship-selector.tsx
+++ b/src/components/ui/coaching-relationship-selector.tsx
@@ -38,9 +38,14 @@ function CoachingRelationshipsSelectItems({
   if (isError) return <div>Error loading coaching relationships</div>;
   if (!relationships?.length) return <div>No coaching relationships found</div>;
 
+  // Sort relationships alphabetically by coachee first name
+  const sortedRelationships = [...relationships].sort((a, b) =>
+    a.coachee_first_name.localeCompare(b.coachee_first_name)
+  );
+
   return (
     <>
-      {relationships.map((rel) => (
+      {sortedRelationships.map((rel) => (
         <SelectItem value={rel.id} key={rel.id}>
           {rel.coach_first_name} {rel.coach_last_name} -&gt;{" "}
           {rel.coachee_first_name} {rel.coachee_last_name}


### PR DESCRIPTION
## Description
This PR sorts the relationship selector's dropdown contents alphabetically by coachee's first name.

#### GitHub Issue: Resolves #153 

### Changes
* Sorts relationship selector's dropdown contents alphabetically by coachee's first name.

### Screenshots / Videos Showing UI Changes (if applicable)
<img width="828" height="564" alt="Screenshot 2025-07-25 at 14 19 56" src="https://github.com/user-attachments/assets/f8e43d12-419d-41c8-b9d9-0e1e13b880be" />


### Testing Strategy
1. Login and observe that the coaching relationship selector's dropdown is now alphabetically sorted by the coachee's first name (the name to the right of the --> arrow)


### Concerns
None