### PR TITLE
Swap Upcoming Sessions and Previous Sessions in the coaching session selector and use backend to sort and group

### DIFF
--- a/__tests__/components/ui/coaching-session-selector.test.tsx
+++ b/__tests__/components/ui/coaching-session-selector.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DateTime } from 'ts-luxon'
+import CoachingSessionSelector from '@/components/ui/coaching-session-selector'
+import { TestProviders } from '@/test-utils/providers'
+
+// Mock dependencies
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}))
+
+vi.mock('@/lib/api/coaching-sessions', () => ({
+  useCoachingSessionList: vi.fn(),
+}))
+
+vi.mock('@/lib/hooks/use-current-coaching-session', () => ({
+  useCurrentCoachingSession: vi.fn(() => ({
+    currentCoachingSessionId: null,
+    currentCoachingSession: null,
+    isLoading: false,
+  })),
+}))
+
+vi.mock('@/lib/api/overarching-goals', () => ({
+  useOverarchingGoalBySession: vi.fn(() => ({
+    overarchingGoal: { title: 'Test Goal' },
+    isLoading: false,
+    isError: false,
+  })),
+}))
+
+vi.mock('@/lib/providers/auth-store-provider', () => ({
+  useAuthStore: vi.fn(() => ({
+    userSession: { timezone: 'America/Chicago' },
+  })),
+}))
+
+vi.mock('@/lib/timezone-utils', () => ({
+  formatDateInUserTimezone: (date: string) => `Formatted: ${date}`,
+  getBrowserTimezone: () => 'America/Chicago',
+}))
+
+vi.mock('@/types/general', () => ({
+  getDateTimeFromString: (dateStr: string) => DateTime.fromISO(dateStr),
+}))
+
+import { useCoachingSessionList } from '@/lib/api/coaching-sessions'
+
+describe('CoachingSessionSelector - Sorting & Grouping', () => {
+  const relationshipId = 'rel-123'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should call API with correct sorting parameters (date desc)', () => {
+    vi.mocked(useCoachingSessionList).mockReturnValue({
+      coachingSessions: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    })
+
+    render(
+      <TestProviders>
+        <CoachingSessionSelector 
+          relationshipId={relationshipId} 
+          disabled={false} 
+        />
+      </TestProviders>
+    )
+
+    // Verify backend sorting is requested: date desc (newest first)
+    expect(useCoachingSessionList).toHaveBeenCalledWith(
+      relationshipId,
+      expect.any(Object), // fromDate
+      expect.any(Object), // toDate  
+      'date',             // sortBy
+      'desc'              // sortOrder - newest first
+    )
+  })
+
+  it('should display "Upcoming Sessions" first, then "Previous Sessions"', () => {
+    const now = DateTime.now()
+    const sessions = [
+      {
+        id: 'upcoming-1',
+        date: now.plus({ days: 1 }).toISO(),
+        coaching_relationship_id: relationshipId,
+      },
+      {
+        id: 'previous-1',
+        date: now.minus({ days: 1 }).toISO(),
+        coaching_relationship_id: relationshipId,
+      },
+    ]
+
+    vi.mocked(useCoachingSessionList).mockReturnValue({
+      coachingSessions: sessions,
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    })
+
+    render(
+      <TestProviders>
+        <CoachingSessionSelector 
+          relationshipId={relationshipId} 
+          disabled={false} 
+        />
+      </TestProviders>
+    )
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('combobox'))
+
+    // Check group order: Upcoming first, Previous second
+    const labels = screen.getAllByText(/Sessions$/)
+    expect(labels[0]).toHaveTextContent('Upcoming Sessions')
+    expect(labels[1]).toHaveTextContent('Previous Sessions')
+  })
+
+  it('should show indented sessions under group headers', () => {
+    const now = DateTime.now()
+    const sessions = [
+      {
+        id: 'upcoming-1',
+        date: now.plus({ days: 1 }).toISO(),
+        coaching_relationship_id: relationshipId,
+      },
+    ]
+
+    vi.mocked(useCoachingSessionList).mockReturnValue({
+      coachingSessions: sessions,
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    })
+
+    render(
+      <TestProviders>
+        <CoachingSessionSelector 
+          relationshipId={relationshipId} 
+          disabled={false} 
+        />
+      </TestProviders>
+    )
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('combobox'))
+
+    // Verify session items have indentation class
+    const sessionOptions = screen.getAllByRole('option')
+    sessionOptions.forEach(option => {
+      expect(option).toHaveClass('pl-8') // Indentation class
+    })
+  })
+})

