### PR TITLE
Security fix: update glob to 10.5.0 to fix CLI command injection vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12794,9 +12794,10 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",


### PR DESCRIPTION
## Description
Updates the transitive glob dependency from 10.4.5 to 10.5.0 to resolve a HIGH severity Dependabot security alert.

#### GitHub Issue: Resolves Dependabot alert #34

### Changes
* Updated `glob` lock file resolution from 10.4.5 to 10.5.0 (within the existing `^10.3.10` semver range)
* No `package.json` changes needed — only `package-lock.json` updated
* Affects transitive dependency paths: `tailwindcss → sucrase → glob` and `@vitest/coverage-v8 → test-exclude → glob`

### Testing Strategy
* All 440 unit tests pass
* Lock file only change — no code or direct dependency changes

### Concerns
* None — this is a patch bump within the existing semver range