### PR TITLE
test: validate PR preview workflow fixes (#322)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -13,14 +13,29 @@
 ## PR Preview Environments
 
 ### Architecture
-The frontend PR preview workflow (`.github/workflows/pr-preview-frontend.yml`) calls the backend repo's reusable workflow (`refactor-platform-rs/ci-deploy-pr-preview.yml`) with `repo_type: 'frontend'`. It uses `secrets: inherit` to pass secrets to the reusable workflow.
+The frontend PR preview workflow (`.github/workflows/pr-preview-frontend.yml`) calls the backend repo's reusable workflow (`refactor-platform-rs/.github/workflows/ci-deploy-pr-preview.yml@main`) with `repo_type: 'frontend'`. It uses `secrets: inherit` to pass secrets to the reusable workflow.
+
+The reusable workflow runs these jobs for frontend PRs:
+1. **lint-frontend** — ESLint
+2. **test-frontend** — Build, unit tests (Vitest), E2E tests (Playwright)
+3. **build-arm64-image** — Docker image build on ARM64 self-hosted runner (`neo`)
+4. **deploy** — SSH deploy to Raspberry Pi 5 via Tailscale
+
+### Test Job Configuration
+The `test-frontend` job runs inside the official Playwright container (`mcr.microsoft.com/playwright:v1.58.2-noble`) with pre-installed browsers. Keep the image tag in sync with the `@playwright/test` version in `package.json`.
+
+The job provides `NEXT_PUBLIC_*` env vars at build time (using `secrets.PR_PREVIEW_*` with localhost fallbacks) and prepares the Next.js standalone server for E2E by copying static assets into `.next/standalone/`. The `HOSTNAME: 0.0.0.0` env var ensures the standalone server binds to all interfaces inside the container.
 
 ### Key Environment Variables
 - **`NEXT_PUBLIC_BASE_PATH`**: Set to `/pr-<NUM>` for sub-path routing in preview environments. Configured in `next.config.mjs` via `basePath`.
 - **`NEXT_PUBLIC_BACKEND_API_VERSION`**: Must be `1.0.0-beta1` (not `v1`). The backend's `CompareApiVersion` extractor validates this header exactly.
+- **`NEXT_PUBLIC_BACKEND_SERVICE_*`**: Protocol, host, port, and API path for backend URL construction. Baked at build time. The test job uses `PR_PREVIEW_*` secrets with fallback defaults; the Docker image build has its own build args.
 
 ### Docker ARG Scoping (Critical)
 Docker `ARG` declarations **do not cross `FROM` boundaries**. Every `NEXT_PUBLIC_*` ARG must be redeclared in **each stage** that uses it (base, builder, runner). The builder stage needs them as `ENV` for `npm run build` to inline them into the client bundle. See `Dockerfile` stages for the pattern.
+
+### Checkout Token Resilience
+The `lint-frontend` and `test-frontend` jobs use a `continue-on-error` + fallback checkout pattern: the primary checkout uses `GHCR_PAT`, and if it fails (e.g., stale/expired token on re-run), a fallback checkout uses the default `GITHUB_TOKEN`. This prevents "re-run failed jobs" from failing on cross-repo `workflow_call` token regeneration issues.
 
 ### Secrets: inherit Pitfall
 `secrets: inherit` passes **all** secrets from the calling repo (frontend) to the reusable workflow (backend). If the frontend repo has a secret like `PR_PREVIEW_BACKEND_API_VERSION`, it will **override** the reusable workflow's `|| 'fallback'` defaults — even if the secret's value is stale. Always check for stale repo-level secrets when debugging environment variable issues in PR previews.


### PR DESCRIPTION
## Summary

Test PR to validate the PR preview workflow fixes from refactor-group/refactor-platform-rs#235. Updates `.claude/CLAUDE.md` with current PR preview CI/CD documentation.

## What this tests

This PR triggers the frontend PR preview workflow (`pr-preview-frontend.yml`), which calls the backend's reusable `ci-deploy-pr-preview.yml`. The backend workflow was updated to fix:

1. **E2E Playwright timeout** — Switched to Playwright container, added `NEXT_PUBLIC_*` build env vars, standalone server prep step, and `HOSTNAME: 0.0.0.0`
2. **Checkout auth on re-run** — `continue-on-error` + fallback checkout pattern replaces fragile `GHCR_PAT || GITHUB_TOKEN`

## Important

The backend PR (refactor-group/refactor-platform-rs#235) must be **merged first** for these fixes to take effect, since the frontend workflow calls `ci-deploy-pr-preview.yml@main`.

## Test plan

- [ ] Verify standard CI (lint + build + test) passes
- [ ] After RS#235 is merged: re-run the PR preview workflow and verify E2E tests pass
- [ ] Verify "re-run failed jobs" works without checkout auth errors