--- a/__tests__/lib/api/coaching-sessions.test.ts
+++ b/__tests__/lib/api/coaching-sessions.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { DateTime } from 'ts-luxon'
+import { CoachingSessionApi, useCoachingSessionList } from '@/lib/api/coaching-sessions'
+import { EntityApi } from '@/lib/api/entity-api'
+import { renderHook } from '@testing-library/react'
+import { TestProviders } from '@/test-utils/providers'
+
+// Mock EntityApi
+vi.mock('@/lib/api/entity-api', () => ({
+  EntityApi: {
+    listFn: vi.fn(),
+    useEntityList: vi.fn(),
+  },
+}))
+
+describe('CoachingSessionApi - Sorting Functionality', () => {
+  const mockRelationshipId = 'rel-123'
+  const mockFromDate = DateTime.fromISO('2025-07-01')
+  const mockToDate = DateTime.fromISO('2025-07-31')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should include both sort_by and sort_order parameters when provided', async () => {
+    const mockSessions = [
+      { id: 'session-1', date: '2025-07-15T10:00:00Z' },
+      { id: 'session-2', date: '2025-07-20T14:00:00Z' },
+    ]
+    
+    vi.mocked(EntityApi.listFn).mockResolvedValue(mockSessions)
+
+    await CoachingSessionApi.list(
+      mockRelationshipId,
+      mockFromDate,
+      mockToDate,
+      'date',
+      'desc'
+    )
+
+    expect(EntityApi.listFn).toHaveBeenCalledWith('/coaching_sessions', {
+      params: {
+        coaching_relationship_id: mockRelationshipId,
+        from_date: '2025-07-01',
+        to_date: '2025-07-31',
+        sort_by: 'date',
+        sort_order: 'desc',
+      },
+    })
+  })
+
+  it('should omit sort parameters when not provided', async () => {
+    const mockSessions = []
+    vi.mocked(EntityApi.listFn).mockResolvedValue(mockSessions)
+
+    await CoachingSessionApi.list(
+      mockRelationshipId,
+      mockFromDate,
+      mockToDate
+    )
+
+    expect(EntityApi.listFn).toHaveBeenCalledWith('/coaching_sessions', {
+      params: {
+        coaching_relationship_id: mockRelationshipId,
+        from_date: '2025-07-01',
+        to_date: '2025-07-31',
+      },
+    })
+  })
+})
+
+describe('useCoachingSessionList hook - Sorting Integration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should pass sorting parameters to EntityApi.useEntityList', () => {
+    const mockUseEntityListReturn = {
+      entities: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    }
+    
+    vi.mocked(EntityApi.useEntityList).mockReturnValue(mockUseEntityListReturn)
+
+    renderHook(
+      () => useCoachingSessionList(
+        'rel-123',
+        DateTime.fromISO('2025-07-01'),
+        DateTime.fromISO('2025-07-31'),
+        'date',
+        'desc'
+      ),
+      { wrapper: TestProviders }
+    )
+
+    expect(EntityApi.useEntityList).toHaveBeenCalledWith(
+      '/coaching_sessions',
+      expect.any(Function), // fetcher function
+      {
+        coaching_relationship_id: 'rel-123',
+        from_date: '2025-07-01',
+        to_date: '2025-07-31',
+        sort_by: 'date',
+        sort_order: 'desc',
+      }
+    )
+  })
+})

--- a/src/components/ui/coaching-session-selector.tsx
+++ b/src/components/ui/coaching-session-selector.tsx
@@ -44,7 +44,7 @@ function CoachingSessionsSelectItems({
     coachingSessions,
     isLoading: isLoadingSessions,
     isError: isErrorSessions,
-  } = useCoachingSessionList(relationshipId, fromDate, toDate);
+  } = useCoachingSessionList(relationshipId, fromDate, toDate, 'date', 'desc');
 
   if (isLoadingSessions) return <div>Loading...</div>;
   if (isErrorSessions) return <div>Error loading coaching sessions</div>;
