### PR TITLE
Replace Today filter with Last Month in Browse Sessions

### DIFF
--- a/__tests__/components/ui/join-session-popover.test.tsx
+++ b/__tests__/components/ui/join-session-popover.test.tsx
@@ -354,9 +354,9 @@ describe("JoinSessionPopover", () => {
       const thisWeekBtn = screen.getByRole("button", { name: "This Week" });
 
       // "This Month" should have the default (filled) variant, others should have outline
-      expect(thisMonthBtn.className).not.toMatch(/border/);
-      expect(lastMonthBtn.className).toMatch(/border/);
-      expect(thisWeekBtn.className).toMatch(/border/);
+      expect(thisMonthBtn.className).toMatch(/bg-primary/);
+      expect(lastMonthBtn.className).toMatch(/border-input/);
+      expect(thisWeekBtn.className).toMatch(/border-input/);
     });
 
     it("fetches sessions for current month by default", () => {
@@ -420,15 +420,15 @@ describe("JoinSessionPopover", () => {
 
       // Click "This Week" — it should become active, others outlined
       fireEvent.click(thisWeekBtn);
-      expect(thisWeekBtn.className).not.toMatch(/border/);
-      expect(lastMonthBtn.className).toMatch(/border/);
-      expect(thisMonthBtn.className).toMatch(/border/);
+      expect(thisWeekBtn.className).toMatch(/bg-primary/);
+      expect(lastMonthBtn.className).toMatch(/border-input/);
+      expect(thisMonthBtn.className).toMatch(/border-input/);
 
       // Click "Last Month" — it should become active
       fireEvent.click(lastMonthBtn);
-      expect(lastMonthBtn.className).not.toMatch(/border/);
-      expect(thisWeekBtn.className).toMatch(/border/);
-      expect(thisMonthBtn.className).toMatch(/border/);
+      expect(lastMonthBtn.className).toMatch(/bg-primary/);
+      expect(thisWeekBtn.className).toMatch(/border-input/);
+      expect(thisMonthBtn.className).toMatch(/border-input/);
     });
   });
 

--- a/src/components/ui/join-session-popover.tsx
+++ b/src/components/ui/join-session-popover.tsx
@@ -158,8 +158,10 @@ type DateFilter = "last_month" | "week" | "month";
 function getDateRange(filter: DateFilter): { from: DateTime; to: DateTime } {
   const now = DateTime.now();
   switch (filter) {
-    case "last_month":
-      return { from: now.minus({ months: 1 }).startOf("month"), to: now.minus({ months: 1 }).endOf("month") };
+    case "last_month": {
+      const lastMonth = now.minus({ months: 1 });
+      return { from: lastMonth.startOf("month"), to: lastMonth.endOf("month") };
+    }
     case "week":
       return { from: now.startOf("week"), to: now.endOf("week") };
     case "month":


### PR DESCRIPTION
## Description
Replace the redundant "Today" date filter button with "Last Month" in the Browse Sessions section of the Join Session popover. "This Week" already covers today's sessions, making the "Today" button unnecessary. Also remove the automatic relationship fallback from the Browse Sessions dropdown so the user must explicitly pick a person, avoiding visual confusion between the two sections.

### Changes
* Replace `"today"` DateFilter value with `"last_month"` and compute the previous calendar month range
* Update button label from "Today" to "Last Month"
* Remove global `currentCoachingRelationshipId` fallback from the Browse Sessions dropdown — it now starts at "Select a coachee..." until the user picks someone
* Keep the Select controlled with `value ?? ""` to avoid uncontrolled-to-controlled warnings
* Add 6 new tests covering all three date filter buttons (rendering, default state, date range correctness, and visual toggle behavior)

### Screenshots / Videos Showing UI Changes (if applicable)

<img width="586" height="346" alt="Screenshot 2026-02-09 at 09 50 17" src="https://github.com/user-attachments/assets/32b81295-d998-409a-86d8-ea150db8a4a1" />

<img width="554" height="432" alt="Screenshot 2026-02-09 at 09 51 41" src="https://github.com/user-attachments/assets/117a1fa0-fab6-48fb-82b5-e613022e7236" />


### Testing Strategy
* All 434 tests pass, including 6 new tests in the `"Browse Sessions date filter buttons"` describe block
* New tests verify: button rendering, default active state, correct date ranges passed to the API hook for each filter, and visual toggle behavior
* Tests use realistic user interaction (clicking through the Select UI) rather than mocking internal state

### Concerns
None