### PR TITLE
Switch to using '/' as the coaching session title separator instead of '<>'

### DIFF
--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -9,12 +9,15 @@ import {
 import { useCurrentCoachingSession } from "@/lib/hooks/use-current-coaching-session";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 import { isPastSession } from "@/types/coaching-session";
-import { formatDateInUserTimezoneWithTZ, getBrowserTimezone } from "@/lib/timezone-utils";
+import {
+  formatDateInUserTimezoneWithTZ,
+  getBrowserTimezone,
+} from "@/lib/timezone-utils";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
-import { useEditorCache } from './editor-cache-context';
-import { PresenceIndicator } from '@/components/ui/presence-indicator';
-import { UserPresence } from '@/types/presence';
-import { RelationshipRole } from '@/types/relationship-role';
+import { useEditorCache } from "./editor-cache-context";
+import { PresenceIndicator } from "@/components/ui/presence-indicator";
+import { UserPresence } from "@/types/presence";
+import { RelationshipRole } from "@/types/relationship-role";
 
 const CoachingSessionTitle: React.FC<{
   locale: string | "us";
@@ -25,10 +28,12 @@ const CoachingSessionTitle: React.FC<{
   const lastRenderedTitle = useRef<string>("");
 
   // Get coaching session from URL path parameter
-  const { currentCoachingSession, isLoading: sessionLoading } = useCurrentCoachingSession();
+  const { currentCoachingSession, isLoading: sessionLoading } =
+    useCurrentCoachingSession();
 
   // Get coaching relationship from simplified store
-  const { currentCoachingRelationship, isLoading: relationshipLoading } = useCurrentCoachingRelationship();
+  const { currentCoachingRelationship, isLoading: relationshipLoading } =
+    useCurrentCoachingRelationship();
 
   // Get presence state from editor cache
   const { presenceState } = useEditorCache();
@@ -44,7 +49,14 @@ const CoachingSessionTitle: React.FC<{
       style,
       locale
     );
-  }, [currentCoachingSession, currentCoachingRelationship, style, locale, sessionLoading, relationshipLoading]);
+  }, [
+    currentCoachingSession,
+    currentCoachingRelationship,
+    style,
+    locale,
+    sessionLoading,
+    relationshipLoading,
+  ]);
 
   // Only call onRender when the title actually changes
   useEffect(() => {
@@ -57,7 +69,9 @@ const CoachingSessionTitle: React.FC<{
   const displayTitle = sessionTitle?.title || defaultSessionTitle().title;
 
   // Helper to get presence by role
-  const getPresenceByRole = (role: RelationshipRole): UserPresence | undefined => {
+  const getPresenceByRole = (
+    role: RelationshipRole
+  ): UserPresence | undefined => {
     if (!presenceState) return undefined;
 
     // Iterate Map directly without array conversion
@@ -76,8 +90,8 @@ const CoachingSessionTitle: React.FC<{
     const coachPresence = getPresenceByRole(RelationshipRole.Coach);
     const coacheePresence = getPresenceByRole(RelationshipRole.Coachee);
 
-    // Parse the existing title format: "Coach Name <> Coachee Name" 
-    const parts = displayTitle.split(' <> ');
+    // Parse the existing title format: "Coach Name / Coachee Name"
+    const parts = displayTitle.split(" / ");
     if (parts.length !== 2 || !parts[0]?.trim() || !parts[1]?.trim()) {
       return displayTitle; // Fallback for malformed titles or default titles
     }
@@ -102,7 +116,8 @@ const CoachingSessionTitle: React.FC<{
       </h4>
       {currentCoachingSession && isPastSession(currentCoachingSession) && (
         <p className="text-sm text-muted-foreground mt-1">
-          This session was held on {formatDateInUserTimezoneWithTZ(
+          This session was held on{" "}
+          {formatDateInUserTimezoneWithTZ(
             currentCoachingSession.date,
             userSession?.timezone || getBrowserTimezone()
           )}

--- a/src/types/session-title.ts
+++ b/src/types/session-title.ts
@@ -23,7 +23,7 @@ function constructCoachFirstCoacheeFirstTitle(
   coach_first_name: string,
   coachee_first_name: string
 ): string {
-  return coach_first_name + " <> " + coachee_first_name;
+  return coach_first_name + " / " + coachee_first_name;
 }
 
 function constructCoachFirstLastCoacheeFirstLastTitle(
@@ -36,7 +36,7 @@ function constructCoachFirstLastCoacheeFirstLastTitle(
     coach_first_name +
     " " +
     coach_last_name +
-    " <> " +
+    " / " +
     coachee_first_name +
     " " +
     coachee_last_name
@@ -49,14 +49,14 @@ function constructCoachFirstCoacheeFirstDate(
   date: string,
   locale: string
 ): string {
-  var title = coach_first_name + " <> " + coachee_first_name;
+  var title = coach_first_name + " / " + coachee_first_name;
   var formattedDateTime =
     " @ " +
     getDateTimeFromString(date)
       .setLocale(locale)
       .toLocaleString(DateTime.DATE_MED);
 
-  return coach_first_name + " <> " + coachee_first_name + formattedDateTime;
+  return coach_first_name + " / " + coachee_first_name + formattedDateTime;
 }
 
 function constructCoachFirstCoacheeFirstDateTime(
@@ -65,14 +65,14 @@ function constructCoachFirstCoacheeFirstDateTime(
   date: string,
   locale: string
 ): string {
-  var title = coach_first_name + " <> " + coachee_first_name;
+  var title = coach_first_name + " / " + coachee_first_name;
   var formattedDateTime =
     " @ " +
     getDateTimeFromString(date)
       .setLocale(locale)
       .toLocaleString(DateTime.DATETIME_MED);
 
-  return coach_first_name + " <> " + coachee_first_name + formattedDateTime;
+  return coach_first_name + " / " + coachee_first_name + formattedDateTime;
 }
 
 export function generateSessionTitle(


### PR DESCRIPTION
## Description
Update the coaching session title separator from `<>` to `/` for improved readability and visual consistency with the presence indicator UI.

### Changes
* Updated title parsing logic in `coaching-session-title.tsx` to split on `" / "` instead of `"
<> "`
* Modified all title generation functions in `session-title.ts` to use `/` as the separator
between coach and coachee names
* Maintained backward compatibility with proper fallback handling for malformed titles

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

The new separator provides better visual harmony with the presence indicators that appear next to each name.

### Testing Strategy
* Verify that coaching session titles display correctly with the new `/` separator
* Confirm presence indicators appear properly alongside both coach and coachee names
* Test fallback behavior for edge cases (empty names, default "Untitled Session" titles)
* Ensure title parsing works correctly when names contain special characters

### Concerns
None - this is a straightforward visual improvement that maintains all existing functionality.