### PR TITLE
Fix responsiveness issue with screen width resizing on dashboard and coaching session pages

### DIFF
--- a/src/app/coaching-sessions/[id]/layout.tsx
+++ b/src/app/coaching-sessions/[id]/layout.tsx
@@ -18,11 +18,11 @@ export default function CoachingSessionLayout({
 }>) {
   return (
     <SidebarProvider>
-      <div className="flex min-h-screen min-w-full">
+      <div className="flex min-h-screen w-full">
         <AppSidebar />
-        <SidebarInset>
+        <SidebarInset className="min-w-0">
           <SiteHeader />
-          <main>{children}</main>
+          <main className="min-w-0">{children}</main>
         </SidebarInset>
       </div>
     </SidebarProvider>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -19,11 +19,11 @@ export default function DashboardLayout({
 }>) {
   return (
     <SidebarProvider>
-      <div className="flex min-h-screen min-w-full">
+      <div className="flex min-h-screen w-full">
         <AppSidebar />
-        <SidebarInset>
+        <SidebarInset className="min-w-0">
           <SiteHeader />
-          <main className="flex-1 p-6">{children}</main>
+          <main className="flex-1 p-6 min-w-0">{children}</main>
           <Toaster />
         </SidebarInset>
       </div>

--- a/src/components/ui/page-container.tsx
+++ b/src/components/ui/page-container.tsx
@@ -14,9 +14,9 @@ export function PageContainer({
         "p-4",
         // Mobile: stack vertically
         "flex flex-col gap-6",
-        // Never grow wider than the site-header
-        "max-w-screen-2xl",
-        // Ensure full width for children
+        // Constrain width to a reasonable maximum while allowing flexibility
+        "w-full max-w-screen-2xl mx-auto",
+        // Ensure children respect the container width
         "[&>*]:w-full"
       )}
     >

--- a/src/components/ui/site-header.tsx
+++ b/src/components/ui/site-header.tsx
@@ -7,8 +7,8 @@ import { UserNav } from "@/components/ui/user-nav";
 
 export function SiteHeader() {
   return (
-    <header className="sticky top-0 z-50 w-full max-w-screen-2xl border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="flex h-14 pl-4 pt-2 max-w-screen-2xl items-start">
+    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+      <div className="flex h-14 pl-4 pt-2 w-full max-w-screen-2xl mx-auto items-start">
         <MainNav />
         <div className="flex flex-1 items-center justify-between space-x-2 md:justify-end">
           {/* <div className="w-full flex-1 md:w-auto md:flex-none">


### PR DESCRIPTION
## Description
Fixes responsive layout issue where dashboard and coaching session pages didn't properly resize content at certain viewport widths (800-1200px range). Content was being cut off due to conflicting flex width constraints.

#### GitHub Issue: None

### Changes
* Changed `min-w-full` to `w-full` in layout containers for proper flex behavior
* Added `min-w-0` to `SidebarInset` and `main` elements to enable flex shrinking
* Updated `PageContainer` and `SiteHeader` to center content with `mx-auto`
* Applied fixes consistently across dashboard and coaching session layouts

### Screenshots / Videos Showing UI Changes (if applicable)

N/A

### Testing Strategy

1. Run `npm run dev` and navigate to `/dashboard`
2. Resize browser window from 800px to 1400px width
3. Verify content adapts smoothly without truncation
4. Test on coaching session page
5. Test sidebar collapse/expand at different widths

These scenarios should no longer happen on either page:

<img width="1311" height="1018" alt="Screenshot 2025-11-12 at 09 50 20" src="https://github.com/user-attachments/assets/0cfa0901-ee46-40c3-bf4b-5b18b17cf7db" />

<img width="1227" height="1410" alt="Screenshot 2025-11-12 at 14 08 50" src="https://github.com/user-attachments/assets/56c7a685-1d8e-490d-afec-815263cb2b23" />


Build verification: `npm run typecheck` and `npm run build` both pass ✅

### Concerns

None. Changes use standard Tailwind utilities and don't modify component APIs.