### PR TITLE
Fix organization settings sidebar collapse behavior

### DIFF
--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -30,7 +30,8 @@ import {
   SidebarRail,
   SidebarSeparator,
 } from "@/components/ui/sidebar";
-import { SidebarCollapsible } from "@/types/sidebar";
+import { SidebarCollapsible, SidebarState, StateChangeSource } from "@/types/sidebar";
+import { useSidebar } from "@/lib/hooks/use-sidebar";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentUserRole } from "@/lib/hooks/use-current-user-role";
 import { isAdminOrSuperAdmin } from "@/types/user";
@@ -50,6 +51,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const router = useRouter();
   const pathname = usePathname();
   const [isAdminMenuOpen, setIsAdminMenuOpen] = useState(false);
+  const { state: sidebarState, expand, isMobile } = useSidebar();
 
   const handleOrgChange = (newOrgId: Id) => {
     // Check if current path is organization-scoped
@@ -123,7 +125,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     <span className={menuButtonStyles.iconWrapper}>
                       <Home className="h-4 w-4" />
                     </span>
-                    <span>Dashboard</span>
+                    <span className="group-data-[collapsible=icon]:hidden">Dashboard</span>
                   </Link>
                 </SidebarMenuButton>
               </SidebarMenuItem>
@@ -148,7 +150,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <span className={menuButtonStyles.iconWrapper}>
                     <Gift className="h-4 w-4" />
                   </span>
-                  <span>Referrals</span>
+                  <span className="group-data-[collapsible=icon]:hidden">Referrals</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
@@ -166,12 +168,21 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                         menuButtonStyles.button,
                         menuButtonStyles.buttonCollapsed
                       )}
+                      onClick={(e) => {
+                        if (!isMobile && sidebarState === SidebarState.Collapsed) {
+                          e.preventDefault();
+                          expand(StateChangeSource.UserAction);
+                          setIsAdminMenuOpen(true);
+                        }
+                      }}
                     >
                       <span className={menuButtonStyles.iconWrapper}>
                         <Settings className="h-4 w-4" />
                       </span>
-                      <span>Organization settings</span>
-                      <ChevronRight className="ml-auto h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                      <span className="group-data-[collapsible=icon]:hidden">
+                        Organization settings
+                      </span>
+                      <ChevronRight className="ml-auto h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90 group-data-[collapsible=icon]:hidden" />
                     </SidebarMenuButton>
                   </CollapsibleTrigger>
                   <CollapsibleContent>
@@ -210,7 +221,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                   <span className={menuButtonStyles.iconWrapper}>
                     <BarChart3 className="h-4 w-4" />
                   </span>
-                  <span>System status</span>
+                  <span className="group-data-[collapsible=icon]:hidden">System status</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>


### PR DESCRIPTION
## Description
Fix the Organization settings sidebar item to properly collapse to icon-only mode and provide access to the Members sub-item when collapsed.

### Changes
* Hide text labels and chevron icon in collapsed mode using `group-data-[collapsible=icon]:hidden`
* Add click handler to expand sidebar and open menu when clicking gear icon in collapsed mode
* Apply consistent text hiding to all menu items (Dashboard, Referrals, System status) for proper icon alignment

### Screenshots / Videos Showing UI Changes (if applicable)

<img width="727" height="1098" alt="Screenshot 2025-12-17 at 09 56 27" src="https://github.com/user-attachments/assets/1e048bfc-b4e4-4a9b-b2ca-a442cee0d824" />

<img width="459" height="1096" alt="Screenshot 2025-12-17 at 09 56 42" src="https://github.com/user-attachments/assets/1c873f77-ec11-4bb0-a335-528bd486fda9" />


### Testing Strategy
1. Collapse the sidebar using the toggle
2. Verify all icons (Home, Gift, Settings, Bar chart) are centered consistently
3. Click the gear icon - sidebar should expand AND Organization settings menu should open
4. Verify Members link is visible and navigates correctly
5. Test on mobile viewport to ensure drawer behavior is unchanged

### Concerns
None - this is a straightforward UX fix with no breaking changes.