### PR TITLE
Route both action tabs through relationship-actions endpoint

### DIFF
--- a/__tests__/e2e/action-edit-textarea-scroll.spec.ts
+++ b/__tests__/e2e/action-edit-textarea-scroll.spec.ts
@@ -199,11 +199,16 @@ async function setupActionsPage(page: Page) {
     })
   })
 
-  await page.route(`**/users/${MOCK_USER_ID}/actions**`, async (route) => {
+  // Batch relationship-actions endpoint (used by actions kanban page)
+  await page.route('**/coaching_relationships/actions**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ data: SESSION_ACTIONS }),
+      body: JSON.stringify({
+        data: {
+          coachee_actions: { [RELATIONSHIP_ID]: SESSION_ACTIONS },
+        },
+      }),
     })
   })
 }

--- a/__tests__/e2e/actions-exit-animation.spec.ts
+++ b/__tests__/e2e/actions-exit-animation.spec.ts
@@ -98,12 +98,16 @@ async function setupActionsPage(
     })
   })
 
-  // User actions list endpoint
-  await page.route(`**/users/${MOCK_USER_ID}/actions**`, async (route) => {
+  // Batch relationship-actions endpoint (used by actions kanban page)
+  await page.route('**/coaching_relationships/actions**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ data: OPEN_ACTIONS }),
+      body: JSON.stringify({
+        data: {
+          coachee_actions: { 'rel-1': OPEN_ACTIONS },
+        },
+      }),
     })
   })
 }

--- a/__tests__/lib/api/relationship-actions.test.ts
+++ b/__tests__/lib/api/relationship-actions.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { relationshipActionsUrl } from "@/lib/api/relationship-actions";
+import {
+  AssigneeScope,
+  UserActionsAssigneeFilter,
+} from "@/types/assigned-actions";
+
+describe("relationshipActionsUrl", () => {
+  const orgId = "org-123";
+  const relId = "rel-456";
+
+  it("includes assignee param in single-relationship URL (regression: was previously dropped)", () => {
+    const params = {
+      assignee: AssigneeScope.Coachee,
+      assignee_filter: UserActionsAssigneeFilter.Assigned,
+    };
+
+    const batchUrl = relationshipActionsUrl(orgId, params);
+    const singleUrl = relationshipActionsUrl(orgId, {
+      ...params,
+      coaching_relationship_id: relId,
+    });
+
+    // Both paths must include assignee=coachee so the backend filters
+    // to coachee-only actions. The single-relationship path previously
+    // used sharedQueryString which omitted the assignee param, causing
+    // both "My Actions" and "Coachee Actions" to show identical results.
+    expect(batchUrl).toContain("assignee=coachee");
+    expect(singleUrl).toContain("assignee=coachee");
+  });
+
+  it("supports assignee=coach for My Actions path", () => {
+    const params = {
+      assignee: AssigneeScope.Coach,
+      assignee_filter: UserActionsAssigneeFilter.Assigned,
+    };
+
+    const batchUrl = relationshipActionsUrl(orgId, params);
+    const singleUrl = relationshipActionsUrl(orgId, {
+      ...params,
+      coaching_relationship_id: relId,
+    });
+
+    expect(batchUrl).toContain("assignee=coach");
+    expect(singleUrl).toContain("assignee=coach");
+  });
+});

--- a/__tests__/lib/hooks/use-actions-fetch.test.ts
+++ b/__tests__/lib/hooks/use-actions-fetch.test.ts
@@ -1,80 +1,89 @@
 import { describe, it, expect } from "vitest";
-import {
-  assignmentFilterToUserActionsParams,
-  assignmentFilterToRelationshipActionsParams,
-} from "@/lib/hooks/use-actions-fetch";
+import { assignmentFilterToRelationshipActionsParams } from "@/lib/hooks/use-actions-fetch";
 import {
   AssigneeScope,
   AssignmentFilter,
   UserActionsAssigneeFilter,
-  UserActionsScope,
 } from "@/types/assigned-actions";
 
