### PR TITLE
Fix N+1 session goal fetching with batch endpoint

### DIFF
--- a/__tests__/lib/api/goals.test.ts
+++ b/__tests__/lib/api/goals.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { GoalApi, useGoalList, useGoalsBySession } from '@/lib/api/goals'
+import { GoalApi, useGoalList, useGoalsBySession, useBatchSessionGoals } from '@/lib/api/goals'
 import { EntityApi } from '@/lib/api/entity-api'
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { TestProviders } from '@/test-utils/providers'
+import { sessionGuard } from '@/lib/auth/session-guard'
 
 // Mock EntityApi
 vi.mock('@/lib/api/entity-api', () => ({
@@ -15,6 +16,13 @@ vi.mock('@/lib/api/entity-api', () => ({
     deleteFn: vi.fn(),
     useEntityList: vi.fn(),
     useEntityMutation: vi.fn(),
+  },
+}))
+
+// Mock sessionGuard for batch endpoint tests
+vi.mock('@/lib/auth/session-guard', () => ({
+  sessionGuard: {
+    get: vi.fn(),
   },
 }))
 
@@ -194,5 +202,68 @@ describe('useGoalsBySession hook', () => {
 
     expect(result.current.goals).toEqual(mockGoals)
     expect(result.current.isLoading).toBe(false)
+  })
+})
+
+describe('useBatchSessionGoals hook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty object when relationship ID is null', () => {
+    const { result } = renderHook(
+      () => useBatchSessionGoals(null),
+      { wrapper: TestProviders }
+    )
+
+    expect(result.current.sessionGoals).toEqual({})
+    expect(sessionGuard.get).not.toHaveBeenCalled()
+  })
+
+  it('fetches batch goals keyed by session ID', async () => {
+    const mockResponse = {
+      data: {
+        data: {
+          session_goals: {
+            'session-1': [{ id: 'goal-A', title: 'Goal A' }],
+            'session-2': [{ id: 'goal-A', title: 'Goal A' }, { id: 'goal-B', title: 'Goal B' }],
+          },
+        },
+      },
+    }
+
+    vi.mocked(sessionGuard.get).mockResolvedValue(mockResponse as any)
+
+    const { result } = renderHook(
+      () => useBatchSessionGoals('rel-123'),
+      { wrapper: TestProviders }
+    )
+
+    await waitFor(() => {
+      expect(result.current.sessionGoals).toEqual(mockResponse.data.data.session_goals)
+    })
+
+    expect(sessionGuard.get).toHaveBeenCalledWith(
+      'http://localhost:3000/coaching_sessions/goals',
+      { params: { coaching_relationship_id: 'rel-123' } }
+    )
+  })
+
+  it('passes coaching_relationship_id as query param to batch endpoint', async () => {
+    vi.mocked(sessionGuard.get).mockResolvedValue({
+      data: { data: { session_goals: {} } },
+    } as any)
+
+    renderHook(
+      () => useBatchSessionGoals('rel-456'),
+      { wrapper: TestProviders }
+    )
+
+    await waitFor(() => {
+      expect(sessionGuard.get).toHaveBeenCalledWith(
+        'http://localhost:3000/coaching_sessions/goals',
+        { params: { coaching_relationship_id: 'rel-456' } }
+      )
+    })
   })
 })

--- a/src/components/ui/coaching-session.tsx
+++ b/src/components/ui/coaching-session.tsx
@@ -4,9 +4,8 @@ import React from "react";
 import { Card, CardHeader } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { useGoalsBySession } from "@/lib/api/goals";
 import { DEFAULT_GOAL_TITLE, goalTitle } from "@/types/goal";
