### PR TITLE
Fix the duplicate Link popover component showing up at 0,0 and under the Link toolbar button

### DIFF
--- a/__tests__/components/ui/tiptap-ui/link-popover.test.tsx
+++ b/__tests__/components/ui/tiptap-ui/link-popover.test.tsx
@@ -1,0 +1,366 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import { EditorProvider } from '@tiptap/react'
+import StarterKit from '@tiptap/starter-kit'
+import Link from '@tiptap/extension-link'
+import { LinkPopover } from '@/components/ui/tiptap-ui/link-popover'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+// Mock ResizeObserver for test environment
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+describe('LinkPopover', () => {
+  const createEditorWithContent = (content: string = '') => {
+    const extensions = [
+      StarterKit,
+      Link.configure({
+        openOnClick: false,
+        HTMLAttributes: {
+          class: 'text-blue-600 underline',
+        },
+      }),
+    ]
+
+    return { extensions, content }
+  }
+
+  // Helper to wrap components with required providers
+  const renderWithProviders = (ui: React.ReactElement) => {
+    return render(
+      <TooltipProvider>
+        {ui}
+      </TooltipProvider>
+    )
+  }
+
+  beforeEach(() => {
+    // Clear any existing popovers from previous tests
+    document.body.innerHTML = ''
+  })
+
+  describe('Single Popover Rendering', () => {
+    it('should render only one popover when link button is clicked', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div data-testid="toolbar">
+            <LinkPopover />
+          </div>
+        </EditorProvider>
+      )
+
+      // Click the link button
+      const linkButton = screen.getByLabelText('Link')
+      await user.click(linkButton)
+
+      // Wait for popover to appear
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+
+      // Verify only ONE popover exists
+      const popovers = document.querySelectorAll('.tiptap-popover')
+      expect(popovers).toHaveLength(1)
+    })
+
+    it('should not show duplicate popovers when clicked multiple times quickly', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div data-testid="toolbar">
+            <LinkPopover />
+          </div>
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+
+      // Rapid clicks
+      await user.click(linkButton)
+      await user.click(linkButton)
+      await user.click(linkButton)
+
+      await waitFor(() => {
+        const popovers = document.querySelectorAll('.tiptap-popover')
+        // Should still be only 1 (clicking toggles it open/closed)
+        expect(popovers.length).toBeLessThanOrEqual(1)
+      })
+    })
+  })
+
+  describe('Popover Positioning', () => {
+    it('should position popover with fixed positioning', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div data-testid="toolbar" style={{ marginTop: '100px', marginLeft: '50px' }}>
+            <LinkPopover />
+          </div>
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+      await user.click(linkButton)
+
+      await waitFor(() => {
+        const popover = document.querySelector('.tiptap-popover')
+        expect(popover).toBeInTheDocument()
+
+        if (popover) {
+          // Verify popover has fixed positioning style
+          const style = window.getComputedStyle(popover)
+          expect(style.position).toBe('fixed')
+
+          // Verify popover has explicit top/left positioning (not default auto)
+          expect(popover.getAttribute('style')).toContain('top:')
+          expect(popover.getAttribute('style')).toContain('left:')
+        }
+      })
+    })
+
+    it('should position popover near the trigger button', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div data-testid="toolbar">
+            <LinkPopover />
+          </div>
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+      const buttonRect = linkButton.getBoundingClientRect()
+
+      await user.click(linkButton)
+
+      await waitFor(() => {
+        const popover = document.querySelector('.tiptap-popover')
+        expect(popover).toBeInTheDocument()
+
+        if (popover) {
+          const popoverRect = popover.getBoundingClientRect()
+          // Popover should be positioned relative to button (within reasonable distance)
+          const verticalDistance = Math.abs(popoverRect.top - buttonRect.bottom)
+          const horizontalDistance = Math.abs(popoverRect.left - buttonRect.left)
+
+          // Should be relatively close (within 200px for generous tolerance)
+          expect(verticalDistance).toBeLessThan(200)
+          expect(horizontalDistance).toBeLessThan(200)
+        }
+      })
+    })
+  })
+
+  describe('Multiple LinkPopover Instances', () => {
+    it('should only show one popover when multiple LinkPopover components exist', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div>
+            {/* Simulate static toolbar */}
+            <div data-testid="static-toolbar" style={{ display: 'block' }}>
+              <LinkPopover />
+            </div>
+            {/* Simulate floating toolbar */}
+            <div data-testid="floating-toolbar" style={{ display: 'none' }}>
+              <LinkPopover />
+            </div>
+          </div>
+        </EditorProvider>
+      )
+
+      // Click link button in static toolbar
+      const toolbars = screen.getAllByLabelText('Link')
+      await user.click(toolbars[0])
+
+      await waitFor(() => {
+        const popovers = document.querySelectorAll('.tiptap-popover')
+        // Even with 2 LinkPopover components, only 1 popover should be visible
+        expect(popovers).toHaveLength(1)
+      })
+    })
+
+    it('should conditionally render based on parent visibility', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      const { rerender } = renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div>
+            {/* Static toolbar - visible */}
+            <div data-testid="static-toolbar" style={{ display: 'block' }}>
+              <LinkPopover />
+            </div>
+            {/* Floating toolbar - conditionally rendered */}
+            {false && (
+              <div data-testid="floating-toolbar">
+                <LinkPopover />
+              </div>
+            )}
+          </div>
+        </EditorProvider>
+      )
+
+      // Should only have 1 LinkPopover rendered
+      const linkButtons = screen.getAllByLabelText('Link')
+      expect(linkButtons).toHaveLength(1)
+
+      // Click to open popover
+      await user.click(linkButtons[0])
+
+      await waitFor(() => {
+        const popovers = document.querySelectorAll('.tiptap-popover')
+        expect(popovers).toHaveLength(1)
+      })
+    })
+  })
+
+  describe('Link Creation Functionality', () => {
+    it('should allow creating a link', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('<p>Test text</p>')
+
+      const { container } = renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <div>
+            <LinkPopover />
+            <div className="ProseMirror" />
+          </div>
+        </EditorProvider>
+      )
+
+      // Click link button
+      const linkButton = screen.getByLabelText('Link')
+      await user.click(linkButton)
+
+      // Wait for popover
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+
+      // Type URL
+      const input = screen.getByPlaceholderText('Paste a link...')
+      await user.type(input, 'https://example.com')
+
+      // URL should be in the input
+      expect(input).toHaveValue('https://example.com')
+    })
+  })
+
+  describe('Popover State Management', () => {
+    it('should toggle popover open and closed', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <LinkPopover />
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+
+      // Open popover
+      await user.click(linkButton)
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+
+      // Close popover by clicking button again
+      await user.click(linkButton)
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText('Paste a link...')).not.toBeInTheDocument()
+      })
+    })
+
+    it('should close popover when clicking outside', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      const { container } = renderWithProviders(
+        <div>
+          <EditorProvider extensions={extensions} content={content}>
+            <LinkPopover />
+          </EditorProvider>
+          <div data-testid="outside">Outside content</div>
+        </div>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+
+      // Open popover
+      await user.click(linkButton)
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+
+      // Click outside
+      const outside = screen.getByTestId('outside')
+      await user.click(outside)
+
+      // Popover should close
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText('Paste a link...')).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle containerRef prop gracefully', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+      const containerRef = { current: document.createElement('div') }
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <LinkPopover containerRef={containerRef} />
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+      await user.click(linkButton)
+
+      // Should still work with containerRef
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+
+      const popovers = document.querySelectorAll('.tiptap-popover')
+      expect(popovers).toHaveLength(1)
+    })
+
+    it('should handle undefined containerRef', async () => {
+      const user = userEvent.setup()
+      const { extensions, content } = createEditorWithContent('Test content')
+
+      renderWithProviders(
+        <EditorProvider extensions={extensions} content={content}>
+          <LinkPopover containerRef={undefined} />
+        </EditorProvider>
+      )
+
+      const linkButton = screen.getByLabelText('Link')
+      await user.click(linkButton)
+
+      // Should work without containerRef
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Paste a link...')).toBeInTheDocument()
+      })
+    })
+  })
+})

