### PR TITLE
Rename Today's Sessions to Upcoming Sessions in join popover

### DIFF
--- a/__tests__/components/ui/join-session-popover.test.tsx
+++ b/__tests__/components/ui/join-session-popover.test.tsx
@@ -148,7 +148,7 @@ describe("JoinSessionPopover", () => {
 
     fireEvent.click(screen.getByText("Join Session"));
 
-    expect(screen.getByText("Today's Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming Sessions")).toBeInTheDocument();
     expect(screen.getByText("Browse Sessions")).toBeInTheDocument();
   });
 
@@ -162,7 +162,7 @@ describe("JoinSessionPopover", () => {
     fireEvent.click(screen.getByText("Join Session"));
 
     expect(
-      screen.getByText("No sessions scheduled for today")
+      screen.getByText("No upcoming sessions")
     ).toBeInTheDocument();
   });
 

--- a/src/components/ui/join-session-popover.tsx
+++ b/src/components/ui/join-session-popover.tsx
@@ -94,7 +94,7 @@ function TodaysSessionsList({
   if (sessions.length === 0) {
     return (
       <p className="px-2 py-3 text-sm text-muted-foreground">
-        No sessions scheduled for today
+        No upcoming sessions
       </p>
     );
   }
@@ -430,10 +430,10 @@ export function JoinSessionPopover() {
           }
         }}
       >
-        {/* Section 1: Today's Sessions */}
+        {/* Section 1: Upcoming Sessions */}
         <div className="p-3">
           <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
-            Today&apos;s Sessions
+            Upcoming Sessions
           </p>
           <TodaysSessionsList
             sessions={sessions}


### PR DESCRIPTION
## Description
Rename the "Today's Sessions" section title in the Join Session popover to "Upcoming Sessions" since the sessions shown are within a 24-hour sliding window, not strictly today.

### Changes
* Renamed section title from "Today's Sessions" to "Upcoming Sessions"
* Updated empty state message from "No sessions scheduled for today" to "No upcoming sessions"
* Updated tests to match new wording

### Screenshots / Videos Showing UI Changes (if applicable)
Screenshot of the Join Session popover showing the updated "Upcoming Sessions" title would be helpful.

### Testing Strategy
* Open the Join Session popover and verify the title reads "Upcoming Sessions"
* With no sessions in the window, verify empty state reads "No upcoming sessions"
* All 434 existing tests pass