### PR TITLE
Add instruction for Claude to output PRs in markdown

### DIFF
--- a/.claude/pr-instructions.md
+++ b/.claude/pr-instructions.md
@@ -7,5 +7,6 @@ When creating pull requests for this repository:
 3. Keep descriptions concise and focused
 4. Only include sections that are relevant to the changes
 5. For UI changes, always specify what screenshots would be helpful
+6. Always output the pull request text as markdown format
 
 The template is located at: `.github/pull_request_template.md`


### PR DESCRIPTION
## Description

Add standardized GitHub PR template and Claude AI instructions to ensure consistent pull request creation across the admin portal repository.

### Changes

- Update `.claude/pr-instructions.md` with guidelines for AI assistants when generating PR descriptions ensuring the output is in Markdown

### Testing Strategy

No code changes to test - documentation and template additions only. The template will be automatically suggested when creating new pull requests on GitHub.

### Concerns

None - this is a process improvement that doesn't affect application functionality.