@@ -54,14 +54,14 @@ function CoachingSessionsSelectItems({
     <>
       {[
         {
-          label: "Previous Sessions",
-          condition: (date: string) =>
-            getDateTimeFromString(date) < DateTime.now(),
-        },
-        {
           label: "Upcoming Sessions",
           condition: (date: string) =>
             getDateTimeFromString(date) >= DateTime.now(),
+        },
+        {
+          label: "Previous Sessions",
+          condition: (date: string) =>
+            getDateTimeFromString(date) < DateTime.now(),
         },
       ].map(
         ({ label, condition }) =>
@@ -91,8 +91,8 @@ function SessionItemWithGoal({ session }: { session: CoachingSession }) {
   if (isError) return <div>Error loading goal</div>;
 
   return (
-    <SelectItem value={session.id}>
-      <div className="flex min-w-0">
+    <SelectItem value={session.id} className="pl-8">
+      <div className="flex min-w-0 ml-4">
         <div className="min-w-0 w-full">
           <p className="truncate text-sm font-medium">
             {overarchingGoal.title || "No goal set"}

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -25,22 +25,35 @@ export const CoachingSessionApi = {
    * coaching sessions should be retrieved from.
    * @param fromDate A date specifying the earliest coaching session date to return.
    * @param toDate A date specifying the latest coaching session date to match.
+   * @param sortBy Optional field to sort by (date, created_at, updated_at).
+   * @param sortOrder Optional sort order (asc, desc).
    * @returns Promise resolving to an array of CoachingSession objects (empty array if data is not yet loaded or
    *  relationshipId is null)
    */
   list: async (
     relationshipId: Id | null,
     fromDate: DateTime,
-    toDate: DateTime
+    toDate: DateTime,
+    sortBy?: 'date' | 'created_at' | 'updated_at',
+    sortOrder?: 'asc' | 'desc'
   ): Promise<CoachingSession[]> => {
     if (!relationshipId) return [];
 
+    const params: Record<string, string> = {
+      coaching_relationship_id: relationshipId,
+      from_date: fromDate.toISODate() || '',
+      to_date: toDate.toISODate() || '',
+    };
+
+    if (sortBy) {
+      params.sort_by = sortBy;
+    }
+    if (sortOrder) {
+      params.sort_order = sortOrder;
+    }
+
     return EntityApi.listFn<CoachingSession>(COACHING_SESSIONS_BASEURL, {
-      params: {
-        coaching_relationship_id: relationshipId,
-        from_date: fromDate.toISODate(),
-        to_date: toDate.toISODate(),
-      },
+      params,
     });
   },
 
@@ -121,6 +134,8 @@ export const CoachingSessionApi = {
  * coaching sessions should be fetched from.
  * @param fromDate A date specifying the earliest coaching session date to return.
  * @param toDate A date specifying the latest coaching session date to match.
+ * @param sortBy Optional field to sort by (date, created_at, updated_at).
+ * @param sortOrder Optional sort order (asc, desc).
  * @returns An object containing:
  *
  * * coachingSessions: Array of CoachingSession objects (empty array if data is not yet loaded or
@@ -132,20 +147,24 @@ export const CoachingSessionApi = {
 export const useCoachingSessionList = (
   relationshipId: Id | null,
   fromDate: DateTime,
-  toDate: DateTime
+  toDate: DateTime,
+  sortBy?: 'date' | 'created_at' | 'updated_at',
+  sortOrder?: 'asc' | 'desc'
 ) => {
   const params = relationshipId
     ? {
         coaching_relationship_id: relationshipId,
         from_date: fromDate.toISODate(),
         to_date: toDate.toISODate(),
+        ...(sortBy && { sort_by: sortBy }),
+        ...(sortOrder && { sort_order: sortOrder }),
       }
     : undefined;
 
   const { entities, isLoading, isError, refresh } =
     EntityApi.useEntityList<CoachingSession>(
       COACHING_SESSIONS_BASEURL,
-      () => CoachingSessionApi.list(relationshipId!, fromDate, toDate),
+      () => CoachingSessionApi.list(relationshipId!, fromDate, toDate, sortBy, sortOrder),
       params
     );
 


### PR DESCRIPTION
## Description
Updates the coaching session selector to fix session ordering issues and improve visual grouping. Sessions now display with "Upcoming Sessions" first, followed by "Previous Sessions", with proper indentation and backend-driven sorting.

**Note:** [pairs with backend PR](https://github.com/refactor-group/refactor-platform-rs/pull/176)

#### GitHub Issue: Resolves #165 

### Changes
* Switched dropdown order to show "Upcoming Sessions" first, then "Previous Sessions"
* Added backend sorting integration - requests sessions sorted by date in descending order
* Enhanced `CoachingSessionApi.list()` and `useCoachingSessionList()` with optional sorting parameters
* Added visual indentation (`pl-8` class) to session items under group headers for better UX
* Updated API calls to use `sort_by=date&sort_order=desc` for consistent ordering

### Testing Strategy
1. Open coaching session selector dropdown
2. Verify "Upcoming Sessions" appears first, "Previous Sessions" second
3. Confirm sessions within each group are properly sorted (newest first for previous sessions)
4. Check visual indentation - session items should be indented under group headers
5. Test with various session combinations (only upcoming, only previous, mixed)

### Concerns
* Visual regression: Indentation changes may affect dropdown appearance on different screen sizes
* Caching: SWR cache keys now include sorting parameters - existing cached data will be invalidated