-describe("assignmentFilterToUserActionsParams", () => {
-  it("maps Assigned to scope=assigned with no assignee filter", () => {
-    const result = assignmentFilterToUserActionsParams(AssignmentFilter.Assigned);
-    expect(result).toEqual({ scope: UserActionsScope.Assigned });
-    expect(result.assigneeFilter).toBeUndefined();
-  });
-
-  it("maps Unassigned to scope=sessions with assignee_filter=unassigned", () => {
-    const result = assignmentFilterToUserActionsParams(AssignmentFilter.Unassigned);
-    expect(result).toEqual({
-      scope: UserActionsScope.Sessions,
-      assigneeFilter: UserActionsAssigneeFilter.Unassigned,
-    });
-  });
-
-  it("maps All to scope=sessions with no assignee filter", () => {
-    const result = assignmentFilterToUserActionsParams(AssignmentFilter.All);
-    expect(result).toEqual({ scope: UserActionsScope.Sessions });
-    expect(result.assigneeFilter).toBeUndefined();
-  });
-});
-
 describe("assignmentFilterToRelationshipActionsParams", () => {
-  it("maps Assigned to assignee=coachee with assignee_filter=assigned", () => {
-    const result = assignmentFilterToRelationshipActionsParams(AssignmentFilter.Assigned);
-    expect(result).toEqual({
-      assignee: AssigneeScope.Coachee,
-      assigneeFilter: UserActionsAssigneeFilter.Assigned,
+  describe("with coachee scope", () => {
+    it("maps Assigned to assignee=coachee with assignee_filter=assigned", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.Assigned,
+        AssigneeScope.Coachee
+      );
+      expect(result).toEqual({
+        assignee: AssigneeScope.Coachee,
+        assigneeFilter: UserActionsAssigneeFilter.Assigned,
+      });
+    });
+
+    it("maps All to assignee=coachee with no assignee filter", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.All,
+        AssigneeScope.Coachee
+      );
+      expect(result).toEqual({ assignee: AssigneeScope.Coachee });
+      expect(result.assigneeFilter).toBeUndefined();
     });
   });
 
-  it("maps Unassigned to assignee_filter=unassigned with no assignee scope", () => {
-    const result = assignmentFilterToRelationshipActionsParams(AssignmentFilter.Unassigned);
-    expect(result).toEqual({
+  describe("with coach scope", () => {
+    it("maps Assigned to assignee=coach with assignee_filter=assigned", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.Assigned,
+        AssigneeScope.Coach
+      );
+      expect(result).toEqual({
+        assignee: AssigneeScope.Coach,
+        assigneeFilter: UserActionsAssigneeFilter.Assigned,
+      });
+    });
+
+    it("maps All to assignee=coach with no assignee filter", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.All,
+        AssigneeScope.Coach
+      );
+      expect(result).toEqual({ assignee: AssigneeScope.Coach });
+      expect(result.assigneeFilter).toBeUndefined();
+    });
+  });
+
+  it("Unassigned ignores scope — returns only assignee_filter=unassigned", () => {
+    const coachResult = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.Unassigned,
+      AssigneeScope.Coach
+    );
+    const coacheeResult = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.Unassigned,
+      AssigneeScope.Coachee
+    );
+    const expected = {
       assigneeFilter: UserActionsAssigneeFilter.Unassigned,
-    });
-    expect(result.assignee).toBeUndefined();
-  });
-
-  it("maps All to assignee=coachee with no assignee filter", () => {
-    const result = assignmentFilterToRelationshipActionsParams(AssignmentFilter.All);
-    expect(result).toEqual({ assignee: AssigneeScope.Coachee });
-    expect(result.assigneeFilter).toBeUndefined();
+    };
+    expect(coachResult).toEqual(expected);
+    expect(coacheeResult).toEqual(expected);
+    expect(coachResult.assignee).toBeUndefined();
   });
 
   it("returns distinct params for each filter value", () => {
-    const assigned = assignmentFilterToRelationshipActionsParams(AssignmentFilter.Assigned);
-    const unassigned = assignmentFilterToRelationshipActionsParams(AssignmentFilter.Unassigned);
-    const all = assignmentFilterToRelationshipActionsParams(AssignmentFilter.All);
+    const assigned = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.Assigned,
+      AssigneeScope.Coachee
+    );
+    const unassigned = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.Unassigned,
+      AssigneeScope.Coachee
+    );
+    const all = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.All,
+      AssigneeScope.Coachee
+    );
 
