### PR TITLE
Add sync timeout to prevent coaching notes loading indefinitely

### DIFF
--- a/__tests__/components/ui/coaching-sessions/coaching-notes/connection-status.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/coaching-notes/connection-status.test.tsx
@@ -226,6 +226,7 @@ describe('ConnectionStatus', () => {
       expect(badge).toBeInTheDocument()
       expect(badge).toHaveClass('bg-destructive') // Destructive variant for error state
     })
+
   })
 
   describe('Connection Transitions', () => {

--- a/__tests__/components/ui/coaching-sessions/editor-cache-context.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/editor-cache-context.test.tsx
@@ -46,29 +46,37 @@ vi.mock('@/components/ui/coaching-sessions/coaching-notes/extensions', () => ({
   ])
 }))
 
-// Simple TipTap mock
+// Controllable TipTap mock: captures event handlers so tests can trigger events manually
 vi.mock('@hocuspocus/provider', () => ({
   TiptapCollabProvider: vi.fn(function() {
+    const eventHandlers = new Map<string, Function[]>()
     const provider = {
-      on: vi.fn((event, callback) => {
-        // Auto-trigger sync for simple testing
-        if (event === 'synced') {
-          setTimeout(() => callback(), 10)
-        }
-        // Handle awarenessChange event
-        if (event === 'awarenessChange') {
-          setTimeout(() => callback({ states: new Map() }), 10)
-        }
+      status: 'connecting',
+      on: vi.fn((event: string, callback: Function) => {
+        const handlers = eventHandlers.get(event) || []
+        handlers.push(callback)
+        eventHandlers.set(event, handlers)
         return provider
       }),
       off: vi.fn(),
       setAwarenessField: vi.fn(),
       destroy: vi.fn(),
       disconnect: vi.fn(),
-      connect: vi.fn()
+      connect: vi.fn(),
+      // Test helper: trigger a registered event for all handlers
+      _triggerEvent: (event: string, ...args: any[]) => {
+        const handlers = eventHandlers.get(event) || []
+        handlers.forEach(handler => handler(...args))
+      },
+      _eventHandlers: eventHandlers,
     }
     return provider
-  })
+  }),
+  WebSocketStatus: {
+    Connecting: 'connecting',
+    Connected: 'connected',
+    Disconnected: 'disconnected',
+  },
 }))
 
 vi.mock('yjs', () => ({
@@ -77,35 +85,48 @@ vi.mock('yjs', () => ({
 
 import { useCollaborationToken } from '@/lib/api/collaboration-token'
 import { useAuthStore } from '@/lib/providers/auth-store-provider'
+import { ConnectionStatus } from '@/components/ui/coaching-sessions/coaching-notes/connection-status'
 
 // Test component
 const TestConsumer = ({ onCacheReady }: { onCacheReady?: (cache: any) => void } = {}) => {
   const cache = useEditorCache()
-  
+
   React.useEffect(() => {
     if (onCacheReady) {
       onCacheReady(cache)
     }
   }, [cache, onCacheReady])
-  
+
   return (
     <div>
       <div data-testid="has-provider">{cache.collaborationProvider ? 'yes' : 'no'}</div>
       <div data-testid="is-ready">{cache.isReady ? 'yes' : 'no'}</div>
+      <div data-testid="has-extensions">{cache.extensions.length > 0 ? 'yes' : 'no'}</div>
+      <div data-testid="is-loading">{cache.isLoading ? 'yes' : 'no'}</div>
     </div>
   )
+}
+
+/** Helper: trigger synced on the provider and wait for the editor to become ready */
+const triggerSyncedAndWaitForReady = async (mockProvider: any) => {
+  act(() => {
+    mockProvider._triggerEvent('synced')
+  })
+  await waitFor(() => {
+    expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
+  })
 }
 
 describe('EditorCacheProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    
+
     // Default happy path mocks
     vi.mocked(useAuthStore).mockReturnValue({
       userSession: { display_name: 'Test User', id: 'user-1' },
       isLoggedIn: true
     })
-    
+
     vi.mocked(useCollaborationToken).mockReturnValue({
       jwt: { sub: 'test-doc', token: 'test-token' },
       isLoading: false,
@@ -116,6 +137,13 @@ describe('EditorCacheProvider', () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
+
+  /** Helper: get the most recently created mock provider instance */
+  const getLatestMockProvider = async () => {
+    const { TiptapCollabProvider } = await import('@hocuspocus/provider')
+    const results = vi.mocked(TiptapCollabProvider).mock.results
+    return results[results.length - 1]?.value
+  }
 
   it('should provide context without errors', () => {
     render(
@@ -183,10 +211,9 @@ describe('EditorCacheProvider', () => {
       </EditorCacheProvider>
     )
 
-    // Wait for provider to potentially be created and ready state reached
-    await waitFor(() => {
-      expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-    }, { timeout: 3000 })
+    // Trigger synced to reach ready state
+    const mockProvider = await getLatestMockProvider()
+    await triggerSyncedAndWaitForReady(mockProvider)
 
     // Simulate logout cleanup by calling the resetCache function directly
     // This is the same operation that would be triggered by the logout cleanup registry
@@ -215,12 +242,11 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-      })
-
-      // Get the mock instance and clear previous calls
+      // Trigger synced to reach ready state
       const mockProvider = vi.mocked(TiptapCollabProvider).mock.results[0]?.value
+      await triggerSyncedAndWaitForReady(mockProvider)
+
+      // Clear previous calls
       vi.clearAllMocks()
 
       // Re-render the same component (simulates user clicking in editor)
@@ -249,11 +275,9 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-      })
-
+      // Trigger synced for first provider
       const oldProvider = vi.mocked(TiptapCollabProvider).mock.results[0]?.value
+      await triggerSyncedAndWaitForReady(oldProvider)
 
       // Change session ID
       rerender(
@@ -273,32 +297,9 @@ describe('EditorCacheProvider', () => {
   })
 
   describe('Extension Creation', () => {
-    it('should create extensions only once even if synced event fires multiple times', async () => {
+    it('should create extensions when sync completes', async () => {
       const { Extensions } = await import('@/components/ui/coaching-sessions/coaching-notes/extensions')
-
-      // Clear any previous calls to Extensions from other tests
       vi.mocked(Extensions).mockClear()
-
-      // Create a mock provider that we can control
-      const { TiptapCollabProvider } = await import('@hocuspocus/provider')
-      let syncedCallback: (() => void) | undefined
-
-      vi.mocked(TiptapCollabProvider).mockImplementationOnce(function() {
-        const provider = {
-          on: vi.fn((event, callback) => {
-            if (event === 'synced') {
-              syncedCallback = callback
-            }
-            return provider
-          }),
-          off: vi.fn(),
-          setAwarenessField: vi.fn(),
-          destroy: vi.fn(),
-          disconnect: vi.fn(),
-          connect: vi.fn()
-        }
-        return provider as any
-      })
 
       render(
         <EditorCacheProvider sessionId="test-session">
@@ -306,19 +307,131 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      // Wait for provider initialization
-      await waitFor(() => {
-        expect(syncedCallback).toBeDefined()
-      })
+      // Before sync: no extensions yet
+      expect(screen.getByTestId('has-extensions')).toHaveTextContent('no')
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('no')
+
+      // Trigger synced
+      const mockProvider = await getLatestMockProvider()
+      await triggerSyncedAndWaitForReady(mockProvider)
+
+      // Now extensions should exist
+      expect(screen.getByTestId('has-extensions')).toHaveTextContent('yes')
+      expect(Extensions).toHaveBeenCalledTimes(1)
+    })
+
+    it('should create extensions only once even if synced event fires multiple times', async () => {
+      const { Extensions } = await import('@/components/ui/coaching-sessions/coaching-notes/extensions')
+      vi.mocked(Extensions).mockClear()
+
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <TestConsumer />
+        </EditorCacheProvider>
+      )
+
+      const mockProvider = await getLatestMockProvider()
 
       // Trigger synced event multiple times
       act(() => {
-        syncedCallback!()
-        syncedCallback!()
-        syncedCallback!()
+        mockProvider._triggerEvent('synced')
+        mockProvider._triggerEvent('synced')
+        mockProvider._triggerEvent('synced')
       })
 
       // Extensions should only be created once
+      expect(Extensions).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Sync Timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should enable offline editing after SYNC_TIMEOUT_MS when sync does not complete', async () => {
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <TestConsumer />
+        </EditorCacheProvider>
+      )
+
+      // Before timeout: not ready, no extensions
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('no')
+      expect(screen.getByTestId('has-extensions')).toHaveTextContent('no')
+
+      // Advance past the sync timeout (10 seconds)
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+      })
+
+      // isReady should now be true with extensions (offline editing enabled)
+      await waitFor(() => {
+        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
+        expect(screen.getByTestId('has-extensions')).toHaveTextContent('yes')
+      })
+    })
+
+    it('should clear sync timeout when sync completes normally', async () => {
+      const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <TestConsumer />
+        </EditorCacheProvider>
+      )
+
+      const callCountBefore = clearTimeoutSpy.mock.calls.length
+
+      // Trigger synced before timeout fires
+      const mockProvider = await getLatestMockProvider()
+      act(() => {
+        mockProvider._triggerEvent('synced')
+      })
+
+      // clearTimeout should have been called by the synced handler
+      expect(clearTimeoutSpy.mock.calls.length).toBeGreaterThan(callCountBefore)
+
+      // isReady should be true
+      await waitFor(() => {
+        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
+      })
+
+      clearTimeoutSpy.mockRestore()
+    })
+
+    it('should not cause errors when sync fires after timeout (idempotent)', async () => {
+      const { Extensions } = await import('@/components/ui/coaching-sessions/coaching-notes/extensions')
+      vi.mocked(Extensions).mockClear()
+
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <TestConsumer />
+        </EditorCacheProvider>
+      )
+
+      // Let the timeout fire first
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
+      })
+
+      // Now trigger a late synced event — should be harmless
+      const mockProvider = await getLatestMockProvider()
+      act(() => {
+        mockProvider._triggerEvent('synced')
+      })
+
+      // Should still be ready, no errors, extensions created only once
+      expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
+      expect(screen.getByTestId('has-provider')).toHaveTextContent('yes')
       expect(Extensions).toHaveBeenCalledTimes(1)
     })
   })
@@ -333,11 +446,9 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-      })
-
+      // Trigger synced to reach ready state
       const mockProvider = vi.mocked(TiptapCollabProvider).mock.results[0]?.value
+      await triggerSyncedAndWaitForReady(mockProvider)
 
       // Should have called setAwarenessField with presence data
       expect(mockProvider?.setAwarenessField).toHaveBeenCalledWith(
@@ -351,26 +462,6 @@ describe('EditorCacheProvider', () => {
     })
 
     it('should update presence state when awarenessChange event fires', async () => {
-      const { TiptapCollabProvider } = await import('@hocuspocus/provider')
-      let awarenessCallback: ((data: any) => void) | undefined
-
-      vi.mocked(TiptapCollabProvider).mockImplementationOnce(function() {
-        const provider = {
-          on: vi.fn((event, callback) => {
-            if (event === 'awarenessChange') {
-              awarenessCallback = callback
-            }
-            return provider
-          }),
-          off: vi.fn(),
-          setAwarenessField: vi.fn(),
-          destroy: vi.fn(),
-          disconnect: vi.fn(),
-          connect: vi.fn()
-        }
-        return provider as any
-      })
-
       let cacheRef: any = null
 
       render(
@@ -379,13 +470,11 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(awarenessCallback).toBeDefined()
-      })
+      const mockProvider = await getLatestMockProvider()
 
       // Simulate awareness change with user data
       act(() => {
-        awarenessCallback!({
+        mockProvider._triggerEvent('awarenessChange', {
           states: [
             {
               clientId: 1,
@@ -420,42 +509,18 @@ describe('EditorCacheProvider', () => {
     })
 
     it('should NOT call setAwarenessField on disconnect event (already offline)', async () => {
-      const { TiptapCollabProvider } = await import('@hocuspocus/provider')
-      let disconnectCallback: (() => void) | undefined
-
-      vi.mocked(TiptapCollabProvider).mockImplementationOnce(function() {
-        const provider = {
-          on: vi.fn((event, callback) => {
-            if (event === 'disconnect') {
-              disconnectCallback = callback
-            }
-            return provider
-          }),
-          off: vi.fn(),
-          setAwarenessField: vi.fn(),
-          destroy: vi.fn(),
-          disconnect: vi.fn(),
-          connect: vi.fn()
-        }
-        return provider as any
-      })
-
       render(
         <EditorCacheProvider sessionId="test-session">
           <TestConsumer />
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(disconnectCallback).toBeDefined()
-      })
-
-      const mockProvider = vi.mocked(TiptapCollabProvider).mock.results[0]?.value
+      const mockProvider = await getLatestMockProvider()
       vi.clearAllMocks()
 
       // Trigger disconnect event
       act(() => {
-        disconnectCallback!()
+        mockProvider._triggerEvent('disconnect')
       })
 
       // Should NOT call setAwarenessField because we're already disconnected
@@ -464,26 +529,6 @@ describe('EditorCacheProvider', () => {
     })
 
     it('should mark users as disconnected when they disappear from awareness states', async () => {
-      const { TiptapCollabProvider } = await import('@hocuspocus/provider')
-      let awarenessCallback: ((data: any) => void) | undefined
-
-      vi.mocked(TiptapCollabProvider).mockImplementationOnce(function() {
-        const provider = {
-          on: vi.fn((event, callback) => {
-            if (event === 'awarenessChange') {
-              awarenessCallback = callback
-            }
-            return provider
-          }),
-          off: vi.fn(),
-          setAwarenessField: vi.fn(),
-          destroy: vi.fn(),
-          disconnect: vi.fn(),
-          connect: vi.fn()
-        }
-        return provider as any
-      })
-
       let cacheRef: any = null
 
       render(
@@ -492,13 +537,11 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        expect(awarenessCallback).toBeDefined()
-      })
+      const mockProvider = await getLatestMockProvider()
 
       // First, simulate both users being connected
       act(() => {
-        awarenessCallback!({
+        mockProvider._triggerEvent('awarenessChange', {
           states: [
             {
               clientId: 1,
@@ -530,7 +573,7 @@ describe('EditorCacheProvider', () => {
 
       // Now simulate user-2 disappearing (network disconnect)
       act(() => {
-        awarenessCallback!({
+        mockProvider._triggerEvent('awarenessChange', {
           states: [
             {
               clientId: 1,
@@ -570,10 +613,9 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      // Wait for provider to be ready (simulates: user on Notes tab, editor working)
-      await waitFor(() => {
-        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-      })
+      // Trigger synced to reach ready state
+      const mockProvider = await getLatestMockProvider()
+      await triggerSyncedAndWaitForReady(mockProvider)
 
       // Provider should be connected, no error
       expect(screen.getByTestId('has-provider')).toHaveTextContent('yes')
@@ -730,11 +772,94 @@ describe('EditorCacheProvider', () => {
         </EditorCacheProvider>
       )
 
-      await waitFor(() => {
-        // Should now be ready
-        expect(screen.getByTestId('is-ready')).toHaveTextContent('yes')
-        expect(cacheRef?.error).toBeNull()
+      // Trigger synced to reach ready state
+      const mockProvider = await getLatestMockProvider()
+      await triggerSyncedAndWaitForReady(mockProvider)
+
+      // Should now be ready with extensions
+      expect(screen.getByTestId('has-extensions')).toHaveTextContent('yes')
+      expect(cacheRef?.error).toBeNull()
+    })
+  })
+
+  describe('Integration: Sync Timeout with ConnectionStatus', () => {
+    /**
+     * Mirrors CoachingNotes' rendering logic:
+     * - Shows loading skeleton when isLoading or extensions are empty
+     * - Shows editor area with ConnectionStatus when extensions are ready
+     */
+    const CoachingNotesSimulator = () => {
+      const { isLoading, extensions } = useEditorCache()
+
+      if (isLoading || extensions.length === 0) {
+        return <div data-testid="loading-skeleton">Loading coaching notes...</div>
+      }
+
+      return (
+        <div data-testid="editor-area">
+          <ConnectionStatus />
+        </div>
+      )
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should transition from loading skeleton to editor with Offline badge on sync timeout', async () => {
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <CoachingNotesSimulator />
+        </EditorCacheProvider>
+      )
+
+      // Should show loading skeleton initially (provider created but sync pending)
+      expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument()
+      expect(screen.queryByTestId('editor-area')).not.toBeInTheDocument()
+
+      // Advance past the sync timeout (10 seconds) — sync never completes
+      await act(async () => {
+        vi.advanceTimersByTime(10_000)
       })
+
+      // Loading skeleton should be gone, editor area should be visible
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-skeleton')).not.toBeInTheDocument()
+        expect(screen.getByTestId('editor-area')).toBeInTheDocument()
+      })
+
+      // ConnectionStatus badge should show "Offline" (provider exists but never synced)
+      expect(screen.getByText('Offline')).toBeInTheDocument()
+    })
+
+    it('should transition from loading skeleton to editor with Connected badge on normal sync', async () => {
+      render(
+        <EditorCacheProvider sessionId="test-session">
+          <CoachingNotesSimulator />
+        </EditorCacheProvider>
+      )
+
+      // Should show loading skeleton initially
+      expect(screen.getByTestId('loading-skeleton')).toBeInTheDocument()
+
+      // Trigger successful sync
+      const mockProvider = await getLatestMockProvider()
+      mockProvider.status = 'connected'
+      act(() => {
+        mockProvider._triggerEvent('synced')
+      })
+
+      // Editor area should appear with Connected badge
+      await waitFor(() => {
+        expect(screen.queryByTestId('loading-skeleton')).not.toBeInTheDocument()
+        expect(screen.getByTestId('editor-area')).toBeInTheDocument()
+      })
+
+      expect(screen.getByText('Connected')).toBeInTheDocument()
     })
   })
 })

--- a/docs/implementation-plans/tiptap-sync-timeout.md
+++ b/docs/implementation-plans/tiptap-sync-timeout.md
@@ -1,0 +1,138 @@
+# Implementation: TipTap Sync Timeout — Fix Stuck Coaching Notes Loading
+
+**Date**: 2026-02-09
+**Branch**: `improve-coaching-notes-loading-timeout`
+
+## Problem
+
+When navigating to a coaching session page in production, the coaching notes editor sometimes gets stuck showing a loading spinner (skeleton toolbar + "Loading coaching notes...") indefinitely. The root cause: `EditorCacheProvider.initializeProvider()` waits for the TipTap Cloud WebSocket `"synced"` event before creating editor extensions and mounting the editor. If `"synced"` never fires (transient TipTap Cloud issue, slow network), the editor stays in loading state forever with no timeout or fallback. A manual browser refresh fixes it (the retry succeeds).
+
+This only occurs in production because TipTap Cloud latency/reliability differs from local dev.
+
+## Solution
+
+Add a 10-second sync timeout to `initializeProvider()`. The `TiptapCollabProvider` is created immediately (starting the WebSocket connection and sync), but extensions are created and the editor is mounted only when **either**:
+
+1. The `"synced"` event fires (normal path, typically < 1s), or
+2. The 10-second timeout expires (fallback to offline editing)
+
+Both paths call the same `enableEditing()` helper, guarded by an `extensionsCreated` flag to prevent duplicate creation. In the timeout path, the provider keeps retrying sync in the background; if sync eventually succeeds, Y.js CRDT merges any local edits with server content seamlessly.
+
+## State Transitions
+
+| Phase | `isLoading` | `extensions` | `isReady` | `provider` | UI |
+|---|---|---|---|---|---|
+| Token fetch | `true` | `[]` | `false` | `null` | Skeleton + spinner |
+| Provider created, syncing | `true` | `[]` | `false` | exists | Skeleton + spinner |
+| Sync completes | `false` | populated | `true` | exists | Editor (editable) + "Connected" |
+| Timeout (no sync) | `false` | populated | `true` | exists | Editor (editable) + "Offline" |
+| Late sync after timeout | `false` | populated | `true` | exists | Content merges via CRDT + "Connected" |
+| Token error | `false` | `[]` | `false` | `null` | Error state with retry |
+
+## Files Modified
+
+### 1. `src/components/ui/coaching-sessions/editor-cache-context.tsx` (primary)
+
+- Added `SYNC_TIMEOUT_MS = 10_000` constant
+- Added `syncTimeoutRef` ref alongside existing refs
+- Restructured `initializeProvider()`:
+  - Provider created immediately (unchanged)
+  - Awareness set (unchanged)
+  - `enableEditing()` helper creates extensions and updates cache with `isReady: true`
+  - `extensionsCreated` flag prevents duplicate extension creation
+  - `"synced"` handler: clears timeout, calls `enableEditing()`
+  - Timeout handler: warns to console, calls `enableEditing()`
+- Added timeout cleanup (`clearTimeout`) in all 6 cleanup paths:
+  - `ActionKind.Cleanup` case in lifecycle effect
+  - Lifecycle effect cleanup return function
+  - Unmount cleanup effect
+  - Logout cleanup callback
+  - `resetCache` function
+  - `catch` block in `initializeProvider`
+
+### 2. `src/components/ui/tiptap-ui/link-popover/link-button.tsx`
+
+- Added `!editor.isEditable` guard to `LinkButton` for consistency with all other toolbar buttons (MarkButton, HeadingDropdownMenu, UndoRedoButton, etc.)
+
+### 3. `__tests__/components/ui/coaching-sessions/editor-cache-context.test.tsx`
+
+- Rewrote mock provider: changed from auto-triggering `"synced"` after 10ms to controllable `_triggerEvent` helper
+- Tests manually trigger synced via `mockProvider._triggerEvent('synced')`
+- Added `has-extensions` and `is-loading` test data attributes to TestConsumer
+- New tests: extensions created on sync, sync timeout enables offline editing, timeout cleared on normal sync, late sync after timeout is idempotent
+- Sync timeout tests use `vi.useFakeTimers({ shouldAdvanceTime: true })`
+
+### 4. `__tests__/components/ui/coaching-sessions/coaching-notes/connection-status.test.tsx`
+
+- Removed test for intermediate "Connecting..." state (no longer exists in the final approach)
+
+### Files NOT Modified
+
+- `src/components/ui/coaching-sessions/coaching-notes.tsx` — existing loading gate `if (isLoading || extensions.length === 0)` works correctly
+- `src/components/ui/coaching-sessions/coaching-notes/extensions.tsx` — no changes needed
+- `src/components/ui/coaching-sessions/coaching-notes/connection-status.tsx` — no changes needed
+
+## Approaches That Did Not Work
+
+### Approach 1: Mount editor before sync with `isReady: false`
+
+**Idea**: Create extensions immediately after provider construction (before `"synced"`), mount the editor in read-only mode (`editable: () => isReady` with `isReady = false`), then flip `isReady = true` on sync/timeout.
+
+**Why it failed**: TipTap's `EditorProvider` captures `editorProps.editable` at editor creation time only — it does NOT re-apply the function on React re-renders. The closure over `isReady = false` was permanently baked in, so the editor stayed read-only even after `isReady` became `true`. All toolbar buttons check `editor.isEditable` and return `null` when false, resulting in only the link button being visible (it was the only one missing the `isEditable` check).
+
+### Approach 2: `EditableSync` component calling `editor.setEditable()`
+
+**Idea**: Add a child component inside `EditorProvider` that uses `useCurrentEditor()` and calls `editor.setEditable(isReady)` in a `useEffect` when `isReady` changes.
+
+**Why it failed**: `editor.setEditable()` dispatches a TipTap transaction. However, `shouldRerenderOnTransaction={false}` on the `EditorProvider` (needed for performance) prevents React re-renders from transactions. So: the initial render happens with `editor.isEditable = false` -> all toolbar buttons return `null` -> the `useEffect` runs `setEditable(true)` -> no React re-render triggered -> toolbar stays permanently empty with no buttons and no `ConnectionStatus` badge.
+
+## Testing Guide
+
+### Automated Tests
+
+```bash
+# Run editor cache context tests (includes sync timeout tests)
+npx vitest run __tests__/components/ui/coaching-sessions/editor-cache-context.test.tsx
+
+# Run connection status tests
+npx vitest run __tests__/components/ui/coaching-sessions/coaching-notes/connection-status.test.tsx
+
+# Run all tests
+npx vitest run
+```
+
+### Manual Testing — Normal Flow
+
+1. Navigate to a coaching session with coaching notes
+2. Verify the editor loads with toolbar buttons and "Connected" badge
+3. Type in the editor — content should save and sync
+4. Open the same session in a second browser tab — edits should appear in real-time
+
+### Manual Testing — Timeout Flow (simulating sync failure)
+
+To test the timeout path, temporarily break the TipTap connection and shorten the timeout:
+
+1. In `.env.local`, change `NEXT_PUBLIC_TIPTAP_APP_ID` to a bogus value (e.g. `"bogus-test-id"`)
+2. In `src/components/ui/coaching-sessions/editor-cache-context.tsx`, change `SYNC_TIMEOUT_MS` from `10_000` to `3_000`
+3. Restart the dev server (`npm run dev`)
+4. Navigate to a coaching session
+5. Loading skeleton shows for ~3 seconds, then editor mounts with "Offline" badge and full toolbar
+6. Check Console for: `TipTap sync did not complete within 3000ms — enabling offline editing`
+7. Revert both changes and restart the dev server
+
+### Manual Testing — Reconnection
+
+1. Load a coaching session normally (editor shows "Connected")
+2. Disable network (DevTools -> Network -> Offline)
+3. Badge should change to "Offline"
+4. Type some content while offline
+5. Re-enable network
+6. Badge should change to "Connected", offline edits preserved and synced
+
+## Risks & Mitigations
+
+1. **User types before sync, content merges** — In the timeout path, user types after seeing "Offline" badge. Y.js CRDT handles merge correctly when sync eventually completes.
+
+2. **Empty editor during sync** — Expected. Loading skeleton shows until sync/timeout. Content appears when editor mounts.
+
+3. **Timeout leak on rapid session changes** — Every cleanup path clears `syncTimeoutRef`. The `enableEditing()` call checks `extensionsCreated` for idempotency.

--- a/src/components/ui/tiptap-ui/link-popover/link-button.tsx
+++ b/src/components/ui/tiptap-ui/link-popover/link-button.tsx
@@ -26,8 +26,11 @@ export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
     const editor = useTiptapEditor(providedEditor);
     const isActive = editor?.isActive("link") ?? false;
 
+    if (!editor || !editor.isEditable) {
+      return null;
+    }
+
     const handleClick = () => {
-      if (!editor) return;
       triggerLinkCreation(editor);
     };
 


### PR DESCRIPTION
## Description
When TipTap Cloud sync hangs due to transient network or service issues, the coaching notes editor gets stuck showing a loading spinner indefinitely. This adds a 10-second sync timeout that falls back to offline editing mode, ensuring the editor always becomes usable.

#### GitHub Issue: Closes #253

### Changes
* Add 10-second sync timeout in `EditorCacheProvider.initializeProvider()` — if the TipTap `"synced"` event doesn't fire within 10s, the editor mounts in offline mode
* Both the synced handler and timeout handler call a shared `enableEditing()` helper guarded by an `extensionsCreated` flag to prevent duplicate extension creation
* Add timeout cleanup (`clearTimeout`) in all 6 cleanup paths (lifecycle effect, unmount, logout, resetCache, error catch, action cleanup)
* Add `isEditable` guard to `LinkButton` for consistency with all other toolbar buttons
* Rewrite editor cache context tests with controllable mock provider (`_triggerEvent` helper) instead of auto-triggering sync
* Add new tests for sync timeout, late sync after timeout (idempotent), and timeout cleanup
* Add implementation plan doc at `docs/implementation-plans/tiptap-sync-timeout.md`

### Screenshots / Videos Showing UI Changes (if applicable)
Screenshots showing:
- Normal flow: editor loads with toolbar + "Connected" badge (unchanged)
- Timeout flow: loading skeleton for ~10s, then editor mounts with "Offline" badge and full toolbar

### Testing Strategy
- All 440 automated tests pass (`npx vitest run`)
- Manual testing: set `NEXT_PUBLIC_TIPTAP_APP_ID` to a bogus value and reduce `SYNC_TIMEOUT_MS` to 3s — confirmed editor mounts with "Offline" badge after timeout, console shows warning message
- Manual testing: reverted to real values — confirmed normal "Connected" flow still works
- See `docs/implementation-plans/tiptap-sync-timeout.md` for detailed manual testing guide

### Concerns
- In the timeout path, the editor starts with empty content and the "Offline" badge. If sync eventually completes, Y.js CRDT merges any local edits with server content. This is expected behavior but worth monitoring in production.
- The 10-second timeout value is a balance between giving TipTap Cloud enough time to sync and not making users wait too long. May need tuning based on production telemetry.