### PR TITLE
Add missing On Hold option to StatusSelect dropdown

### DIFF
--- a/src/components/ui/coaching-sessions/session-action-card.tsx
+++ b/src/components/ui/coaching-sessions/session-action-card.tsx
@@ -122,6 +122,12 @@ function StatusSelect({ status, onStatusChange }: StatusSelectProps) {
             In Progress
           </span>
         </SelectItem>
+        <SelectItem value={ItemStatus.OnHold}>
+          <span className="flex items-center gap-1.5">
+            <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", statusDotColor(ItemStatus.OnHold))} />
+            On Hold
+          </span>
+        </SelectItem>
         <SelectItem value={ItemStatus.Completed}>
           <span className="flex items-center gap-1.5">
             <span className={cn("inline-block h-2 w-2 rounded-full shrink-0", statusDotColor(ItemStatus.Completed))} />


### PR DESCRIPTION
## Description
Add the missing `OnHold` SelectItem to the `StatusSelect` dropdown component used in action cards. Without this option, Radix UI's `Select` threw a runtime error when the controlled `value` was set to `OnHold` (e.g. during a drag-and-drop optimistic update), causing the card to snap back to its original column.

### Changes
* Added `OnHold` SelectItem to `StatusSelect` in `session-action-card.tsx`, positioned between In Progress and Completed to match the kanban column order

### Screenshots / Videos Showing UI Changes (if applicable)
- Screenshot of the status dropdown showing all 5 options including "On Hold"
- Screen recording of drag-and-drop to the On Hold column succeeding

### Testing Strategy
1. Open the Actions page, ensure the "Open" or "All" filter is selected so the On Hold column is visible
2. Drag an action card to the On Hold column — it should stay and persist
3. Click a card's status pill and verify "On Hold" appears in the dropdown
4. Select "On Hold" from the dropdown — card should move to the On Hold column

### Concerns
None