-    // All three produce different param shapes
     expect(assigned).not.toEqual(unassigned);
     expect(assigned).not.toEqual(all);
     expect(unassigned).not.toEqual(all);
-
-    // Assigned scopes to coachee AND filters to assigned
-    expect(assigned.assignee).toBe(AssigneeScope.Coachee);
-    expect(assigned.assigneeFilter).toBe(UserActionsAssigneeFilter.Assigned);
-
-    // Unassigned omits assignee scope (unassigned actions have no assignee to scope by)
-    expect(unassigned.assignee).toBeUndefined();
-    expect(unassigned.assigneeFilter).toBe(UserActionsAssigneeFilter.Unassigned);
-
-    // All scopes to coachee with no assignee filter (returns everything for coachee)
-    expect(all.assignee).toBe(AssigneeScope.Coachee);
-    expect(all.assigneeFilter).toBeUndefined();
   });
 });

--- a/__tests__/lib/hooks/use-all-actions-with-context.test.ts
+++ b/__tests__/lib/hooks/use-all-actions-with-context.test.ts
@@ -6,7 +6,6 @@ import { None } from "@/types/option";
 import {
   AssignmentFilter,
   CoachViewMode,
-  UserActionsScope,
 } from "@/types/assigned-actions";
 import type { Action } from "@/types/action";
 import type { EnrichedCoachingSession } from "@/lib/api/coaching-sessions";
@@ -16,12 +15,12 @@ import type { EnrichedCoachingSession } from "@/lib/api/coaching-sessions";
 // ---------------------------------------------------------------------------
 
 const mockRefreshActions = vi.fn();
-const mockRefreshRelationshipActions = vi.fn();
 
 vi.mock("@/lib/providers/auth-store-provider", () => ({
   useAuthStore: (sel: (s: Record<string, unknown>) => unknown) =>
     sel({
       userSession: { id: "user-1" },
+      isACoach: true,
     }),
 }));
 
@@ -51,34 +50,17 @@ vi.mock("@/lib/api/coaching-relationships", () => ({
   }),
 }));
 
-// Actions returned by useUserActionsList
-let mockMyActions: Action[] = [];
-let mockMyActionsLoading = false;
-let mockMyActionsError = false;
-
-vi.mock("@/lib/api/user-actions", () => ({
-  useUserActionsList: (userId: string | null) => ({
-    actions: userId ? mockMyActions : [],
-    isLoading: mockMyActionsLoading,
-    isError: mockMyActionsError,
-    refresh: mockRefreshActions,
-  }),
-  UserActionsApi: {
-    list: vi.fn().mockResolvedValue([]),
-  },
-}));
-
-// Relationship actions returned by useBatchRelationshipActions
-let mockRelationshipActions: Action[] = [];
-let mockRelationshipActionsLoading = false;
-let mockRelationshipActionsError = false;
+// Both "My Actions" and "Coachee Actions" now use useBatchRelationshipActions
+let mockActions: Action[] = [];
+let mockActionsLoading = false;
+let mockActionsError = false;
 
 vi.mock("@/lib/api/relationship-actions", () => ({
   useBatchRelationshipActions: () => ({
-    actions: mockRelationshipActions,
-    isLoading: mockRelationshipActionsLoading,
-    isError: mockRelationshipActionsError,
-    refresh: mockRefreshRelationshipActions,
+    actions: mockActions,
+    isLoading: mockActionsLoading,
+    isError: mockActionsError,
+    refresh: mockRefreshActions,
   }),
 }));
 
