### PR TITLE
Fix flaky isSessionToday test that fails near midnight

### DIFF
--- a/__tests__/coaching-session.test.ts
+++ b/__tests__/coaching-session.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DateTime, Settings } from "ts-luxon";
 import {
   isPastSession,
   isFutureSession,
@@ -65,13 +66,25 @@ describe("isUnderwaySession", () => {
 });
 
 describe("isSessionToday", () => {
+  // Pin "now" to noon so +60 minutes never crosses midnight
+  const originalNow = Settings.now;
+
+  beforeEach(() => {
+    const noon = DateTime.now().set({ hour: 12, minute: 0, second: 0, millisecond: 0 });
+    Settings.now = () => noon.toMillis();
+  });
+
+  afterEach(() => {
+    Settings.now = originalNow;
+  });
+
   it("returns true for a session scheduled today", () => {
-    const session = createSessionAt(0); // right now
+    const session = createSessionAt(0); // right now (noon)
     expect(isSessionToday(session)).toBe(true);
   });
 
   it("returns true for a session later today", () => {
-    const session = createSessionAt(60); // 1 hour from now
+    const session = createSessionAt(60); // 1 hour from now (1 PM)
     expect(isSessionToday(session)).toBe(true);
   });
 });


### PR DESCRIPTION
## Description
Fix a flaky test in `isSessionToday` that fails when the test suite runs within 60 minutes of midnight. The test `createSessionAt(60)` adds 60 minutes to "now", which crosses into the next calendar day when run late at night, causing `isSessionToday` to correctly return `false` while the test expects `true`.

### Changes
* Pin `DateTime.now()` to noon via `Settings.now` in the `isSessionToday` describe block
* Restore original `Settings.now` in `afterEach` to avoid leaking into other tests

### Testing Strategy
Run `npx vitest run __tests__/coaching-session.test.ts` — all 12 tests pass. Full suite (447 tests) also passes.

### Concerns
Other time-relative tests (e.g. `isPastSession`, `isUnderwaySession`) could theoretically be flaky near midnight too, but have much wider margins and haven't been reported as failing.