### PR TITLE
Use relative due_by dates in actions e2e mocks to prevent time bomb

### DIFF
--- a/__tests__/e2e/action-edit-textarea-scroll.spec.ts
+++ b/__tests__/e2e/action-edit-textarea-scroll.spec.ts
@@ -45,6 +45,12 @@ const LONG_ACTION_BODY = [
   'Line 10: Plan the next iteration of the feature roadmap.',
 ].join('\n')
 
+// Keep `due_by` near "today" so the kanban page's default Last-30-days time
+// filter always includes these mock actions. Hardcoded dates cause the test to
+// silently start failing once the test run date drifts past 30 days from the
+// chosen value.
+const DUE_BY_ISO = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+
 function mockAction(id: string, sessionId: string, body: string) {
   return {
     id,
@@ -53,7 +59,7 @@ function mockAction(id: string, sessionId: string, body: string) {
     user_id: MOCK_USER_ID,
     status: 'NotStarted',
     status_changed_at: '2026-03-25T10:00:00Z',
-    due_by: '2026-04-01T00:00:00Z',
+    due_by: DUE_BY_ISO,
     created_at: '2026-03-25T10:00:00Z',
     updated_at: '2026-03-25T10:00:00Z',
     assignee_ids: [COACH_ID],

--- a/__tests__/e2e/actions-exit-animation.spec.ts
+++ b/__tests__/e2e/actions-exit-animation.spec.ts
@@ -53,6 +53,12 @@ const ENRICHED_SESSION = {
   }],
 }
 
+// Keep `due_by` near "today" so the kanban page's default Last-30-days time
+// filter always includes these mock actions. Hardcoded dates cause the test to
+// silently start failing once the test run date drifts past 30 days from the
+// chosen value.
+const DUE_BY_ISO = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()
+
 function mockAction(
   id: string,
   status: string,
@@ -65,7 +71,7 @@ function mockAction(
     user_id: MOCK_USER_ID,
     status,
     status_changed_at: '2026-02-15T00:00:00Z',
-    due_by: '2026-03-15T00:00:00Z',
+    due_by: DUE_BY_ISO,
     created_at: '2026-02-01T00:00:00Z',
     updated_at: '2026-02-01T00:00:00Z',
     assignee_ids: [MOCK_USER_ID],


### PR DESCRIPTION
## Description
Two actions-page e2e specs used hardcoded `due_by` ISO strings in their mocked action payloads. The kanban page (`/actions`) applies a default `Last 30 days` time filter on `action.due_by`, so once the test run date drifts past 30 days from the hardcoded value, every mock action gets filtered out before render. The result: the kanban renders empty — no cards, no `[role="combobox"]` status pills, all column count badges showing 0 — producing errors like `No visible combobox found in the card` and missing count-badge assertions.

`actions-exit-animation.spec.ts` had already tripped this (`due_by: '2026-03-15'` is outside today's 30-day window). `action-edit-textarea-scroll.spec.ts` had `due_by: '2026-04-01'` which is still inside the window but would break within about two weeks — fixing both together.

### Changes
* Replace the hardcoded `due_by` literal with a module-scope `DUE_BY_ISO = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString()` in both specs — always 7 days in the future, so the filter never excludes the mocks.
* Short comment in each spec explaining the time-bomb hazard so future readers don't re-introduce a fixed date.

### Testing Strategy
* Re-run the Build & Test job: the 10 previously-failing tests in `actions-exit-animation.spec.ts` (chromium + firefox) should pass.
* Visual / local verification optional: open the `/actions` page with the mocks — the "Not Started" column should show count `2` with two cards visible.

### Concerns
* The fix is surgical and doesn't touch page logic. The underlying time filter is intentional product behavior, so these specs will always need their `due_by` to be recent relative to the run time. The comment in each spec documents this constraint.