--- a/src/components/ui/coaching-sessions/coaching-notes.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes.tsx
@@ -206,7 +206,7 @@ const buildToolbarSlots = (
       ref={toolbarRef}
       className={`toolbar-container ${toolbarState.originalToolbarVisible ? 'visible' : 'hidden'}`}
     >
-      <SimpleToolbar containerRef={editorRef} />
+      <SimpleToolbar containerRef={editorRef} isVisible={toolbarState.originalToolbarVisible} />
     </div>
   ),
   slotAfter: (

--- a/src/components/ui/coaching-sessions/coaching-notes/floating-toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/floating-toolbar.tsx
@@ -213,7 +213,7 @@ const renderFloatingToolbar = (
     }}
   >
     <div className="floating-toolbar-content">
-      <SimpleToolbar containerRef={editorRef} />
+      <SimpleToolbar containerRef={editorRef} isVisible={isVisible} />
     </div>
   </div>
 );

--- a/src/components/ui/coaching-sessions/coaching-notes/simple-toolbar.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes/simple-toolbar.tsx
@@ -26,9 +26,14 @@ interface SimpleToolbarProps {
    * Reference to the editor container for proper popover positioning.
    */
   containerRef?: React.RefObject<HTMLDivElement>;
+  /**
+   * Whether this toolbar is currently visible. Used to prevent duplicate popovers
+   * when both static and floating toolbars are present.
+   */
+  isVisible?: boolean;
 }
 
