### PR TITLE
Correct Goals Overview heading per user role in session

### DIFF
--- a/__tests__/components/ui/dashboard/goals-overview-card.test.tsx
+++ b/__tests__/components/ui/dashboard/goals-overview-card.test.tsx
@@ -26,14 +26,14 @@ vi.mock("@/lib/providers/auth-store-provider", () => ({
 }));
 
 // Session utilities are pure; we mock them to isolate the card's behavior
-// (their own tests cover participant-name resolution).
+// (their own tests cover participant-info resolution).
 const mockSelectNextUpcomingSession = vi.fn();
-const mockGetSessionParticipantName = vi.fn();
+const mockGetSessionParticipantInfo = vi.fn();
 vi.mock("@/lib/utils/session", () => ({
   selectNextUpcomingSession: (...args: unknown[]) =>
     mockSelectNextUpcomingSession(...args),
-  getSessionParticipantName: (...args: unknown[]) =>
-    mockGetSessionParticipantName(...args),
+  getSessionParticipantInfo: (...args: unknown[]) =>
+    mockGetSessionParticipantInfo(...args),
 }));
 
 // ── Fixtures ───────────────────────────────────────────────────────────
@@ -72,9 +72,10 @@ function makeUpcomingSession() {
 }
 
 /**
- * Default: a logged-in user with an upcoming session resolvable to "Alex
- * Chen". The card trusts the server's response — tests mock whatever goals
- * the server would return for `?coaching_session_id=sess-1&assignee=coachee`.
+ * Default: a logged-in user who is the COACH in an upcoming session whose
+ * coachee is "Alex Chen". The card trusts the server's response — tests mock
+ * whatever goals the server would return for
+ * `?coaching_session_id=sess-1&assignee=coachee`.
  */
 function setupDefault() {
   const session = makeUpcomingSession();
@@ -86,7 +87,14 @@ function setupDefault() {
     refresh: vi.fn(),
   });
   mockSelectNextUpcomingSession.mockReturnValue(session);
