### PR TITLE
Make sure when editing an existing session's time that it displays in their configured local time zone

### DIFF
--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -42,8 +42,8 @@ export default function CoachingSessionForm({
   const [sessionDate, setSessionDate] = useState<Date | undefined>(() => {
     if (!existingSession) return undefined;
     // Convert stored UTC time back to user's local timezone for editing
-    const userTimezone = userSession.timezone || getBrowserTimezone();
-    const utcDateTime = DateTime.fromISO(existingSession.date);
+    const userTimezone = userSession?.timezone || getBrowserTimezone();
+    const utcDateTime = DateTime.fromISO(existingSession.date, { zone: 'utc' });
     const localDateTime = utcDateTime.setZone(userTimezone);
     return localDateTime.toJSDate();
   });
@@ -51,8 +51,8 @@ export default function CoachingSessionForm({
   const [sessionTime, setSessionTime] = useState<string>(() => {
     if (!existingSession) return "";
     // Convert stored UTC time back to user's local timezone for editing
-    const userTimezone = userSession.timezone || getBrowserTimezone();
-    const utcDateTime = DateTime.fromISO(existingSession.date);
+    const userTimezone = userSession?.timezone || getBrowserTimezone();
+    const utcDateTime = DateTime.fromISO(existingSession.date, { zone: 'utc' });
     const localDateTime = utcDateTime.setZone(userTimezone);
     return localDateTime.toFormat("HH:mm");
   });
@@ -77,7 +77,7 @@ export default function CoachingSessionForm({
     await update(existingSession.id, {
       ...existingSession,
       date: dateTime,
-      updated_at: DateTime.now(),
+      updated_at: DateTime.now().toUTC(),
     });
   };
 
@@ -88,7 +88,7 @@ export default function CoachingSessionForm({
     const [hours, minutes] = sessionTime.split(":").map(Number);
 
     // Create datetime in user's timezone, then convert to UTC for storage
-    const userTimezone = userSession.timezone || getBrowserTimezone();
+    const userTimezone = userSession?.timezone || getBrowserTimezone();
     const localDateTime = DateTime.fromJSDate(sessionDate)
       .setZone(userTimezone)
       .set({ hour: hours, minute: minutes });


### PR DESCRIPTION
## Description
This PR fixes timezone handling in the coaching session edit popup to properly display session times in the user's configured timezone instead of UTC, while maintaining UTC storage in the database.

#### GitHub Issue: Fixes #168

### Changes
* Added explicit UTC timezone parsing when reading stored session dates to ensure proper conversion
* Fixed `updated_at` field to properly convert to UTC format when updating sessions
* Added optional chaining for `userSession.timezone` to prevent potential runtime errors
* Ensured consistent timezone handling: display in user's timezone, store in UTC

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

### Testing Strategy
1. Create a coaching session with a specific time
2. Click edit on the session to open the edit popup
3. Verify the time displayed matches the time you originally set (in your timezone)
4. Change the time and save
5. Verify the updated time displays correctly in your timezone
6. Check that different users with different timezone settings see times in their respective timezones

### Concerns
None