-import { Id } from "@/types/general";
+import type { Goal } from "@/types/goal";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,12 +24,15 @@ import {
 
 interface CoachingSessionProps {
   coachingSession: CoachingSessionType;
+  /** Pre-fetched goals for this session from the batch endpoint */
+  sessionGoals?: Goal[];
   onUpdate: () => void;
   onDelete: () => void;
 }
 
 const CoachingSession: React.FC<CoachingSessionProps> = ({
   coachingSession,
+  sessionGoals,
   onUpdate,
   onDelete,
 }) => {
@@ -45,7 +47,7 @@ const CoachingSession: React.FC<CoachingSessionProps> = ({
       <CardHeader className="p-4">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2">
           <div className="space-y-1">
-            <SessionGoal coachingSessionId={coachingSession.id} />
+            <SessionGoal goals={sessionGoals} />
             <div className="text-sm text-muted-foreground">
               {formatDateInUserTimezoneWithTZ(
                 coachingSession.date,
@@ -95,29 +97,16 @@ const CoachingSession: React.FC<CoachingSessionProps> = ({
 };
 
 interface SessionGoalProps {
-  coachingSessionId: Id;
+  /** Pre-fetched goals from the batch endpoint. Undefined means still loading. */
+  goals?: Goal[];
 }
 
-const SessionGoal: React.FC<SessionGoalProps> = ({
-  coachingSessionId,
-}) => {
-  const {
-    goals,
-    isLoading: isLoadingGoals,
-    isError: isErrorGoals,
-  } = useGoalsBySession(coachingSessionId);
-
-  let titleText: string;
-
-  if (isLoadingGoals) {
-    titleText = "Loading...";
-  } else if (isErrorGoals) {
-    titleText = "Error loading goal";
-  } else {
-    titleText = goals.length > 0
+const SessionGoal: React.FC<SessionGoalProps> = ({ goals }) => {
+  const titleText = goals === undefined
+    ? "Loading..."
+    : goals.length > 0
       ? goalTitle(goals[0])
       : DEFAULT_GOAL_TITLE;
-  }
 
   return <div>{titleText}</div>;
 };

--- a/src/components/ui/dashboard/coaching-session-list.tsx
+++ b/src/components/ui/dashboard/coaching-session-list.tsx
@@ -7,6 +7,7 @@ import { useCoachingSessionList } from "@/lib/api/coaching-sessions";
 import { useCoachingSessionMutation } from "@/lib/api/coaching-sessions";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { CoachingSession as CoachingSessionComponent } from "@/components/ui/coaching-session";
+import { useBatchSessionGoals } from "@/lib/api/goals";
 import { DateTime } from "ts-luxon";
 import { useMemo } from "react";
 import {
@@ -45,6 +46,7 @@ export default function CoachingSessionList({
     refresh: refreshCoachingSessions,
   } = useCoachingSessionList(currentCoachingRelationshipId, fromDate, toDate);
 
+  const { sessionGoals } = useBatchSessionGoals(currentCoachingRelationshipId);
   const { delete: deleteCoachingSession } = useCoachingSessionMutation();
 
   const handleDeleteCoachingSession = async (id: Id) => {
@@ -132,6 +134,7 @@ export default function CoachingSessionList({
                   <CoachingSessionComponent
                     key={coachingSession.id}
                     coachingSession={coachingSession}
+                    sessionGoals={sessionGoals[coachingSession.id]}
                     onUpdate={() => onUpdateSession(coachingSession)}
                     onDelete={() =>
                       handleDeleteCoachingSession(coachingSession.id)
@@ -154,6 +157,7 @@ export default function CoachingSessionList({
                   <CoachingSessionComponent
                     key={coachingSession.id}
                     coachingSession={coachingSession}
+                    sessionGoals={sessionGoals[coachingSession.id]}
                     onUpdate={() => onUpdateSession(coachingSession)}
                     onDelete={() =>
                       handleDeleteCoachingSession(coachingSession.id)

--- a/src/lib/api/goals.ts
+++ b/src/lib/api/goals.ts
@@ -8,6 +8,8 @@ import {
 } from "@/types/goal";
 import { ApiSortOrder, GoalSortField } from "@/types/sorting";
 import { EntityApi } from "./entity-api";
+import useSWR from "swr";
+import { sessionGuard } from "@/lib/auth/session-guard";
 
 const GOALS_BASEURL: string = `${siteConfig.env.backendServiceURL}/goals`;
 const COACHING_SESSIONS_BASEURL: string = `${siteConfig.env.backendServiceURL}/coaching_sessions`;
@@ -130,6 +132,64 @@ export const GoalApi = {
   ): Promise<Goal> => {
     throw new Error("Delete nested operation not implemented");
   },
+};
+
+/** Response shape from GET /coaching_sessions/goals batch endpoint. */
+interface BatchSessionGoalsResponse {
+  session_goals: Record<Id, Goal[]>;
+}
+
+/** Wrapped API response from the backend. */
+interface ApiResponse<T> {
+  status_code: number;
+  data: T;
+}
+
+/**
+ * Fetches goals for all sessions in a coaching relationship in a single request.
+ * Replaces the N+1 pattern of calling GET /coaching_sessions/{id}/goals per session.
+ *
+ * @param coachingRelationshipId The coaching relationship whose session goals to fetch
+ * @returns Record mapping session IDs to their linked goals
+ */
+async function fetchBatchSessionGoals(
+  coachingRelationshipId: Id
+): Promise<Record<Id, Goal[]>> {
+  const response = await sessionGuard.get<ApiResponse<BatchSessionGoalsResponse>>(
+    `${COACHING_SESSIONS_BASEURL}/goals`,
+    {
+      params: { coaching_relationship_id: coachingRelationshipId },
+    }
+  );
+  return response.data.data.session_goals;
+}
+
+/**
+ * SWR hook that fetches goals for all sessions in a coaching relationship
+ * via the batch endpoint GET /coaching_sessions/goals?coaching_relationship_id=UUID.
+ *
+ * Returns a Record<Id, Goal[]> mapping session IDs to their linked goals.
+ * Session cards can read sessionGoals[sessionId] directly.
+ *
+ * @param coachingRelationshipId The relationship ID, or null to skip fetching
+ */
+export const useBatchSessionGoals = (coachingRelationshipId: Id | null) => {
+  const key = coachingRelationshipId
+    ? `${COACHING_SESSIONS_BASEURL}/goals?coaching_relationship_id=${coachingRelationshipId}`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWR<Record<Id, Goal[]>>(
+    key,
+    () => fetchBatchSessionGoals(coachingRelationshipId!),
+    { revalidateOnMount: true }
+  );
+
+  return {
+    sessionGoals: data ?? {},
+    isLoading,
+    isError: error,
+    refresh: mutate,
+  };
 };
 
 /**

--- a/src/lib/hooks/use-sse-cache-invalidation.ts
+++ b/src/lib/hooks/use-sse-cache-invalidation.ts
@@ -37,15 +37,21 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
   }, [mutate, baseUrl]);
 
   /**
-   * Invalidates only the session-scoped goal caches (e.g. /coaching_sessions/{id}/goals)
-   * without touching other coaching_sessions caches (session list, enriched sessions, etc.).
+   * Invalidates session-scoped goal caches: both per-session caches
+   * (e.g. /coaching_sessions/{id}/goals) and the batch endpoint cache
+   * (e.g. /coaching_sessions/goals?coaching_relationship_id=...).
    */
   const invalidateSessionGoals = useCallback((eventName: string) => {
     const sessionGoalsPattern = `${baseUrl}/coaching_sessions/`;
     mutate(
       (key) => {
         const url = typeof key === 'string' ? key : Array.isArray(key) ? key[0] : null;
-        return typeof url === 'string' && url.startsWith(sessionGoalsPattern) && url.endsWith('/goals');
+        if (typeof url !== 'string' || !url.startsWith(sessionGoalsPattern)) return false;
+        // Match per-session caches: /coaching_sessions/{id}/goals
+        if (url.endsWith('/goals')) return true;
+        // Match batch cache: /coaching_sessions/goals?coaching_relationship_id=...
+        if (url.includes('/coaching_sessions/goals?')) return true;
+        return false;
       },
       undefined,
       { revalidate: true }


### PR DESCRIPTION
## Description
Fixes the N+1 goal-fetching pattern that caused `ConnectionAcquire(Timeout)` 503s in production. When loading a coaching relationship view with N sessions, the frontend was firing N individual `GET /coaching_sessions/{id}/goals` requests simultaneously, exhausting the backend's DB connection pool.

### Changes
* Added `useBatchSessionGoals` SWR hook and `fetchBatchSessionGoals` API function that calls the new `GET /coaching_sessions/goals?coaching_relationship_id=UUID` batch endpoint (see `BatchSessionGoals` contract v1)
* Updated `CoachingSessionList` to fetch all session goals in a single request and pass them down as props
* Converted `SessionGoal` from a self-fetching component (with `useGoalsBySession`) to a pure display component that receives goals via props
* Updated SSE cache invalidation to also revalidate the batch endpoint's SWR key on `coaching_session_goal_created`/`deleted` events

### Testing Strategy
- 3 new unit tests for `useBatchSessionGoals`: null relationship skips fetch, batch response correctly returned, query param passed correctly
- All 712 existing tests pass — no regressions
- Full verification requires the backend `GET /coaching_sessions/goals` endpoint (BatchSessionGoals contract v1) to be deployed

### Concerns
- This PR depends on the backend implementing the `BatchSessionGoals` v1 contract (`GET /coaching_sessions/goals`). Until that endpoint is deployed, the session list will show "Loading..." for goal titles. The per-session `useGoalsBySession` hook is preserved for the single-session detail view (e.g. PR #343's GoalPanel).