-  mockGetSessionParticipantName.mockReturnValue("Alex Chen");
+  mockGetSessionParticipantInfo.mockReturnValue({
+    participantName: "Alex Chen",
+    firstName: "Alex",
+    lastName: "Chen",
+    userRole: "Coach",
+    isCoach: true,
+    isMissing: false,
+  });
 }
 
 describe("GoalsOverviewCard", () => {
@@ -114,7 +122,11 @@ describe("GoalsOverviewCard", () => {
     expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
   });
 
-  it("renders the empty state when there is no upcoming session", () => {
+  it("renders the empty state with role-neutral copy when there is no upcoming session", () => {
+    // Without an upcoming session there's no relationship to derive a role
+    // from, so the copy must be role-neutral — never "your coachee's" (wrong
+    // for users who are never a coach) and never "your" (wrong for users who
+    // are only coaches).
     mockAuthStore.mockReturnValue({ userId: "user-1" });
     mockUseTodaysSessions.mockReturnValue({
       sessions: [],
@@ -132,6 +144,12 @@ describe("GoalsOverviewCard", () => {
 
     render(<GoalsOverviewCard />);
     expect(screen.getByText("No active goals to show")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "When you have an upcoming session, active goals will appear here."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/coachee['’]s/i)).not.toBeInTheDocument();
   });
 
   it("renders an inline error message when goal_progress fails", () => {
@@ -149,7 +167,7 @@ describe("GoalsOverviewCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders the coachee name and the goal count returned by the server", () => {
+  it("renders the coachee name and the goal count when the user is the coach", () => {
     // Card trusts the server's filtered+scoped response — whatever goals it
     // gets back are the goals it renders.
     const goals = [
@@ -165,10 +183,39 @@ describe("GoalsOverviewCard", () => {
     });
 
     render(<GoalsOverviewCard />);
-    expect(screen.getByText("Alex Chen's active goals")).toBeInTheDocument();
+    expect(screen.getByText("Alex Chen’s active goals")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByText("Goal A")).toBeInTheDocument();
     expect(screen.getByText("Goal B")).toBeInTheDocument();
+  });
+
+  it("renders 'Your active goals' when the user is the coachee in the upcoming session", () => {
+    // The server already returned coachee-scoped goals — i.e., the user's own
+    // goals — so the heading should refer to the user themself, not the coach.
+    const goals = [makeGoalWithProgress({ goal_id: "g1", title: "Goal A" })];
+    setupDefault();
+    mockGetSessionParticipantInfo.mockReturnValue({
+      participantName: "Bob Coach",
+      firstName: "Bob",
+      lastName: "Coach",
+      userRole: "Coachee",
+      isCoach: false,
+      isMissing: false,
+    });
+    mockUseGoalProgressList.mockReturnValue({
+      goalsWithProgress: goals,
+      isLoading: false,
+      isError: undefined,
+      refresh: vi.fn(),
+    });
+
+    render(<GoalsOverviewCard />);
+    expect(screen.getByText("Your active goals")).toBeInTheDocument();
+    // The coach's name must NOT appear in the heading even though
+    // getSessionParticipantInfo returns it as the "other participant".
+    expect(
+      screen.queryByText("Bob Coach’s active goals")
+    ).not.toBeInTheDocument();
   });
 
   it("shows 'No active goals' when the server returns an empty list", () => {
@@ -355,7 +402,14 @@ describe("GoalsOverviewCard", () => {
       refresh: vi.fn(),
     });
     mockSelectNextUpcomingSession.mockReturnValue(partial);
-    mockGetSessionParticipantName.mockReturnValue("Alex Chen");
+    mockGetSessionParticipantInfo.mockReturnValue({
+      participantName: "Alex Chen",
+      firstName: "Alex",
+      lastName: "Chen",
+      userRole: "Coach",
+      isCoach: true,
+      isMissing: false,
+    });
     mockUseGoalProgressList.mockReturnValue({
       goalsWithProgress: [],
       isLoading: false,

--- a/src/components/ui/dashboard/goals-overview-card-empty.tsx
+++ b/src/components/ui/dashboard/goals-overview-card-empty.tsx
@@ -23,8 +23,7 @@ export function GoalsOverviewCardEmpty() {
               No active goals to show
             </p>
             <p className="text-xs text-muted-foreground">
-              When you have an upcoming session, your coachee&apos;s active
-              goals will appear here.
+              When you have an upcoming session, active goals will appear here.
             </p>
           </div>
         </div>

--- a/src/components/ui/dashboard/goals-overview-card.tsx
+++ b/src/components/ui/dashboard/goals-overview-card.tsx
@@ -20,7 +20,7 @@ import { useGoalProgressList } from "@/lib/api/goal-progress";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useTodaysSessions } from "@/lib/hooks/use-todays-sessions";
 import {
-  getSessionParticipantName,
+  getSessionParticipantInfo,
   selectNextUpcomingSession,
 } from "@/lib/utils/session";
 import { GoalProgress } from "@/types/goal-progress";
@@ -168,9 +168,12 @@ export function GoalsOverviewCard() {
   // 404 from a relationship the caller isn't in, 5xx, etc.).
   if (isError) return <GoalsOverviewCardError />;
 
-  const coacheeName = userId
-    ? getSessionParticipantName(upcomingSession, userId)
-    : "";
+  // Resolve the user's role in this specific session — org-wide isACoach
+  // can't disambiguate users who are coach in one relationship and coachee in
+  // another within the same org.
+  const participantInfo = userId
+    ? getSessionParticipantInfo(upcomingSession, userId)
+    : null;
 
   // Server already filtered to this session's linked goals + coachee scope;
   // render whatever it returned.
@@ -212,7 +215,9 @@ export function GoalsOverviewCard() {
                 <ProgressRing percent={overallPercent} />
                 <div>
                   <p className="text-xs text-muted-foreground">
-                    {coacheeName}&apos;s active goals
+                    {participantInfo?.isCoach
+                      ? `${participantInfo.participantName}’s active goals`
+                      : "Your active goals"}
                   </p>
                   <p className="text-lg font-semibold tabular-nums -mt-0.5">
                     {activeGoals.length}


### PR DESCRIPTION
## Description
The dashboard's Goals Overview card was rendering an incorrect heading for users who are the coachee in their upcoming session. The card always derived the heading from the *other* participant's name, producing `<coach name>'s active goals` for a coachee — even though the goals shown are the coachee's own. The empty state was hardcoded to "your coachee's active goals", which is wrong for any user who is never a coach.

#### GitHub Issue: N/A

### Changes
* `goals-overview-card.tsx`: switched from `getSessionParticipantName` to `getSessionParticipantInfo` so we know the user's role in the *specific* upcoming session. When the user is the coach in that session, heading reads `<coachee name>'s active goals`; when the user is the coachee, heading reads `Your active goals`.
* `goals-overview-card-empty.tsx`: dropped role-specific copy (there is no session to derive role from in the empty state) and replaced with neutral "When you have an upcoming session, active goals will appear here."

### Screenshots / Videos Showing UI Changes
N/A

### Testing Strategy
* Sign in as a coach with an upcoming session today → verify heading shows `<coachee name>'s active goals`.
* Sign in as a coachee with an upcoming session today → verify heading shows `Your active goals`.
* Sign in as a hybrid user (coach in one relationship, coachee in another, same org) and confirm the heading correctly reflects the role in whichever session is next.
* Sign in as any user with no upcoming session today → verify the empty card reads "When you have an upcoming session, active goals will appear here."

### Concerns
None. Behavior change is limited to user-facing copy on the dashboard Goals Overview card; no API or data-shape changes.