-export const SimpleToolbar: React.FC<SimpleToolbarProps> = ({ containerRef }) => {
+export const SimpleToolbar: React.FC<SimpleToolbarProps> = ({ containerRef, isVisible = true }) => {
   const { editor } = useCurrentEditor();
 
   // Use TipTap's official pattern for undo/redo state tracking
@@ -82,7 +87,7 @@ export const SimpleToolbar: React.FC<SimpleToolbarProps> = ({ containerRef }) =>
         <MarkButton type="strike" />
         <MarkButton type="code" />
         <MarkButton type="highlight" />
-        <LinkPopover hideWhenUnavailable={false} containerRef={containerRef} />
+        {isVisible && <LinkPopover hideWhenUnavailable={false} containerRef={containerRef} />}
       </ToolbarGroup>
 
       <Spacer />

--- a/src/components/ui/tiptap-ui-primitive/popover/popover.tsx
+++ b/src/components/ui/tiptap-ui-primitive/popover/popover.tsx
@@ -156,7 +156,7 @@ function usePopover({
       });
     },
     middleware,
-    strategy: 'absolute', // Use absolute positioning for better container awareness
+    strategy: 'fixed', // Use fixed positioning for portaling to document.body
   })
 
   const interactions = useInteractions([
@@ -264,7 +264,6 @@ interface PopoverContentProps extends React.HTMLProps<HTMLDivElement> {
   portal?: boolean
   portalProps?: Omit<React.ComponentProps<typeof FloatingPortal>, "children">
   asChild?: boolean
-  container?: HTMLElement | null  // New prop for portal container
 }
 
 const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
@@ -279,7 +278,6 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       portal = true,
       portalProps = {},
       asChild = false,
-      container = null,
       children,
       ...props
     },
@@ -297,53 +295,28 @@ const PopoverContent = React.forwardRef<HTMLDivElement, PopoverContentProps>(
       context.updatePosition(side, align, sideOffset, alignOffset)
     }, [context, side, align, sideOffset, alignOffset])
 
