### PR TITLE
Only reset the current coaching relationship if the current organization changes

### DIFF
--- a/src/components/ui/coaching-relationship-selector.tsx
+++ b/src/components/ui/coaching-relationship-selector.tsx
@@ -12,7 +12,7 @@ import { Id } from "@/types/general";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 import { useAutoSelectSingleRelationship } from "@/lib/hooks/use-auto-select-single-relationship";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { cn } from "../lib/utils";
 
@@ -75,6 +75,8 @@ export default function CoachingRelationshipSelector({
     (state) => state
   );
 
+  const prevOrganizationIdRef = useRef<Id>(organizationId);
+
   const handleSetCoachingRelationship = (relationshipId: Id) => {
     setCurrentCoachingRelationshipId(relationshipId);
     if (onSelect) {
@@ -89,10 +91,11 @@ export default function CoachingRelationshipSelector({
   }, [currentCoachingRelationship, setIsCurrentCoach]);
 
   useEffect(() => {
-    if (organizationId && currentCoachingRelationshipId) {
+    if (organizationId && prevOrganizationIdRef.current && organizationId !== prevOrganizationIdRef.current) {
       setCurrentCoachingRelationshipId("");
     }
-  }, [organizationId]);
+    prevOrganizationIdRef.current = organizationId;
+  }, [organizationId, setCurrentCoachingRelationshipId]);
 
   // Auto-select relationship when user has exactly one and none is currently selected
   useAutoSelectSingleRelationship(


### PR DESCRIPTION
## Description
This PR is a small fix to my last one. Only reset the current coaching relationship if the current organization is changed.


#### GitHub Issue: None

### Changes
* Guard against unnecessary changes/updates to the current coaching relationship stored in the state store

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
1. Login and select an organization
2. Select a coaching relationship
3. Join a coaching session for this relationship
4. Navigate back to the dashboard page
5. Observe that the coaching relationship selector remains unchanged
6. Select a new organization
7. Notice that the coaching relationship selector updates and does not have a current relationship selected


### Concerns
None