### PR TITLE
Reorder actions tab: move Actions for Review above New Actions

### DIFF
--- a/src/components/ui/coaching-sessions/actions-panel.tsx
+++ b/src/components/ui/coaching-sessions/actions-panel.tsx
@@ -428,7 +428,7 @@ function ReviewActionsSection({
                         No actions
                       </p>
                     ) : (
-                      <div className="space-y-3">
+                      <div className="space-y-3 max-w-full sm:max-w-[75%] lg:max-w-[50%]">
                         {group.map((action) => (
                           <div
                             key={action.id}
@@ -677,23 +677,7 @@ const ActionsPanel = ({
   // -- Render ---------------------------------------------------------------
 
   return (
-    <div className="flex flex-col gap-6 pt-4 pb-24 -mx-4 px-4 rounded-xl bg-muted/40">
-      <NewActionsSection
-        actions={sessionActions}
-        locale={locale}
-        coachId={coachId}
-        coachName={coachName}
-        coacheeId={coacheeId}
-        coacheeName={coacheeName}
-        onStatusChange={(id, v) => updateField(sessionActions, id, { field: ActionField.Status, value: v })}
-        onDueDateChange={(id, v) => updateField(sessionActions, id, { field: ActionField.DueBy, value: v })}
-        onAssigneesChange={(id, v) => updateField(sessionActions, id, { field: ActionField.AssigneeIds, value: v })}
-        onBodyChange={(id, v) => updateField(sessionActions, id, { field: ActionField.Body, value: v })}
-        onDelete={handleDeleteAction}
-        onCreateAction={handleCreateAction}
-        isSaving={isSaving}
-      />
-
+    <div className="flex flex-col gap-10 pt-4 pb-24 -mx-4 px-4 rounded-xl bg-muted/40">
       <div ref={reviewRef} className="scroll-mt-20">
         <ReviewActionsSection
           actions={reviewableActions}
@@ -714,6 +698,22 @@ const ActionsPanel = ({
           justMovedId={justMovedId}
         />
       </div>
+
+      <NewActionsSection
+        actions={sessionActions}
+        locale={locale}
+        coachId={coachId}
+        coachName={coachName}
+        coacheeId={coacheeId}
+        coacheeName={coacheeName}
+        onStatusChange={(id, v) => updateField(sessionActions, id, { field: ActionField.Status, value: v })}
+        onDueDateChange={(id, v) => updateField(sessionActions, id, { field: ActionField.DueBy, value: v })}
+        onAssigneesChange={(id, v) => updateField(sessionActions, id, { field: ActionField.AssigneeIds, value: v })}
+        onBodyChange={(id, v) => updateField(sessionActions, id, { field: ActionField.Body, value: v })}
+        onDelete={handleDeleteAction}
+        onCreateAction={handleCreateAction}
+        isSaving={isSaving}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Description
Reorders the coaching session actions tab so that **Actions for Review** appears above **New Actions**, increases spacing between sections, and makes review action card widths responsive.

### Changes
* Move Actions for Review section above New Actions section
* Increase gap between sections from `gap-6` to `gap-10`
* Add responsive max-width to review action cards: full width on mobile, 75% on sm, 50% on lg

### Screenshots / Videos Showing UI Changes (if applicable)

<img width="1588" height="788" alt="Screenshot 2026-02-25 at 15 39 10" src="https://github.com/user-attachments/assets/93fd7695-7aad-47ef-861f-897731e6c73d" />

### Testing Strategy
1. Open a coaching session with both new actions and review actions
2. Verify Actions for Review appears above New Actions
3. Resize browser from desktop to mobile and confirm review cards scale from 50% → 75% → full width
4. Existing tests pass (`npx vitest run __tests__/components/ui/coaching-sessions/actions-panel.test.tsx`)

### Concerns
None