-    // Determine portal container - prioritize passed container, then find positioned parent
+    // Determine portal container - always use document.body for portal
+    // The boundary prop handles positioning constraints, not the portal container
     const portalContainer = React.useMemo(() => {
       if (!portal) return null;
-      if (container) return container;
-      
-      // Find closest positioned ancestor (not static)
-      // Handle both Element and VirtualElement references
-      const referenceElement = context.refs.reference.current;
-      if (!referenceElement) return document.body;
-      
-      // Check if it's a real DOM element with parentElement
-      if ('parentElement' in referenceElement) {
-        let element = referenceElement.parentElement;
-        while (element) {
-          const position = window.getComputedStyle(element).position;
-          if (position !== 'static') {
-            return element;
-          }
-          element = element.parentElement;
-        }
-      }
-      
+      // Always use document.body - FloatingUI handles positioning with boundaries
       return document.body;
-    }, [portal, container, context.refs.reference]);
+    }, [portal]);
 
-    // Calculate position relative to container if not body
+    // Use FloatingUI's calculated position directly
     const enhancedStyle = React.useMemo(() => {
-      if (!portalContainer || portalContainer === document.body) {
-        return {
-          position: context.strategy,
-          top: context.y ?? 0,
-          left: context.x ?? 0,
-          ...style,
-        };
-      }
-      
-      // Calculate relative position within container
-      const containerRect = portalContainer.getBoundingClientRect();
       return {
-        position: 'absolute' as const,
-        top: (context.y ?? 0) - containerRect.top,
-        left: (context.x ?? 0) - containerRect.left,
+        position: context.strategy,
+        top: context.y ?? 0,
+        left: context.x ?? 0,
         ...style,
       };
-    }, [context, portalContainer, style]);
+    }, [context, style]);
 
-    if (!context.context.open) return null
+    // Defensive check: Don't render if we don't have valid positioning
+    // This prevents rendering at 0,0 when FloatingUI hasn't calculated position yet
+    if (!context.context.open) return null;
+    if (context.x === null || context.y === null) return null;
 
     const contentProps = {
       ref,


### PR DESCRIPTION
## Description
Fixes duplicate link popover issue where two popovers would appear when clicking the link button in the coaching notes editor - one correctly positioned under the toolbar button and another incorrectly positioned at coordinates 0,0
 in the upper-left corner.

The issue occurred in two scenarios:
1. When clicking the link button in either toolbar (static or floating)
2. After scrolling with long documents that trigger the floating toolbar

#### GitHub Issue: Fixes #188

### Changes
* Simplified popover portal positioning logic in `popover.tsx` to always use `document.body` and `fixed` positioning strategy
* Added `isVisible` prop to `SimpleToolbar` component to conditionally render `LinkPopover` based on toolbar visibility state
* Updated `coaching-notes.tsx` and `floating-toolbar.tsx` to pass visibility state to their respective `SimpleToolbar` instances
* Removed unused `container` prop from `PopoverContentProps` interface
* Added comprehensive component tests covering single popover rendering, positioning, multiple instances, and edge cases

### Screenshots / Videos Showing UI Changes (if applicable)

No longer does this:
<img width="2219" height="1405" alt="Screenshot 2025-10-15 at 10 49 48" src="https://github.com/user-attachments/assets/ce3ff7da-3a3f-440b-a208-16cae8745f27" />

### Testing Strategy
**Component Tests**: Run `npm test -- __tests__/components/ui/tiptap-ui/link-popover.test.tsx`
- 11 tests covering single popover rendering, positioning, multiple instances, link creation, state management, and edge cases

**Manual Testing**:
1. Navigate to any coaching session with notes editor
2. Click the link button in the static toolbar → verify single popover appears below button
3. Add enough content to make editor scrollable (30+ lines)
4. Scroll down to trigger floating toolbar
5. Click link button in floating toolbar → verify single popover appears, no duplicate at 0,0
6. Try rapid clicks on link button → verify no duplicate popovers appear

### Concerns
None - the solution addresses both root causes (portal positioning and conditional rendering) and includes comprehensive test coverage.