### PR TITLE
Sort coachee dropdown alphabetically in create session dialog

### DIFF
--- a/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import React from "react";
@@ -8,7 +8,8 @@ import { TestProviders } from "@/test-utils/providers";
 import { EntityApiError } from "@/types/general";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import { createMockSession } from "../../../test-utils";
+import { createMockRelationship, createMockSession } from "../../../test-utils";
+import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -103,6 +104,57 @@ beforeEach(() => {
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("CoachingSessionForm – coachee dropdown ordering", () => {
+  function renderCreateForm() {
+    render(
+      <Wrapper>
+        <CoachingSessionForm mode="create" onOpenChange={vi.fn()} />
+      </Wrapper>
+    );
+  }
+
+  it("lists coachees alphabetically by full name when the user is the coach", () => {
+    vi.mocked(useCoachingRelationshipList).mockReturnValue({
+      relationships: [
+        createMockRelationship({
+          id: "r-zoe",
+          coach_id: "user-1",
+          coachee_first_name: "Zoe",
+          coachee_last_name: "Zimmerman",
+        }),
+        createMockRelationship({
+          id: "r-alice",
+          coach_id: "user-1",
+          coachee_first_name: "Alice",
+          coachee_last_name: "Anderson",
+        }),
+        createMockRelationship({
+          id: "r-mike",
+          coach_id: "user-1",
+          coachee_first_name: "Mike",
+          coachee_last_name: "Miller",
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    });
+
+    renderCreateForm();
+
+    fireEvent.click(screen.getByRole("combobox"));
+
+    const optionNames = screen
+      .getAllByRole("option")
+      .map((o) => o.textContent?.trim());
+    expect(optionNames).toEqual([
+      "Alice Anderson",
+      "Mike Miller",
+      "Zoe Zimmerman",
+    ]);
+  });
+});
 
 describe("CoachingSessionForm – handleSubmit error handling", () => {
   /**

--- a/__tests__/types/coaching-relationship.test.ts
+++ b/__tests__/types/coaching-relationship.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { sortRelationshipsByParticipantName } from "@/types/coaching-relationship";
+import { createMockRelationship } from "../test-utils";
+
+describe("sortRelationshipsByParticipantName", () => {
+  const coachId = "user-coach";
+
+  it("sorts by coachee full name when the user is the coach", () => {
+    const unsorted = [
+      createMockRelationship({
+        id: "r-1",
+        coach_id: coachId,
+        coachee_first_name: "Zoe",
+        coachee_last_name: "Zimmerman",
+      }),
+      createMockRelationship({
+        id: "r-2",
+        coach_id: coachId,
+        coachee_first_name: "Alice",
+        coachee_last_name: "Anderson",
+      }),
+      createMockRelationship({
+        id: "r-3",
+        coach_id: coachId,
+        coachee_first_name: "Mike",
+        coachee_last_name: "Miller",
+      }),
+    ];
+
+    const sorted = sortRelationshipsByParticipantName(unsorted, coachId);
+
+    expect(sorted.map((r) => r.id)).toEqual(["r-2", "r-3", "r-1"]);
+  });
+
+  it("sorts by coach full name when the user is the coachee", () => {
+    const coacheeId = "user-coachee";
+    const unsorted = [
+      createMockRelationship({
+        id: "r-1",
+        coachee_id: coacheeId,
+        coach_id: "other-1",
+        coach_first_name: "Zach",
+        coach_last_name: "Zeller",
+      }),
+      createMockRelationship({
+        id: "r-2",
+        coachee_id: coacheeId,
+        coach_id: "other-2",
+        coach_first_name: "Beth",
+        coach_last_name: "Brown",
+      }),
+    ];
+
+    const sorted = sortRelationshipsByParticipantName(unsorted, coacheeId);
+
+    expect(sorted.map((r) => r.id)).toEqual(["r-2", "r-1"]);
+  });
+
+  it("is case-insensitive via localeCompare", () => {
+    const unsorted = [
+      createMockRelationship({
+        id: "r-lower",
+        coach_id: coachId,
+        coachee_first_name: "bob",
+        coachee_last_name: "brown",
+      }),
+      createMockRelationship({
+        id: "r-upper",
+        coach_id: coachId,
+        coachee_first_name: "Alice",
+        coachee_last_name: "Anderson",
+      }),
+    ];
+
+    const sorted = sortRelationshipsByParticipantName(unsorted, coachId);
+
+    expect(sorted.map((r) => r.id)).toEqual(["r-upper", "r-lower"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [
+      createMockRelationship({
+        id: "r-1",
+        coach_id: coachId,
+        coachee_first_name: "Zoe",
+      }),
+      createMockRelationship({
+        id: "r-2",
+        coach_id: coachId,
+        coachee_first_name: "Alice",
+      }),
+    ];
+    const originalOrder = input.map((r) => r.id);
+
+    sortRelationshipsByParticipantName(input, coachId);
+
+    expect(input.map((r) => r.id)).toEqual(originalOrder);
+  });
+
+  it("returns an empty array when given an empty array", () => {
+    expect(sortRelationshipsByParticipantName([], coachId)).toEqual([]);
+  });
+});

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -1,5 +1,8 @@
 import { CoachingSession } from "@/types/coaching-session";
-import { getRelationshipsAsCoach } from "@/types/coaching-relationship";
+import {
+  getRelationshipsAsCoach,
+  sortRelationshipsByParticipantName,
+} from "@/types/coaching-relationship";
 import { Label } from "@/components/ui/label";
 import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
@@ -63,10 +66,11 @@ export default function CoachingSessionForm({
     useCoachingRelationshipList(currentOrganizationId ?? "");
   const { connections } = useOAuthConnections();
 
-  // Filter to relationships where current user is the coach
+  // Filter to relationships where current user is the coach, sorted alphabetically by coachee name
   const coacheeRelationships = useMemo(() => {
     if (!userSession?.id || !relationships) return [];
-    return getRelationshipsAsCoach(userSession.id, relationships);
+    const asCoach = getRelationshipsAsCoach(userSession.id, relationships);
+    return sortRelationshipsByParticipantName(asCoach, userSession.id);
   }, [relationships, userSession?.id]);
 
   // State for selected coachee in create mode


### PR DESCRIPTION
## Description
The coachee dropdown in the "Create New Coaching Session" dialog (opened from the dashboard "Add New" button) was rendering relationships in their unsorted fetch order. This applies the existing `sortRelationshipsByParticipantName` helper — the same one used by `CoachingRelationshipSelector` — so the options are alphabetical.

### Changes
* `src/components/ui/dashboard/coaching-session-form.tsx` — wrap `getRelationshipsAsCoach(...)` in `sortRelationshipsByParticipantName(...)` inside the `coacheeRelationships` memo
* `__tests__/types/coaching-relationship.test.ts` — new unit tests for `sortRelationshipsByParticipantName` (previously uncovered; used by three components)
* `__tests__/components/ui/dashboard/coaching-session-form.test.tsx` — new assertion that the rendered dropdown options appear alphabetically in create mode

### Screenshots / Videos Showing UI Changes (if applicable)
N/A

### Testing Strategy
1. `npx vitest run __tests__/types/coaching-relationship.test.ts __tests__/components/ui/dashboard/coaching-session-form.test.tsx` — all pass (12 tests).
2. Manual: from the dashboard, click "Add New" → open the "Select Coachee" dropdown → verify coachees are listed alphabetically by full name.