### PR TITLE
Fix broken tests: update stale dropdown placeholder text

### DIFF
--- a/__tests__/components/settings/meeting-integration-section.test.tsx
+++ b/__tests__/components/settings/meeting-integration-section.test.tsx
@@ -59,7 +59,7 @@ describe("MeetingIntegrationSection", () => {
     it("shows the platform dropdown", () => {
       render(<MeetingIntegrationSection />);
 
-      expect(screen.getByText("Select a platform")).toBeInTheDocument();
+      expect(screen.getByText("Select a provider")).toBeInTheDocument();
     });
 
     it("shows the updated description text", () => {
@@ -110,7 +110,7 @@ describe("MeetingIntegrationSection", () => {
     it("does not show the platform dropdown", () => {
       render(<MeetingIntegrationSection />);
 
-      expect(screen.queryByText("Select a platform")).not.toBeInTheDocument();
+      expect(screen.queryByText("Select a provider")).not.toBeInTheDocument();
     });
   });
 

--- a/__tests__/integration/google-oauth-flow.integration.test.tsx
+++ b/__tests__/integration/google-oauth-flow.integration.test.tsx
@@ -84,7 +84,7 @@ describe("Google OAuth Flow Integration", () => {
 
       render(<IntegrationsPage />);
 
-      expect(screen.getByText("Select a platform")).toBeInTheDocument();
+      expect(screen.getByText("Select a provider")).toBeInTheDocument();
     });
 
     it("shows success toast and refreshes when returning from Google OAuth", async () => {


### PR DESCRIPTION
## Description
Fix two failing tests on main that expected the old "Select a platform" dropdown placeholder text after the component was updated to "Select a provider".

### Changes
* Updated `meeting-integration-section.test.tsx` to assert "Select a provider" (2 occurrences)
* Updated `google-oauth-flow.integration.test.tsx` to assert "Select a provider" (1 occurrence)

### Testing Strategy
All 684 unit tests pass locally. The CI run that exposed these failures: https://github.com/refactor-group/refactor-platform-fe/actions/runs/23388301537