### PR TITLE
View Session button for joining past sessions and indicate when a past session was held on the session page

### DIFF
--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -100,23 +100,21 @@ export default function CoachingSessionsPage() {
     <div className="max-w-screen-2xl">
       <div className="flex-col h-full pl-4 md:flex ">
         <div className="flex flex-col items-start justify-between space-y-2 py-4 px-4 sm:flex-row sm:items-center sm:space-y-0 md:h-16">
-          <div className="flex items-center space-x-2">
-            <CoachingSessionTitle
-              locale={siteConfig.locale}
-              style={siteConfig.titleStyle}
-              onRender={handleTitleRender}
-            ></CoachingSessionTitle>
+          <CoachingSessionTitle
+            locale={siteConfig.locale}
+            style={siteConfig.titleStyle}
+            onRender={handleTitleRender}
+          />
+          <div className="ml-auto flex w-full sm:max-w-sm md:max-w-md items-center gap-3 sm:justify-end md:justify-start">
             <ShareSessionLink
               sessionId={params.id as string}
               onError={handleShareError}
             />
-          </div>
-          <div className="ml-auto flex w-full sm:max-w-sm md:max-w-md space-x-2 sm:justify-end md:justify-start">
             <CoachingSessionSelector
               relationshipId={currentCoachingRelationshipId}
               disabled={!currentCoachingRelationshipId}
               onSelect={handleCoachingSessionSelect}
-            ></CoachingSessionSelector>
+            />
           </div>
         </div>
       </div>

--- a/src/components/ui/coaching-session.tsx
+++ b/src/components/ui/coaching-session.tsx
@@ -14,7 +14,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { MoreHorizontal, Share } from "lucide-react";
-import { CoachingSession as CoachingSessionType } from "@/types/coaching-session";
+import { CoachingSession as CoachingSessionType, isPastSession } from "@/types/coaching-session";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { copyCoachingSessionLinkWithToast } from "@/components/ui/share-session-link";
 import {
@@ -58,7 +58,7 @@ const CoachingSession: React.FC<CoachingSessionProps> = ({
                 size="sm"
                 className="w-full sm:w-auto mt-2 sm:mt-0 text-sm px-3 py-1"
               >
-                Join Session
+                {isPastSession(coachingSession) ? "View Session" : "Join Session"}
               </Button>
             </Link>
             <DropdownMenu>

--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -8,12 +8,16 @@ import {
 } from "@/types/session-title";
 import { useCurrentCoachingSession } from "@/lib/hooks/use-current-coaching-session";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
+import { isPastSession } from "@/types/coaching-session";
+import { formatDateInUserTimezoneWithTZ, getBrowserTimezone } from "@/lib/timezone-utils";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
 
 const CoachingSessionTitle: React.FC<{
   locale: string | "us";
   style: SessionTitleStyle;
   onRender: (sessionTitle: string) => void;
 }> = ({ locale, style, onRender }) => {
+  const { userSession } = useAuthStore((state) => state);
   const lastRenderedTitle = useRef<string>("");
   
   // Get coaching session from URL path parameter
@@ -46,9 +50,19 @@ const CoachingSessionTitle: React.FC<{
   const displayTitle = sessionTitle?.title || defaultSessionTitle().title;
 
   return (
-    <h4 className="font-semibold break-words w-full md:text-clip">
-      {displayTitle}
-    </h4>
+    <div>
+      <h4 className="font-semibold break-words w-full md:text-clip">
+        {displayTitle}
+      </h4>
+      {currentCoachingSession && isPastSession(currentCoachingSession) && (
+        <p className="text-sm text-muted-foreground mt-1">
+          This session was held on {formatDateInUserTimezoneWithTZ(
+            currentCoachingSession.date,
+            userSession?.timezone || getBrowserTimezone()
+          )}
+        </p>
+      )}
+    </div>
   );
 };
 

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -103,3 +103,21 @@ export function coachingSessionsToString(
 ): string {
   return JSON.stringify(coaching_sessions);
 }
+
+export function isPastSession(session: CoachingSession): boolean {
+  const sessionDate = DateTime.fromISO(session.date);
+  const now = DateTime.now();
+  return sessionDate < now;
+}
+
+export function isSessionToday(session: CoachingSession): boolean {
+  const sessionDate = DateTime.fromISO(session.date);
+  const today = DateTime.now();
+  return sessionDate.hasSame(today, 'day');
+}
+
+export function isFutureSession(session: CoachingSession): boolean {
+  const sessionDate = DateTime.fromISO(session.date);
+  const now = DateTime.now();
+  return sessionDate > now;
+}


### PR DESCRIPTION
## Description
Update UI to better distinguish past sessions from upcoming ones by changing button text and adding session date information.

#### GitHub Issue: Fixes #168

### Changes
* Added date utility functions (`isPastSession`, `isSessionToday`, `isFutureSession`) using ts-luxon
* Changed button text from "Join Session" to "View Session" for past sessions
* Added sub-header showing session date on past session pages
* Repositioned share link button to align with session selector

### Screenshots / Videos Showing UI Changes (if applicable)

Upcoming session's button unchanged:
<img width="1676" height="320" alt="Screenshot 2025-08-02 at 12 30 28" src="https://github.com/user-attachments/assets/5ae91977-0f4f-44b1-85b3-dea704b208bd" />

Previous session's new button text:
<img width="1687" height="543" alt="Screenshot 2025-08-02 at 12 30 55" src="https://github.com/user-attachments/assets/9bb28452-5e68-44a2-bc9d-b847015afefe" />

Previous session coaching session page:
<img width="1695" height="404" alt="Screenshot 2025-08-02 at 12 31 23" src="https://github.com/user-attachments/assets/02b3607c-ad88-4d8c-b0be-3df52711d53c" />

### Testing Strategy
* Navigate to past/future sessions and verify correct button text
* Confirm sub-header appears only on past sessions
* Check share link alignment with session selector

### Concerns
* Date comparisons use local timezone - verify consistency with backend
* "This session was held on..." text may need i18n support