@@ -172,19 +154,16 @@ function makeTestSession(
 describe("useAllActionsWithContext", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockMyActions = [];
-    mockMyActionsLoading = false;
-    mockMyActionsError = false;
-    mockRelationshipActions = [];
-    mockRelationshipActionsLoading = false;
-    mockRelationshipActionsError = false;
+    mockActions = [];
+    mockActionsLoading = false;
+    mockActionsError = false;
     mockSessions = [];
     mockSessionsLoading = false;
     mockSessionsError = false;
   });
 
   it("returns enriched actions with relationship context", () => {
-    mockMyActions = [makeTestAction()];
+    mockActions = [makeTestAction()];
     mockSessions = [makeTestSession()];
 
     const { result } = renderHook(() =>
@@ -202,7 +181,7 @@ describe("useAllActionsWithContext", () => {
   });
 
   it("returns empty array when there are no actions", () => {
-    mockMyActions = [];
+    mockActions = [];
     mockSessions = [makeTestSession()];
 
     const { result } = renderHook(() =>
@@ -214,7 +193,7 @@ describe("useAllActionsWithContext", () => {
   });
 
   it("excludes orphaned actions with no matching session", () => {
-    mockMyActions = [makeTestAction({ coaching_session_id: "nonexistent" })];
+    mockActions = [makeTestAction({ coaching_session_id: "nonexistent" })];
     mockSessions = [makeTestSession()];
 
     const { result } = renderHook(() =>
@@ -225,7 +204,7 @@ describe("useAllActionsWithContext", () => {
   });
 
   it("isLoading is true while actions are loading", () => {
-    mockMyActionsLoading = true;
+    mockActionsLoading = true;
 
     const { result } = renderHook(() =>
       useAllActionsWithContext(CoachViewMode.MyActions)
@@ -245,7 +224,7 @@ describe("useAllActionsWithContext", () => {
   });
 
   it("isError is true when actions fetch fails", () => {
-    mockMyActionsError = true;
+    mockActionsError = true;
 
     const { result } = renderHook(() =>
       useAllActionsWithContext(CoachViewMode.MyActions)
@@ -279,7 +258,7 @@ describe("useAllActionsWithContext", () => {
       coach: { id: "user-1", first_name: "Alice", last_name: "Smith" },
       coachee: { id: "coachee-2", first_name: "Charlie", last_name: "Brown" },
     });
-    mockMyActions = [
+    mockActions = [
       makeTestAction({ id: "a1", coaching_session_id: "session-1" }),
       makeTestAction({ id: "a2", coaching_session_id: "session-2" }),
     ];
@@ -298,7 +277,7 @@ describe("useAllActionsWithContext", () => {
   });
 
   it("sets isOverdue when due_by is in the past", () => {
-    mockMyActions = [
+    mockActions = [
       makeTestAction({ due_by: now.minus({ days: 5 }) }),
     ];
     mockSessions = [makeTestSession()];
@@ -317,7 +296,7 @@ describe("useAllActionsWithContext", () => {
 
   describe("CoacheeActions mode", () => {
     it("returns enriched actions in CoacheeActions mode", () => {
-      mockRelationshipActions = [makeTestAction()];
+      mockActions = [makeTestAction()];
       mockSessions = [makeTestSession()];
 
       const { result } = renderHook(() =>
@@ -331,7 +310,7 @@ describe("useAllActionsWithContext", () => {
     });
 
     it("isLoading is true while coachee actions are loading", () => {
-      mockRelationshipActionsLoading = true;
+      mockActionsLoading = true;
 
       const { result } = renderHook(() =>
         useAllActionsWithContext(CoachViewMode.CoacheeActions)
@@ -341,7 +320,7 @@ describe("useAllActionsWithContext", () => {
     });
 
     it("isError is true when coachee actions fetch fails", () => {
-      mockRelationshipActionsError = true;
+      mockActionsError = true;
 
       const { result } = renderHook(() =>
         useAllActionsWithContext(CoachViewMode.CoacheeActions)
@@ -351,7 +330,7 @@ describe("useAllActionsWithContext", () => {
     });
 
     it("forwards relationshipId to useActionsFetch", () => {
-      mockRelationshipActions = [makeTestAction()];
+      mockActions = [makeTestAction()];
       mockSessions = [makeTestSession()];
 
       const { result } = renderHook(() =>
@@ -365,7 +344,7 @@ describe("useAllActionsWithContext", () => {
     });
 
     it("forwards assignmentFilter to useActionsFetch", () => {
-      mockRelationshipActions = [makeTestAction()];
+      mockActions = [makeTestAction()];
       mockSessions = [makeTestSession()];
 
       const { result } = renderHook(() =>

--- a/src/lib/api/relationship-actions.ts
+++ b/src/lib/api/relationship-actions.ts
@@ -33,18 +33,8 @@ export interface RelationshipActionsParams {
   sort_order?: string;
 }
 
-/** Builds the query params shared by both endpoints (excludes `assignee`). */
-function sharedQueryString(params: RelationshipActionsParams): string {
-  return buildQueryString({
-    assignee_filter: params.assignee_filter,
-    status: params.status,
-    sort_by: params.sort_by,
-    sort_order: params.sort_order,
-  });
-}
-
-/** Builds the batch endpoint query string, including the `assignee` param. */
-function batchQueryString(params: RelationshipActionsParams): string {
+/** Builds the query string for relationship action endpoints. */
+export function relationshipQueryString(params: RelationshipActionsParams): string {
   return buildQueryString({
     assignee: params.assignee,
     assignee_filter: params.assignee_filter,
@@ -54,13 +44,12 @@ function batchQueryString(params: RelationshipActionsParams): string {
   });
 }
 
-function relationshipActionsUrl(orgId: Id, params: RelationshipActionsParams): string {
+export function relationshipActionsUrl(orgId: Id, params: RelationshipActionsParams): string {
   const relId = params.coaching_relationship_id;
+  const qs = relationshipQueryString(params);
   if (relId) {
-    const qs = sharedQueryString(params);
     return `${ORGANIZATIONS_BASEURL}/${orgId}/${COACHING_RELATIONSHIPS_PATH}/${relId}/actions${qs}`;
   }
-  const qs = batchQueryString(params);
   return `${ORGANIZATIONS_BASEURL}/${orgId}/${COACHING_RELATIONSHIPS_PATH}/actions${qs}`;
 }
 

--- a/src/lib/hooks/use-actions-fetch.ts
+++ b/src/lib/hooks/use-actions-fetch.ts
@@ -1,6 +1,4 @@
-import { useMemo } from "react";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
-import { useUserActionsList } from "@/lib/api/user-actions";
 import { useBatchRelationshipActions } from "@/lib/api/relationship-actions";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import {
@@ -8,55 +6,30 @@ import {
   AssignmentFilter,
   CoachViewMode,
   UserActionsAssigneeFilter,
-  UserActionsScope,
 } from "@/types/assigned-actions";
-import type { Action } from "@/types/action";
 import type { Id } from "@/types/general";
 
 /**
- * Maps a UI-level AssignmentFilter to the user-actions API params
- * (scope + assignee_filter) used by the "My Actions" path.
+ * Maps a UI-level AssignmentFilter to the relationship-actions API params
+ * (assignee + assignee_filter).
  *
- * - Assigned: scope=assigned (backend handles filtering to assigned user)
- * - Unassigned: scope=sessions + assignee_filter=unassigned
- * - All: scope=sessions (returns both assigned and unassigned)
- */
-export function assignmentFilterToUserActionsParams(filter: AssignmentFilter): {
-  scope: UserActionsScope;
-  assigneeFilter?: UserActionsAssigneeFilter;
-} {
-  switch (filter) {
-    case AssignmentFilter.Assigned:
-      return { scope: UserActionsScope.Assigned };
-    case AssignmentFilter.Unassigned:
-      return {
-        scope: UserActionsScope.Sessions,
-        assigneeFilter: UserActionsAssigneeFilter.Unassigned,
-      };
-    case AssignmentFilter.All:
-      return { scope: UserActionsScope.Sessions };
-    default: {
-      const _exhaustive: never = filter;
-      throw new Error(`Unhandled assignment filter: ${_exhaustive}`);
-    }
-  }
-}
-
-/**
- * Maps a UI-level AssignmentFilter to the batch relationship-actions API params
- * (assignee + assignee_filter) used by the "Coachee Actions" path.
+ * The `assigneeScope` determines whose actions are returned (coach or coachee),
+ * while `assignee_filter` controls assigned/unassigned filtering.
  *
- * The `assignee` param scopes by role (coachee/coach) while `assignee_filter`
- * controls assigned/unassigned filtering.
+ * Used by both "My Actions" (with coach or coachee scope depending on role)
+ * and "Coachee Actions" (always coachee scope).
  */
-export function assignmentFilterToRelationshipActionsParams(filter: AssignmentFilter): {
+export function assignmentFilterToRelationshipActionsParams(
+  filter: AssignmentFilter,
+  assigneeScope: AssigneeScope
+): {
   assignee?: AssigneeScope;
   assigneeFilter?: UserActionsAssigneeFilter;
 } {
   switch (filter) {
     case AssignmentFilter.Assigned:
       return {
-        assignee: AssigneeScope.Coachee,
+        assignee: assigneeScope,
         assigneeFilter: UserActionsAssigneeFilter.Assigned,
       };
     case AssignmentFilter.Unassigned:
@@ -64,7 +37,7 @@ export function assignmentFilterToRelationshipActionsParams(filter: AssignmentFi
         assigneeFilter: UserActionsAssigneeFilter.Unassigned,
       };
     case AssignmentFilter.All:
-      return { assignee: AssigneeScope.Coachee };
+      return { assignee: assigneeScope };
     default: {
       const _exhaustive: never = filter;
       throw new Error(`Unhandled assignment filter: ${_exhaustive}`);
@@ -73,10 +46,13 @@ export function assignmentFilterToRelationshipActionsParams(filter: AssignmentFi
 }
 
 /**
- * Fetches actions based on the current view mode and assignment filter.
+ * Fetches actions via the batch relationship-actions endpoint.
  *
- * In "My Actions" mode, fetches actions for the current user.
- * In "Coachee Actions" mode, fetches actions for all coachees via a single batch request.
+ * Both "My Actions" and "Coachee Actions" use the same endpoint, differentiated
+ * by the `assignee` query param:
+ * - My Actions (coach user): assignee=coach
+ * - My Actions (coachee-only user): assignee=coachee
+ * - Coachee Actions: assignee=coachee
  *
  * @param viewMode - Whether to show the user's own actions or their coachees' actions
  * @param relationshipId - Optional server-side filter to a specific coaching relationship
@@ -87,62 +63,30 @@ export function useActionsFetch(
   relationshipId?: Id,
   assignmentFilter: AssignmentFilter = AssignmentFilter.Assigned
 ) {
-  const { userSession } = useAuthStore((state) => ({
-    userSession: state.userSession,
+  const { isACoach } = useAuthStore((state) => ({
+    isACoach: state.isACoach,
   }));
-  const userId = userSession?.id ?? null;
   const { currentOrganizationId } = useCurrentOrganization();
 
   const isCoacheeMode = viewMode === CoachViewMode.CoacheeActions;
 
-  const userActionsParams = assignmentFilterToUserActionsParams(assignmentFilter);
-  const relationshipActionsParams = assignmentFilterToRelationshipActionsParams(assignmentFilter);
+  const assigneeScope: AssigneeScope =
+    isCoacheeMode
+      ? AssigneeScope.Coachee
+      : isACoach
+        ? AssigneeScope.Coach
+        : AssigneeScope.Coachee;
 
-  // --- User Actions path ---
+  const params = assignmentFilterToRelationshipActionsParams(assignmentFilter, assigneeScope);
 
-  const {
-    actions: userActions,
-    isLoading: userActionsLoading,
-    isError: userActionsError,
-    refresh: refreshUserActions,
-  } = useUserActionsList(
-    !isCoacheeMode ? userId : null,
+  const { actions, isLoading, isError, refresh } = useBatchRelationshipActions(
+    currentOrganizationId,
     {
-      scope: userActionsParams.scope,
-      coaching_relationship_id: relationshipId,
-      assignee_filter: userActionsParams.assigneeFilter,
-    }
-  );
-
-  // --- Relationship Actions path (single batch request) ---
-
-  const {
-    actions: relationshipActions,
-    isLoading: relationshipActionsLoading,
-    isError: relationshipActionsError,
-    refresh: refreshRelationshipActions,
-  } = useBatchRelationshipActions(
-    isCoacheeMode ? currentOrganizationId : null,
-    {
-      assignee: relationshipActionsParams.assignee,
-      assignee_filter: relationshipActionsParams.assigneeFilter,
+      assignee: params.assignee,
+      assignee_filter: params.assigneeFilter,
       coaching_relationship_id: relationshipId,
     }
   );
-
-  // --- Combine based on mode ---
-
-  const actions: Action[] = useMemo(
-    () => (isCoacheeMode ? relationshipActions : (userActions ?? [])),
-    [isCoacheeMode, relationshipActions, userActions]
-  );
-
-  const isLoading = isCoacheeMode
-    ? relationshipActionsLoading
-    : userActionsLoading;
-
-  const isError = isCoacheeMode ? relationshipActionsError : userActionsError;
-  const refresh = isCoacheeMode ? refreshRelationshipActions : refreshUserActions;
 
   return { actions, isLoading, isError, refresh };
 }


### PR DESCRIPTION
## Description
Fixes the bug where "My Actions" and "Coachee Actions" tabs showed identical results on the Actions page. Both tabs now use the same batch relationship-actions endpoint, differentiated by `assignee=coach` vs `assignee=coachee`.

### Changes
* Unified URL query string builder in `relationship-actions.ts` — the `assignee` param was previously dropped on single-relationship URLs
* Parameterized `assignmentFilterToRelationshipActionsParams` with `assigneeScope` so it serves both coach and coachee views
* Removed the user-actions path from `use-actions-fetch.ts` — both tabs now route through `useBatchRelationshipActions`
* Role-aware scoping: coach users get `assignee=coach`, coachee-only users get `assignee=coachee` on "My Actions"
* Cleaned up dead code: removed `assignmentFilterToUserActionsParams`, unused imports

### Screenshots / Videos Showing UI Changes (if applicable)

None

### Testing Strategy
* `npx tsc --noEmit` — passes
* `npx vitest run` — 22 tests pass across `use-actions-fetch`, `relationship-actions`, and `use-all-actions-with-context` test files
* Manual: verify "My Actions" sends `assignee=coach` and "Coachee Actions" sends `assignee=coachee` in network tab
* Full fix requires backend PR to respect the `assignee` param on the single-relationship endpoint

### Concerns
* The backend's single-relationship endpoint (`/coaching_relationships/{rel_id}/actions`) currently ignores the `assignee` query param — backend team has confirmed the root cause and is implementing the fix
* `useUserActionsList` is intentionally kept in `user-actions.ts` since it's used by 3 other callers (panel-actions, assigned-actions, coaching-tabs-container)