### PR TITLE
Align goal-session link error handling with BE wire formats

### DIFF
--- a/__tests__/components/ui/coaching-sessions/goal-flow.test.ts
+++ b/__tests__/components/ui/coaching-sessions/goal-flow.test.ts
@@ -3,7 +3,11 @@ import { renderHook, act } from '@testing-library/react'
 import { DateTime } from 'ts-luxon'
 import { ItemStatus } from '@/types/general'
 import type { Goal, InProgressGoalSummary } from '@/types/goal'
-import { useGoalFlow, GoalFlowStep } from '@/components/ui/coaching-sessions/goal-flow'
+import {
+  useGoalFlow,
+  GoalFlowStep,
+  type LinkAttemptResult,
+} from '@/components/ui/coaching-sessions/goal-flow'
 
 function makeGoal(id: string, overrides: Partial<Goal> = {}): Goal {
   const now = DateTime.now()
@@ -28,13 +32,17 @@ interface HarnessOptions {
   atLimit?: boolean
   allGoals?: Goal[]
   linkedGoalIds?: Set<string>
+  onLinkResult?: LinkAttemptResult
 }
 
 function setupFlow(options: HarnessOptions = {}) {
-  const onLink = vi.fn()
+  const onLink = vi.fn(async (_goalId: string): Promise<LinkAttemptResult> => {
+    return options.onLinkResult ?? { kind: 'done' }
+  })
   const onSwapAndLink = vi.fn()
   const onCreateAndLink = vi.fn()
   const onCreateAndSwap = vi.fn()
+  const onRefreshGoals = vi.fn()
   const { result } = renderHook(() =>
     useGoalFlow({
       atLimit: options.atLimit ?? false,
@@ -44,13 +52,14 @@ function setupFlow(options: HarnessOptions = {}) {
       onSwapAndLink,
       onCreateAndLink,
       onCreateAndSwap,
+      onRefreshGoals,
     })
   )
-  return { result, onLink, onSwapAndLink, onCreateAndLink, onCreateAndSwap }
+  return { result, onLink, onSwapAndLink, onCreateAndLink, onCreateAndSwap, onRefreshGoals }
 }
 
 describe('useGoalFlow — proactive swap path (existing behavior)', () => {
-  it('Add → atLimit → SelectingSwap → pick demote → Browsing(swapGoalId) → pick replacement → onSwapAndLink', () => {
+  it('Add → atLimit → SelectingSwap → pick demote → Browsing(swapGoalId) → pick replacement → onSwapAndLink', async () => {
     const linked = [makeGoal('g1'), makeGoal('g2'), makeGoal('g3')]
     const replacement = makeGoal('g4', { status: ItemStatus.OnHold })
     const { result, onSwapAndLink } = setupFlow({
@@ -67,12 +76,12 @@ describe('useGoalFlow — proactive swap path (existing behavior)', () => {
     act(() => result.current.handleSwapSelected('g2'))
     expect(result.current.flow).toEqual({ step: GoalFlowStep.Browsing, swapGoalId: 'g2' })
 
-    act(() => result.current.handleBrowseGoalClick('g4'))
+    await act(async () => { await result.current.handleBrowseGoalClick('g4') })
     expect(onSwapAndLink).toHaveBeenCalledWith('g4', 'g2')
     expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
   })
 
-  it('Add → !atLimit → Browsing → pick existing → onLink', () => {
+  it('Add → !atLimit → Browsing → pick existing → onLink', async () => {
     const candidate = makeGoal('g4', { status: ItemStatus.OnHold })
     const { result, onLink, onSwapAndLink } = setupFlow({
       atLimit: false,
@@ -83,7 +92,7 @@ describe('useGoalFlow — proactive swap path (existing behavior)', () => {
     act(() => result.current.handleAddGoalClick())
     expect(result.current.flow.step).toBe(GoalFlowStep.Browsing)
 
-    act(() => result.current.handleBrowseGoalClick('g4'))
+    await act(async () => { await result.current.handleBrowseGoalClick('g4') })
     expect(onLink).toHaveBeenCalledWith('g4')
     expect(onSwapAndLink).not.toHaveBeenCalled()
     expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
@@ -91,64 +100,87 @@ describe('useGoalFlow — proactive swap path (existing behavior)', () => {
 })
 
 describe('useGoalFlow — 409-recovery swap path (new behavior)', () => {
-  it('enterSwapForLink seeds the dialog with BE-supplied candidates and resolves via onSwapAndLink', () => {
-    // After clicking +Add for an OnHold goal "g4" the BE returns 409 with
-    // its own InProgress list [g1, g2, g3]. enterSwapForLink should open
-    // the swap dialog using those goals as candidates, and after the user
-    // picks one, the flow should call onSwapAndLink('g4', <picked>).
+  it('onLink returning needs-swap-recovery transitions to SelectingSwap and resolves via onSwapAndLink', async () => {
+    // The user clicks an OnHold goal "g4" in the browse view. The panel's
+    // handleLink hits the BE, gets a 409, and returns
+    // { kind: "needs-swap-recovery", candidates: [g1,g2,g3] }. The hook
+    // should transition to SelectingSwap with those candidates, and after
+    // the user picks one, resolve via onSwapAndLink('g4', <picked>).
     const inProgress = [
       makeGoal('g1'),
       makeGoal('g2'),
       makeGoal('g3'),
     ]
     const pendingGoal = makeGoal('g4', { status: ItemStatus.OnHold })
+    const candidates: InProgressGoalSummary[] = inProgress.map((g) => ({ id: g.id, title: g.title }))
 
-    const { result, onSwapAndLink, onLink } = setupFlow({
+    const { result, onSwapAndLink, onLink, onRefreshGoals } = setupFlow({
       atLimit: false,
       allGoals: [...inProgress, pendingGoal],
-      linkedGoalIds: new Set(['g1']), // session has 1 linked, relationship has 3 InProgress
+      linkedGoalIds: new Set(['g1']),
+      onLinkResult: { kind: 'needs-swap-recovery', candidates },
     })
 
-    const candidates: InProgressGoalSummary[] = inProgress.map((g) => ({ id: g.id, title: g.title }))
-    act(() => result.current.enterSwapForLink('g4', candidates))
+    act(() => result.current.handleAddGoalClick())
+    expect(result.current.flow.step).toBe(GoalFlowStep.Browsing)
 
+    await act(async () => { await result.current.handleBrowseGoalClick('g4') })
+
+    expect(onLink).toHaveBeenCalledWith('g4')
     expect(result.current.flow.step).toBe(GoalFlowStep.SelectingSwap)
     expect(result.current.swapCandidates.map((g) => g.id)).toEqual(['g1', 'g2', 'g3'])
+    // FE just learned its view is stale; refresh fires unconditionally on
+    // entry to 409-recovery so candidates resolve as the cache repopulates.
+    expect(onRefreshGoals).toHaveBeenCalledTimes(1)
 
     act(() => result.current.handleSwapSelected('g2'))
     // Crucial: resolves via onSwapAndLink (NOT a transition to Browsing).
     expect(onSwapAndLink).toHaveBeenCalledWith('g4', 'g2')
-    expect(onLink).not.toHaveBeenCalled()
     expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
   })
 
-  it('filters BE-supplied candidates that are missing from local allGoals', () => {
+  it('filters BE-supplied candidates that are missing from local allGoals (refresh repopulates them)', async () => {
     // Stale FE state: BE says g1, g2, g3 are InProgress, but FE only has
-    // g1 and g3 cached. Show what's resolvable; user picks from those.
+    // g1 and g3 cached. swapCandidates filters to what's resolvable for
+    // the moment; the auto-refresh fired on entry will repopulate.
     const allGoals = [makeGoal('g1'), makeGoal('g3'), makeGoal('g4', { status: ItemStatus.OnHold })]
-    const { result } = setupFlow({ atLimit: false, allGoals, linkedGoalIds: new Set() })
+    const { result, onRefreshGoals } = setupFlow({
+      atLimit: false,
+      allGoals,
+      linkedGoalIds: new Set(),
+      onLinkResult: {
+        kind: 'needs-swap-recovery',
+        candidates: [
+          { id: 'g1', title: 'one' },
+          { id: 'g2', title: 'two-but-stale' },
+          { id: 'g3', title: 'three' },
+        ],
+      },
+    })
 
-    act(() =>
-      result.current.enterSwapForLink('g4', [
-        { id: 'g1', title: 'one' },
-        { id: 'g2', title: 'two-but-stale' },
-        { id: 'g3', title: 'three' },
-      ])
-    )
+    act(() => result.current.handleAddGoalClick())
+    await act(async () => { await result.current.handleBrowseGoalClick('g4') })
+
     expect(result.current.swapCandidates.map((g) => g.id)).toEqual(['g1', 'g3'])
+    expect(onRefreshGoals).toHaveBeenCalledTimes(1)
   })
 
-  it('handleCancel from 409-recovery returns to Idle without invoking either callback', () => {
-    const { result, onLink, onSwapAndLink } = setupFlow({
+  it('handleCancel from 409-recovery returns to Idle without invoking onSwapAndLink', async () => {
+    const { result, onSwapAndLink } = setupFlow({
       atLimit: false,
-      allGoals: [makeGoal('g1')],
+      allGoals: [makeGoal('g1'), makeGoal('g4', { status: ItemStatus.OnHold })],
+      onLinkResult: {
+        kind: 'needs-swap-recovery',
+        candidates: [{ id: 'g1', title: 'one' }],
+      },
     })
-    act(() =>
-      result.current.enterSwapForLink('g4', [{ id: 'g1', title: 'one' }])
-    )
+
+    act(() => result.current.handleAddGoalClick())
+    await act(async () => { await result.current.handleBrowseGoalClick('g4') })
+    expect(result.current.flow.step).toBe(GoalFlowStep.SelectingSwap)
+
     act(() => result.current.handleCancel())
     expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
-    expect(onLink).not.toHaveBeenCalled()
     expect(onSwapAndLink).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/components/ui/coaching-sessions/goal-flow.test.ts
+++ b/__tests__/components/ui/coaching-sessions/goal-flow.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { DateTime } from 'ts-luxon'
+import { ItemStatus } from '@/types/general'
+import type { Goal, InProgressGoalSummary } from '@/types/goal'
+import { useGoalFlow, GoalFlowStep } from '@/components/ui/coaching-sessions/goal-flow'
+
+function makeGoal(id: string, overrides: Partial<Goal> = {}): Goal {
+  const now = DateTime.now()
+  return {
+    id,
+    coaching_relationship_id: 'rel-1',
+    created_in_session_id: null,
+    user_id: 'user-1',
+    title: `Goal ${id}`,
+    body: '',
+    status: ItemStatus.InProgress,
+    status_changed_at: now,
+    completed_at: now,
+    target_date: null,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  }
+}
+
+interface HarnessOptions {
+  atLimit?: boolean
+  allGoals?: Goal[]
+  linkedGoalIds?: Set<string>
+}
+
+function setupFlow(options: HarnessOptions = {}) {
+  const onLink = vi.fn()
+  const onSwapAndLink = vi.fn()
+  const onCreateAndLink = vi.fn()
+  const onCreateAndSwap = vi.fn()
+  const { result } = renderHook(() =>
+    useGoalFlow({
+      atLimit: options.atLimit ?? false,
+      allGoals: options.allGoals ?? [],
+      linkedGoalIds: options.linkedGoalIds ?? new Set(),
+      onLink,
+      onSwapAndLink,
+      onCreateAndLink,
+      onCreateAndSwap,
+    })
+  )
+  return { result, onLink, onSwapAndLink, onCreateAndLink, onCreateAndSwap }
+}
+
+describe('useGoalFlow — proactive swap path (existing behavior)', () => {
+  it('Add → atLimit → SelectingSwap → pick demote → Browsing(swapGoalId) → pick replacement → onSwapAndLink', () => {
+    const linked = [makeGoal('g1'), makeGoal('g2'), makeGoal('g3')]
+    const replacement = makeGoal('g4', { status: ItemStatus.OnHold })
+    const { result, onSwapAndLink } = setupFlow({
+      atLimit: true,
+      allGoals: [...linked, replacement],
+      linkedGoalIds: new Set(['g1', 'g2', 'g3']),
+    })
+
+    act(() => result.current.handleAddGoalClick())
+    expect(result.current.flow.step).toBe(GoalFlowStep.SelectingSwap)
+    // No override → display session-linked goals as candidates
+    expect(result.current.swapCandidates.map((g) => g.id)).toEqual(['g1', 'g2', 'g3'])
+
+    act(() => result.current.handleSwapSelected('g2'))
+    expect(result.current.flow).toEqual({ step: GoalFlowStep.Browsing, swapGoalId: 'g2' })
+
+    act(() => result.current.handleBrowseGoalClick('g4'))
+    expect(onSwapAndLink).toHaveBeenCalledWith('g4', 'g2')
+    expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
+  })
+
+  it('Add → !atLimit → Browsing → pick existing → onLink', () => {
+    const candidate = makeGoal('g4', { status: ItemStatus.OnHold })
+    const { result, onLink, onSwapAndLink } = setupFlow({
+      atLimit: false,
+      allGoals: [candidate],
+      linkedGoalIds: new Set(),
+    })
+
+    act(() => result.current.handleAddGoalClick())
+    expect(result.current.flow.step).toBe(GoalFlowStep.Browsing)
+
+    act(() => result.current.handleBrowseGoalClick('g4'))
+    expect(onLink).toHaveBeenCalledWith('g4')
+    expect(onSwapAndLink).not.toHaveBeenCalled()
+    expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
+  })
+})
+
+describe('useGoalFlow — 409-recovery swap path (new behavior)', () => {
+  it('enterSwapForLink seeds the dialog with BE-supplied candidates and resolves via onSwapAndLink', () => {
+    // After clicking +Add for an OnHold goal "g4" the BE returns 409 with
+    // its own InProgress list [g1, g2, g3]. enterSwapForLink should open
+    // the swap dialog using those goals as candidates, and after the user
+    // picks one, the flow should call onSwapAndLink('g4', <picked>).
+    const inProgress = [
+      makeGoal('g1'),
+      makeGoal('g2'),
+      makeGoal('g3'),
+    ]
+    const pendingGoal = makeGoal('g4', { status: ItemStatus.OnHold })
+
+    const { result, onSwapAndLink, onLink } = setupFlow({
+      atLimit: false,
+      allGoals: [...inProgress, pendingGoal],
+      linkedGoalIds: new Set(['g1']), // session has 1 linked, relationship has 3 InProgress
+    })
+
+    const candidates: InProgressGoalSummary[] = inProgress.map((g) => ({ id: g.id, title: g.title }))
+    act(() => result.current.enterSwapForLink('g4', candidates))
+
+    expect(result.current.flow.step).toBe(GoalFlowStep.SelectingSwap)
+    expect(result.current.swapCandidates.map((g) => g.id)).toEqual(['g1', 'g2', 'g3'])
+
+    act(() => result.current.handleSwapSelected('g2'))
+    // Crucial: resolves via onSwapAndLink (NOT a transition to Browsing).
+    expect(onSwapAndLink).toHaveBeenCalledWith('g4', 'g2')
+    expect(onLink).not.toHaveBeenCalled()
+    expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
+  })
+
+  it('filters BE-supplied candidates that are missing from local allGoals', () => {
+    // Stale FE state: BE says g1, g2, g3 are InProgress, but FE only has
+    // g1 and g3 cached. Show what's resolvable; user picks from those.
+    const allGoals = [makeGoal('g1'), makeGoal('g3'), makeGoal('g4', { status: ItemStatus.OnHold })]
+    const { result } = setupFlow({ atLimit: false, allGoals, linkedGoalIds: new Set() })
+
+    act(() =>
+      result.current.enterSwapForLink('g4', [
+        { id: 'g1', title: 'one' },
+        { id: 'g2', title: 'two-but-stale' },
+        { id: 'g3', title: 'three' },
+      ])
+    )
+    expect(result.current.swapCandidates.map((g) => g.id)).toEqual(['g1', 'g3'])
+  })
+
+  it('handleCancel from 409-recovery returns to Idle without invoking either callback', () => {
+    const { result, onLink, onSwapAndLink } = setupFlow({
+      atLimit: false,
+      allGoals: [makeGoal('g1')],
+    })
+    act(() =>
+      result.current.enterSwapForLink('g4', [{ id: 'g1', title: 'one' }])
+    )
+    act(() => result.current.handleCancel())
+    expect(result.current.flow.step).toBe(GoalFlowStep.Idle)
+    expect(onLink).not.toHaveBeenCalled()
+    expect(onSwapAndLink).not.toHaveBeenCalled()
+  })
+})

--- a/__tests__/types/goal.test.ts
+++ b/__tests__/types/goal.test.ts
@@ -12,6 +12,7 @@ import {
   goalsToString,
   extractActiveGoalLimitError,
   isCannotLinkCompletedGoalError,
+  isGoalAlreadyLinkedToSessionError,
 } from '@/types/goal'
 import type { Goal } from '@/types/goal'
 
@@ -309,5 +310,82 @@ describe('isCannotLinkCompletedGoalError', () => {
     expect(isCannotLinkCompletedGoalError(new Error('plain'))).toBe(false)
     expect(isCannotLinkCompletedGoalError(null)).toBe(false)
     expect(isCannotLinkCompletedGoalError(undefined)).toBe(false)
+  })
+})
+
+describe('isGoalAlreadyLinkedToSessionError', () => {
+  // Wire format: GoalAlreadyLinkedToSessionError v1 contract.
+  // Specific top-level discriminator (no `details` envelope), distinct
+  // from the cap-collision 409 which uses error: "conflict" + details.
+
+  it('returns true for the BE 409 goal_already_linked_to_session shape', () => {
+    const err = makeEntityApiError(409, {
+      status_code: 409,
+      error: 'goal_already_linked_to_session',
+      message: 'This goal is already linked to the coaching session.',
+    })
+    expect(isGoalAlreadyLinkedToSessionError(err)).toBe(true)
+  })
+
+  it('returns false for the cap-collision 409 (different discriminator)', () => {
+    const err = makeEntityApiError(409, {
+      error: 'conflict',
+      details: { max_in_progress_goals: 3, in_progress_goals: [] },
+    })
+    expect(isGoalAlreadyLinkedToSessionError(err)).toBe(false)
+  })
+
+  it('returns false for a 422 cannot_link_completed_goal response', () => {
+    const err = makeEntityApiError(422, { error: 'cannot_link_completed_goal' })
+    expect(isGoalAlreadyLinkedToSessionError(err)).toBe(false)
+  })
+
+  it('returns false for non-EntityApiError input', () => {
+    expect(isGoalAlreadyLinkedToSessionError(new Error('plain'))).toBe(false)
+    expect(isGoalAlreadyLinkedToSessionError(null)).toBe(false)
+    expect(isGoalAlreadyLinkedToSessionError(undefined)).toBe(false)
+  })
+})
+
+describe('link-endpoint error disambiguation', () => {
+  // The link endpoint POST /coaching_sessions/:id/goals can emit two
+  // structurally different 409s plus a structured 422. Each of the three
+  // parsers must match exactly one shape and reject the others. This
+  // test pins that mutual exclusion so future contract drift is caught
+  // at FE-test-time, not user-rendering-time.
+
+  const capCollision409 = {
+    status_code: 409,
+    error: 'conflict' as const,
+    message: 'cap',
+    details: { max_in_progress_goals: 3, in_progress_goals: [] },
+  }
+  const alreadyLinked409 = {
+    status_code: 409,
+    error: 'goal_already_linked_to_session' as const,
+    message: 'dup',
+  }
+  const completed422 = {
+    status_code: 422,
+    error: 'cannot_link_completed_goal' as const,
+    message: 'completed',
+  }
+
+  it('extractActiveGoalLimitError matches only the cap-collision 409', () => {
+    expect(extractActiveGoalLimitError(makeEntityApiError(409, capCollision409))).not.toBeNull()
+    expect(extractActiveGoalLimitError(makeEntityApiError(409, alreadyLinked409))).toBeNull()
+    expect(extractActiveGoalLimitError(makeEntityApiError(422, completed422))).toBeNull()
+  })
+
+  it('isGoalAlreadyLinkedToSessionError matches only the duplicate-link 409', () => {
+    expect(isGoalAlreadyLinkedToSessionError(makeEntityApiError(409, capCollision409))).toBe(false)
+    expect(isGoalAlreadyLinkedToSessionError(makeEntityApiError(409, alreadyLinked409))).toBe(true)
+    expect(isGoalAlreadyLinkedToSessionError(makeEntityApiError(422, completed422))).toBe(false)
+  })
+
+  it('isCannotLinkCompletedGoalError matches only the completed-goal 422', () => {
+    expect(isCannotLinkCompletedGoalError(makeEntityApiError(409, capCollision409))).toBe(false)
+    expect(isCannotLinkCompletedGoalError(makeEntityApiError(409, alreadyLinked409))).toBe(false)
+    expect(isCannotLinkCompletedGoalError(makeEntityApiError(422, completed422))).toBe(true)
   })
 })

--- a/__tests__/types/goal.test.ts
+++ b/__tests__/types/goal.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { DateTime } from 'ts-luxon'
-import { ItemStatus } from '@/types/general'
+import { ItemStatus, EntityApiError } from '@/types/general'
 import {
   isGoal,
   isGoalArray,
@@ -10,8 +10,18 @@ import {
   getGoalById,
   goalToString,
   goalsToString,
+  extractActiveGoalLimitError,
+  isCannotLinkCompletedGoalError,
 } from '@/types/goal'
 import type { Goal } from '@/types/goal'
+
+function makeEntityApiError(status: number, data: unknown): EntityApiError {
+  const axiosLikeError = Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { status, statusText: 'Error', data },
+  })
+  return new EntityApiError('POST', '/coaching_sessions/x/goals', axiosLikeError)
+}
 
 /** Factory for creating test Goal data matching the PR2 schema */
 function makeGoalData(overrides?: Partial<Record<string, unknown>>): Record<string, unknown> {
@@ -195,5 +205,109 @@ describe('goalToString / goalsToString', () => {
   it('serializes a goal array to JSON', () => {
     const json = goalsToString([defaultGoal()])
     expect(json).toContain('coaching_relationship_id')
+  })
+})
+
+describe('extractActiveGoalLimitError', () => {
+  // Wire format: ActiveGoalLimitConflict v1 contract on the coordination board.
+  // 409 carries a generic `error: "conflict"` and the limit info under `details`.
+
+  it('returns the limit info for the BE 409 conflict shape with details.in_progress_goals', () => {
+    const err = makeEntityApiError(409, {
+      status_code: 409,
+      error: 'conflict',
+      message: 'A coaching relationship can have at most 3 in-progress goals.',
+      details: {
+        max_in_progress_goals: 3,
+        in_progress_goals: [
+          { id: 'g1', title: 'Goal one' },
+          { id: 'g2', title: 'Goal two' },
+          { id: 'g3', title: 'Goal three' },
+        ],
+      },
+    })
+
+    const info = extractActiveGoalLimitError(err)
+    expect(info).not.toBeNull()
+    expect(info?.maxInProgressGoals).toBe(3)
+    expect(info?.inProgressGoals).toHaveLength(3)
+    expect(info?.inProgressGoals[0]).toEqual({ id: 'g1', title: 'Goal one' })
+  })
+
+  it('returns null for a 422 (wrong status)', () => {
+    const err = makeEntityApiError(422, {
+      details: { max_in_progress_goals: 3, in_progress_goals: [] },
+    })
+    expect(extractActiveGoalLimitError(err)).toBeNull()
+  })
+
+  it('returns null for a 409 without a details object', () => {
+    const err = makeEntityApiError(409, { error: 'conflict', message: 'other' })
+    expect(extractActiveGoalLimitError(err)).toBeNull()
+  })
+
+  it('returns null for a 409 with details missing max_in_progress_goals', () => {
+    const err = makeEntityApiError(409, {
+      error: 'conflict',
+      details: { in_progress_goals: [] },
+    })
+    expect(extractActiveGoalLimitError(err)).toBeNull()
+  })
+
+  it('returns null for a 409 with details missing in_progress_goals array', () => {
+    const err = makeEntityApiError(409, {
+      error: 'conflict',
+      details: { max_in_progress_goals: 3 },
+    })
+    expect(extractActiveGoalLimitError(err)).toBeNull()
+  })
+
+  it('returns null for the legacy active_goal_limit_reached top-level shape (no longer on the wire)', () => {
+    // Documents the regression that existed pre-fix: the BE stopped sending
+    // this shape on 2026-03-12. If a stub or older proxy ever surfaces it,
+    // the parser must still return null so the UI surfaces an honest error
+    // rather than a stale "limit reached" toast.
+    const err = makeEntityApiError(409, {
+      error: 'active_goal_limit_reached',
+      max_active_goals: 3,
+      active_goals: [{ id: 'g1', title: 'Goal one' }],
+    })
+    expect(extractActiveGoalLimitError(err)).toBeNull()
+  })
+
+  it('returns null for a non-EntityApiError input', () => {
+    expect(extractActiveGoalLimitError(new Error('plain'))).toBeNull()
+    expect(extractActiveGoalLimitError(null)).toBeNull()
+    expect(extractActiveGoalLimitError(undefined)).toBeNull()
+  })
+})
+
+describe('isCannotLinkCompletedGoalError', () => {
+  it('returns true for a 422 cannot_link_completed_goal response', () => {
+    const err = makeEntityApiError(422, {
+      status_code: 422,
+      error: 'cannot_link_completed_goal',
+      message: 'This goal is completed',
+    })
+    expect(isCannotLinkCompletedGoalError(err)).toBe(true)
+  })
+
+  it('returns false for a 422 with a different error code', () => {
+    const err = makeEntityApiError(422, { error: 'validation_failed' })
+    expect(isCannotLinkCompletedGoalError(err)).toBe(false)
+  })
+
+  it('returns false for a 409 in-progress-goal-limit conflict response', () => {
+    const err = makeEntityApiError(409, {
+      error: 'conflict',
+      details: { max_in_progress_goals: 3, in_progress_goals: [] },
+    })
+    expect(isCannotLinkCompletedGoalError(err)).toBe(false)
+  })
+
+  it('returns false for non-EntityApiError input', () => {
+    expect(isCannotLinkCompletedGoalError(new Error('plain'))).toBe(false)
+    expect(isCannotLinkCompletedGoalError(null)).toBe(false)
+    expect(isCannotLinkCompletedGoalError(undefined)).toBe(false)
   })
 })

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/components/lib/utils";
 import { toast } from "@/components/ui/use-toast";
@@ -39,6 +39,7 @@ import {
   isAtGoalLimit,
   isCannotLinkCompletedGoalError,
   maxActiveGoals,
+  type InProgressGoalSummary,
 } from "@/types/goal";
 import type { Id } from "@/types/general";
 import { ItemStatus } from "@/types/general";
@@ -189,14 +190,16 @@ export function GoalFlowPages({
         </div>
       );
 
-    case GoalFlowStep.SelectingSwap:
+    case GoalFlowStep.SelectingSwap: {
+      const isLinkRecovery = flow.pendingLinkGoalId !== undefined;
+      const prompt = isLinkRecovery
+        ? `You already have ${maxActiveGoals()} goals in progress. Pick one to put on hold so this one can replace it.`
+        : `You already have ${maxActiveGoals()} goals in progress. Select an existing goal to replace with a new one.`;
       return (
         <SlidePanel direction={goalFlow.direction}>
           <div className="rounded-lg border border-border bg-background p-3 space-y-3">
-            <p className="text-[12px] text-muted-foreground">
-              You already have {maxActiveGoals()} goals in progress. Select an existing goal to replace with a new one.
-            </p>
-            {linkedGoals.map((goal) => (
+            <p className="text-[12px] text-muted-foreground">{prompt}</p>
+            {goalFlow.swapCandidates.map((goal) => (
               <CompactGoalCard
                 key={goal.id}
                 goal={goal}
@@ -216,6 +219,7 @@ export function GoalFlowPages({
           </div>
         </SlidePanel>
       );
+    }
 
     case GoalFlowStep.Browsing:
       return (
@@ -315,6 +319,13 @@ export function CoachingSessionPanel({
 
   // ── Goal handlers ────────────────────────────────────────────────
 
+  // useGoalFlow consumes handleLink, but handleLink (on 409) needs to call
+  // back into the hook's enterSwapForLink. Break the cycle with a ref that
+  // we populate after useGoalFlow runs (assigned during render below).
+  const enterSwapForLinkRef = useRef<
+    ((goalId: string, candidates: InProgressGoalSummary[]) => void) | null
+  >(null);
+
   const handleLink = useCallback(
     async (goalId: string) => {
       // BE auto-promotes NotStarted/OnHold goals to InProgress atomically with
@@ -329,14 +340,12 @@ export function CoachingSessionPanel({
         (err) => {
           const limitInfo = extractActiveGoalLimitError(err);
           if (limitInfo) {
-            // TODO(goal_session_link_invariant): re-enter SelectingSwap with
-            // limitInfo.inProgressGoals as the demote candidates and goalId
-            // as the pending link target, then call onSwapAndLink on selection.
-            toast({
-              variant: "destructive",
-              title: "Goal limit reached",
-              description: `You already have ${limitInfo.maxInProgressGoals} goals in progress. Please complete or change the status of one before linking another.`,
-            });
+            // Re-open the swap dialog seeded with the BE-supplied InProgress
+            // goals. After the user picks a demote candidate, the flow
+            // resolves via onSwapAndLink(goalId, demoteId). Authoritative
+            // candidate list comes from details.in_progress_goals — the FE's
+            // own atLimit/linkedGoals view may be stale at this point.
+            enterSwapForLinkRef.current?.(goalId, limitInfo.inProgressGoals);
             return;
           }
           if (isCannotLinkCompletedGoalError(err)) {
@@ -623,6 +632,12 @@ export function CoachingSessionPanel({
     onCreateAndLink: handleCreateAndLink,
     onCreateAndSwap: handleCreateAndSwap,
   });
+
+  // Backfill the ref handleLink reads on 409. enterSwapForLink is memoized
+  // with empty deps inside the hook, so this is a one-shot assignment in
+  // practice — but tracking it on every render is cheap and avoids any
+  // staleness risk if the hook's memoization ever changes.
+  enterSwapForLinkRef.current = goalFlow.enterSwapForLink;
 
   // ── Action hooks & state ─────────────────────────────────────────
 

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/components/lib/utils";
 import { toast } from "@/components/ui/use-toast";
@@ -15,7 +15,7 @@ import {
   SlideDirection,
   useGoalFlow,
 } from "@/components/ui/coaching-sessions/goal-flow";
-import type { GoalFlowState } from "@/components/ui/coaching-sessions/goal-flow";
+import type { GoalFlowState, LinkAttemptResult } from "@/components/ui/coaching-sessions/goal-flow";
 import {
   useGoalsBySession,
   useGoalList,
@@ -40,7 +40,6 @@ import {
   isCannotLinkCompletedGoalError,
   isGoalAlreadyLinkedToSessionError,
   maxActiveGoals,
-  type InProgressGoalSummary,
 } from "@/types/goal";
 import type { Id } from "@/types/general";
 import { ItemStatus } from "@/types/general";
@@ -320,70 +319,64 @@ export function CoachingSessionPanel({
 
   // ── Goal handlers ────────────────────────────────────────────────
 
-  // useGoalFlow consumes handleLink, but handleLink (on 409) needs to call
-  // back into the hook's enterSwapForLink. Break the cycle with a ref that
-  // we populate after useGoalFlow runs (assigned during render below).
-  const enterSwapForLinkRef = useRef<
-    ((goalId: string, candidates: InProgressGoalSummary[]) => void) | null
-  >(null);
-
+  // Returns a LinkAttemptResult so useGoalFlow can react to a cap-collision
+  // 409 by transitioning into 409-recovery without a feedback cycle. All
+  // other terminal outcomes (success, already-linked, completed-goal,
+  // generic error) are handled inline with toasts/refreshes here.
   const handleLink = useCallback(
-    async (goalId: string) => {
+    async (goalId: string): Promise<LinkAttemptResult> => {
       // BE auto-promotes NotStarted/OnHold goals to InProgress atomically with
       // the join insert (see goal_session_link_invariant decision). FE must
       // NOT pre-promote — that races with the server's atomic write.
       const result = await GoalApi.linkToSession(coachingSessionId, goalId);
-      result.match(
-        () => {
-          refreshSessionGoals();
-          refreshAllGoals();
-        },
-        (err) => {
-          const limitInfo = extractActiveGoalLimitError(err);
-          if (limitInfo) {
-            // Re-open the swap dialog seeded with the BE-supplied InProgress
-            // goals. After the user picks a demote candidate, the flow
-            // resolves via onSwapAndLink(goalId, demoteId). Authoritative
-            // candidate list comes from details.in_progress_goals — the FE's
-            // own atLimit/linkedGoals view may be stale at this point.
-            enterSwapForLinkRef.current?.(goalId, limitInfo.inProgressGoals);
-            return;
-          }
-          if (isGoalAlreadyLinkedToSessionError(err)) {
-            // Race: another tab/window linked the same goal between when the
-            // FE's linkable list was computed and this request. The FE
-            // normally filters already-linked goals out of the picker, so
-            // this is rare in practice. Refresh state so the goal disappears
-            // from any visible list.
-            refreshSessionGoals();
-            refreshAllGoals();
-            const goal = allGoals.find((g) => g.id === goalId);
-            const name = goal ? goalTitle(goal) : "This goal";
-            toast({
-              variant: "destructive",
-              title: "Already linked",
-              description: `"${name}" is already linked to this session.`,
-            });
-            return;
-          }
-          if (isCannotLinkCompletedGoalError(err)) {
-            const goal = allGoals.find((g) => g.id === goalId);
-            const name = goal ? goalTitle(goal) : "This goal";
-            toast({
-              variant: "destructive",
-              title: "Goal is completed",
-              description: `"${name}" is completed. Reopen it to in-progress before linking it to a session.`,
-            });
-            return;
-          }
-          console.error("Failed to link goal:", err);
-          toast({
-            variant: "destructive",
-            title: "Failed to link goal",
-            description: err.message,
-          });
-        }
-      );
+      if (result.isOk()) {
+        refreshSessionGoals();
+        refreshAllGoals();
+        return { kind: "done" };
+      }
+
+      const err = result.error;
+      const limitInfo = extractActiveGoalLimitError(err);
+      if (limitInfo) {
+        // Authoritative candidate list comes from details.in_progress_goals —
+        // the FE's own atLimit/linkedGoals view may be stale at this point.
+        // The hook will transition to SelectingSwap; the panel doesn't toast.
+        return { kind: "needs-swap-recovery", candidates: limitInfo.inProgressGoals };
+      }
+      if (isGoalAlreadyLinkedToSessionError(err)) {
+        // Race: another tab/window linked the same goal between when the
+        // FE's linkable list was computed and this request. The FE
+        // normally filters already-linked goals out of the picker, so
+        // this is rare in practice. Refresh state so the goal disappears
+        // from any visible list.
+        refreshSessionGoals();
+        refreshAllGoals();
+        const goal = allGoals.find((g) => g.id === goalId);
+        const name = goal ? goalTitle(goal) : "This goal";
+        toast({
+          variant: "destructive",
+          title: "Already linked",
+          description: `"${name}" is already linked to this session.`,
+        });
+        return { kind: "done" };
+      }
+      if (isCannotLinkCompletedGoalError(err)) {
+        const goal = allGoals.find((g) => g.id === goalId);
+        const name = goal ? goalTitle(goal) : "This goal";
+        toast({
+          variant: "destructive",
+          title: "Goal is completed",
+          description: `"${name}" is completed. Reopen it to in-progress before linking it to a session.`,
+        });
+        return { kind: "done" };
+      }
+      console.error("Failed to link goal:", err);
+      toast({
+        variant: "destructive",
+        title: "Failed to link goal",
+        description: err.message,
+      });
+      return { kind: "done" };
     },
     [coachingSessionId, allGoals, refreshSessionGoals, refreshAllGoals]
   );
@@ -657,13 +650,8 @@ export function CoachingSessionPanel({
     onSwapAndLink: handleSwapAndLink,
     onCreateAndLink: handleCreateAndLink,
     onCreateAndSwap: handleCreateAndSwap,
+    onRefreshGoals: refreshAllGoals,
   });
-
-  // Backfill the ref handleLink reads on 409. enterSwapForLink is memoized
-  // with empty deps inside the hook, so this is a one-shot assignment in
-  // practice — but tracking it on every render is cheap and avoids any
-  // staleness risk if the hook's memoization ever changes.
-  enterSwapForLinkRef.current = goalFlow.enterSwapForLink;
 
   // ── Action hooks & state ─────────────────────────────────────────
 

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -37,6 +37,7 @@ import {
   extractActiveGoalLimitError,
   goalTitle,
   isAtGoalLimit,
+  isCannotLinkCompletedGoalError,
   maxActiveGoals,
 } from "@/types/goal";
 import type { Id } from "@/types/general";
@@ -316,25 +317,9 @@ export function CoachingSessionPanel({
 
   const handleLink = useCallback(
     async (goalId: string) => {
-      const goal = allGoals.find((g) => g.id === goalId);
-      if (goal && goal.status === ItemStatus.OnHold) {
-        try {
-          await updateGoal(goalId, { ...goal, status: ItemStatus.InProgress });
-        } catch (err) {
-          const limitInfo = extractActiveGoalLimitError(err);
-          if (limitInfo) {
-            toast({
-              variant: "destructive",
-              title: "Goal limit reached",
-              description: `You already have ${limitInfo.maxActiveGoals} goals in progress. Please complete or change the status of one before starting another.`,
-            });
-          } else {
-            console.error("Failed to activate goal:", err);
-          }
-          return;
-        }
-      }
-
+      // BE auto-promotes NotStarted/OnHold goals to InProgress atomically with
+      // the join insert (see goal_session_link_invariant decision). FE must
+      // NOT pre-promote — that races with the server's atomic write.
       const result = await GoalApi.linkToSession(coachingSessionId, goalId);
       result.match(
         () => {
@@ -342,6 +327,28 @@ export function CoachingSessionPanel({
           refreshAllGoals();
         },
         (err) => {
+          const limitInfo = extractActiveGoalLimitError(err);
+          if (limitInfo) {
+            // TODO(goal_session_link_invariant): re-enter SelectingSwap with
+            // limitInfo.inProgressGoals as the demote candidates and goalId
+            // as the pending link target, then call onSwapAndLink on selection.
+            toast({
+              variant: "destructive",
+              title: "Goal limit reached",
+              description: `You already have ${limitInfo.maxInProgressGoals} goals in progress. Please complete or change the status of one before linking another.`,
+            });
+            return;
+          }
+          if (isCannotLinkCompletedGoalError(err)) {
+            const goal = allGoals.find((g) => g.id === goalId);
+            const name = goal ? goalTitle(goal) : "This goal";
+            toast({
+              variant: "destructive",
+              title: "Goal is completed",
+              description: `"${name}" is completed. Reopen it to in-progress before linking it to a session.`,
+            });
+            return;
+          }
           console.error("Failed to link goal:", err);
           toast({
             variant: "destructive",
@@ -351,7 +358,7 @@ export function CoachingSessionPanel({
         }
       );
     },
-    [coachingSessionId, allGoals, updateGoal, refreshSessionGoals, refreshAllGoals]
+    [coachingSessionId, allGoals, refreshSessionGoals, refreshAllGoals]
   );
 
   const handleUnlink = useCallback(
@@ -382,9 +389,19 @@ export function CoachingSessionPanel({
               onClick: async () => {
                 const relinkResult = await GoalApi.linkToSession(coachingSessionId, goalId);
                 if (relinkResult.isErr()) {
-                  sonnerToast.error("Failed to undo", {
-                    description: relinkResult.error.message,
-                  });
+                  const err = relinkResult.error;
+                  const limitInfo = extractActiveGoalLimitError(err);
+                  if (limitInfo) {
+                    sonnerToast.error("Goal limit reached", {
+                      description: `You already have ${limitInfo.maxInProgressGoals} goals in progress. Demote one before restoring this goal.`,
+                    });
+                  } else if (isCannotLinkCompletedGoalError(err)) {
+                    sonnerToast.error("Goal is completed", {
+                      description: "Reopen this goal to in-progress before linking it again.",
+                    });
+                  } else {
+                    sonnerToast.error("Failed to undo", { description: err.message });
+                  }
                   return;
                 }
                 if (!readOnly && goal && previousStatus === ItemStatus.InProgress) {
@@ -432,7 +449,7 @@ export function CoachingSessionPanel({
           toast({
             variant: "destructive",
             title: "Goal limit reached",
-            description: `You already have ${limitInfo.maxActiveGoals} goals in progress. Please complete or change the status of one before starting another.`,
+            description: `You already have ${limitInfo.maxInProgressGoals} goals in progress. Please complete or change the status of one before starting another.`,
           });
         } else {
           console.error("Failed to create goal:", err);

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -38,6 +38,7 @@ import {
   goalTitle,
   isAtGoalLimit,
   isCannotLinkCompletedGoalError,
+  isGoalAlreadyLinkedToSessionError,
   maxActiveGoals,
   type InProgressGoalSummary,
 } from "@/types/goal";
@@ -348,6 +349,23 @@ export function CoachingSessionPanel({
             enterSwapForLinkRef.current?.(goalId, limitInfo.inProgressGoals);
             return;
           }
+          if (isGoalAlreadyLinkedToSessionError(err)) {
+            // Race: another tab/window linked the same goal between when the
+            // FE's linkable list was computed and this request. The FE
+            // normally filters already-linked goals out of the picker, so
+            // this is rare in practice. Refresh state so the goal disappears
+            // from any visible list.
+            refreshSessionGoals();
+            refreshAllGoals();
+            const goal = allGoals.find((g) => g.id === goalId);
+            const name = goal ? goalTitle(goal) : "This goal";
+            toast({
+              variant: "destructive",
+              title: "Already linked",
+              description: `"${name}" is already linked to this session.`,
+            });
+            return;
+          }
           if (isCannotLinkCompletedGoalError(err)) {
             const goal = allGoals.find((g) => g.id === goalId);
             const name = goal ? goalTitle(goal) : "This goal";
@@ -404,6 +422,14 @@ export function CoachingSessionPanel({
                     sonnerToast.error("Goal limit reached", {
                       description: `You already have ${limitInfo.maxInProgressGoals} goals in progress. Demote one before restoring this goal.`,
                     });
+                  } else if (isGoalAlreadyLinkedToSessionError(err)) {
+                    // Concurrent re-link won the race — the goal is back, so
+                    // surface a softer message and refresh.
+                    sonnerToast("Goal already restored", {
+                      description: "Looks like it was added back from another window.",
+                    });
+                    refreshSessionGoals();
+                    refreshAllGoals();
                   } else if (isCannotLinkCompletedGoalError(err)) {
                     sonnerToast.error("Goal is completed", {
                       description: "Reopen this goal to in-progress before linking it again.",

--- a/src/components/ui/coaching-sessions/goal-flow.ts
+++ b/src/components/ui/coaching-sessions/goal-flow.ts
@@ -28,14 +28,34 @@ export type GoalFlowState =
   | { step: GoalFlowStep.Browsing; swapGoalId?: string }
   | { step: GoalFlowStep.Creating; swapGoalId?: string };
 
+/**
+ * Outcome of a link attempt. `done` covers both success and any terminal
+ * failure that the panel has already surfaced (e.g. via toast).
+ * `needs-swap-recovery` is the cap-collision 409: the flow stays open and
+ * transitions to SelectingSwap, seeded with the BE-supplied InProgress
+ * candidates, so the user can pick a demote target without leaving the
+ * interaction.
+ */
+export type LinkAttemptResult =
+  | { kind: "done" }
+  | { kind: "needs-swap-recovery"; candidates: InProgressGoalSummary[] };
+
 interface GoalFlowCallbacks {
   atLimit: boolean;
   allGoals: Goal[];
   linkedGoalIds: Set<string>;
-  onLink: (goalId: string) => void;
+  onLink: (goalId: string) => Promise<LinkAttemptResult>;
   onSwapAndLink: (newGoalId: string, swapGoalId: string) => void;
   onCreateAndLink: (title: string, body?: string) => void;
   onCreateAndSwap: (title: string, swapGoalId: string, body?: string) => void;
+  /**
+   * Called when the flow enters 409-recovery (cap-collision). The BE's
+   * candidate ids are authoritative but the FE may not have all of them
+   * cached, so the hook asks the consumer to refresh the goal list in
+   * the background. The hook makes no guarantee about completion timing;
+   * `swapCandidates` will reactively re-resolve once `allGoals` updates.
+   */
+  onRefreshGoals: () => void;
 }
 
 export enum SlideDirection {
@@ -51,6 +71,7 @@ export function useGoalFlow({
   onSwapAndLink,
   onCreateAndLink,
   onCreateAndSwap,
+  onRefreshGoals,
 }: GoalFlowCallbacks) {
   const [flow, setFlow] = useState<GoalFlowState>({ step: GoalFlowStep.Idle });
   const [direction, setDirection] = useState<SlideDirection>(SlideDirection.Forward);
@@ -98,30 +119,11 @@ export function useGoalFlow({
   );
 
   /**
-   * Open the swap dialog programmatically in response to a 409 from the
-   * link endpoint. The user has already picked `goalId`; after they pick
-   * a demote candidate, the flow resolves via onSwapAndLink rather than
-   * re-entering Browsing. `candidates` is the BE-supplied authoritative
-   * list of currently-InProgress goals (from `details.in_progress_goals`).
-   */
-  const enterSwapForLink = useCallback(
-    (goalId: string, candidates: InProgressGoalSummary[]) => {
-      setDirection(SlideDirection.Forward);
-      setFlow({
-        step: GoalFlowStep.SelectingSwap,
-        pendingLinkGoalId: goalId,
-        candidateOverrides: candidates,
-      });
-    },
-    []
-  );
-
-  /**
    * Resolved swap-candidate Goal[] for the SelectingSwap UI.
    * - When `candidateOverrides` is set (entered via 409), look up each id
    *   in `allGoals`. If a candidate isn't in local state (rare cache lag),
-   *   it's filtered out — the user picks from what's resolvable, and the
-   *   subsequent demote update_status call would otherwise fail anyway.
+   *   it's filtered out for the moment — `onRefreshGoals()` was triggered
+   *   on entry, so the list will populate as soon as the refresh lands.
    * - Otherwise, the dialog was opened proactively from "+Add → at limit";
    *   show the session-linked goals (which under the new invariant are all
    *   InProgress).
@@ -137,16 +139,39 @@ export function useGoalFlow({
   }, [flow, allGoals, linkedGoalIds]);
 
   const handleBrowseGoalClick = useCallback(
-    (goalId: string) => {
-      setDirection(SlideDirection.Backward);
+    async (goalId: string) => {
       if (flow.step === GoalFlowStep.Browsing && flow.swapGoalId) {
+        setDirection(SlideDirection.Backward);
         onSwapAndLink(goalId, flow.swapGoalId);
-      } else {
-        onLink(goalId);
+        setFlow({ step: GoalFlowStep.Idle });
+        return;
       }
+
+      // Direct link path. The BE may reject with a cap-collision 409, in
+      // which case the panel surfaces the BE-supplied InProgress
+      // candidates and we transition to SelectingSwap so the user can
+      // pick a demote target without leaving the interaction. The panel
+      // owns toasts/refreshes for every other terminal outcome.
+      const result = await onLink(goalId);
+
+      if (result.kind === "needs-swap-recovery") {
+        setDirection(SlideDirection.Forward);
+        setFlow({
+          step: GoalFlowStep.SelectingSwap,
+          pendingLinkGoalId: goalId,
+          candidateOverrides: result.candidates,
+        });
+        // The FE just learned its view of who's InProgress is stale.
+        // Refresh in the background so swapCandidates resolves any
+        // candidates not currently in the local cache.
+        onRefreshGoals();
+        return;
+      }
+
+      setDirection(SlideDirection.Backward);
       setFlow({ step: GoalFlowStep.Idle });
     },
-    [flow, onLink, onSwapAndLink]
+    [flow, onLink, onSwapAndLink, onRefreshGoals]
   );
 
   const handleCreateNewClick = useCallback(() => {
@@ -217,7 +242,6 @@ export function useGoalFlow({
     handleCreateBack,
     handleFormSubmit,
     handleCancel,
-    enterSwapForLink,
   }), [
     flow,
     direction,
@@ -231,6 +255,5 @@ export function useGoalFlow({
     handleCreateBack,
     handleFormSubmit,
     handleCancel,
-    enterSwapForLink,
   ]);
 }

--- a/src/components/ui/coaching-sessions/goal-flow.ts
+++ b/src/components/ui/coaching-sessions/goal-flow.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import type { Goal } from "@/types/goal";
+import type { Goal, InProgressGoalSummary } from "@/types/goal";
 import { ItemStatus } from "@/types/general";
 
 // ── Goal Flow State Machine ────────────────────────────────────────────
@@ -13,7 +13,18 @@ export enum GoalFlowStep {
 
 export type GoalFlowState =
   | { step: GoalFlowStep.Idle }
-  | { step: GoalFlowStep.SelectingSwap }
+  | {
+      step: GoalFlowStep.SelectingSwap;
+      // When set, the user already picked the goal to link (via Browsing)
+      // and the BE rejected with 409. After they pick a demote candidate,
+      // resolve via onSwapAndLink(pendingLinkGoalId, demoteId) instead of
+      // re-entering Browsing.
+      pendingLinkGoalId?: string;
+      // BE-supplied list of currently-InProgress goals from the 409 body.
+      // Authoritative; preferred over the FE's view of session-linked goals
+      // when the cap was hit on the relationship (not the session).
+      candidateOverrides?: InProgressGoalSummary[];
+    }
   | { step: GoalFlowStep.Browsing; swapGoalId?: string }
   | { step: GoalFlowStep.Creating; swapGoalId?: string };
 
@@ -70,10 +81,60 @@ export function useGoalFlow({
     }
   }, [atLimit]);
 
-  const handleSwapSelected = useCallback((goalId: string) => {
-    setDirection(SlideDirection.Forward);
-    setFlow({ step: GoalFlowStep.Browsing, swapGoalId: goalId });
-  }, []);
+  const handleSwapSelected = useCallback(
+    (goalId: string) => {
+      setDirection(SlideDirection.Forward);
+      // 409-recovery path: user already chose what to link; just resolve
+      // the swap and exit. Otherwise fall through to the "+Add → at limit"
+      // path which transitions to Browsing for the user to pick the new goal.
+      if (flow.step === GoalFlowStep.SelectingSwap && flow.pendingLinkGoalId) {
+        onSwapAndLink(flow.pendingLinkGoalId, goalId);
+        setFlow({ step: GoalFlowStep.Idle });
+        return;
+      }
+      setFlow({ step: GoalFlowStep.Browsing, swapGoalId: goalId });
+    },
+    [flow, onSwapAndLink]
+  );
+
+  /**
+   * Open the swap dialog programmatically in response to a 409 from the
+   * link endpoint. The user has already picked `goalId`; after they pick
+   * a demote candidate, the flow resolves via onSwapAndLink rather than
+   * re-entering Browsing. `candidates` is the BE-supplied authoritative
+   * list of currently-InProgress goals (from `details.in_progress_goals`).
+   */
+  const enterSwapForLink = useCallback(
+    (goalId: string, candidates: InProgressGoalSummary[]) => {
+      setDirection(SlideDirection.Forward);
+      setFlow({
+        step: GoalFlowStep.SelectingSwap,
+        pendingLinkGoalId: goalId,
+        candidateOverrides: candidates,
+      });
+    },
+    []
+  );
+
+  /**
+   * Resolved swap-candidate Goal[] for the SelectingSwap UI.
+   * - When `candidateOverrides` is set (entered via 409), look up each id
+   *   in `allGoals`. If a candidate isn't in local state (rare cache lag),
+   *   it's filtered out — the user picks from what's resolvable, and the
+   *   subsequent demote update_status call would otherwise fail anyway.
+   * - Otherwise, the dialog was opened proactively from "+Add → at limit";
+   *   show the session-linked goals (which under the new invariant are all
+   *   InProgress).
+   */
+  const swapCandidates = useMemo<Goal[]>(() => {
+    if (flow.step !== GoalFlowStep.SelectingSwap) return [];
+    if (flow.candidateOverrides) {
+      return flow.candidateOverrides
+        .map(({ id }) => allGoals.find((g) => g.id === id))
+        .filter((g): g is Goal => g !== undefined);
+    }
+    return allGoals.filter((g) => linkedGoalIds.has(g.id));
+  }, [flow, allGoals, linkedGoalIds]);
 
   const handleBrowseGoalClick = useCallback(
     (goalId: string) => {
@@ -147,6 +208,7 @@ export function useGoalFlow({
     flow,
     direction,
     availableGoals,
+    swapCandidates,
     handleBack,
     handleAddGoalClick,
     handleSwapSelected,
@@ -155,10 +217,12 @@ export function useGoalFlow({
     handleCreateBack,
     handleFormSubmit,
     handleCancel,
+    enterSwapForLink,
   }), [
     flow,
     direction,
     availableGoals,
+    swapCandidates,
     handleBack,
     handleAddGoalClick,
     handleSwapSelected,
@@ -167,5 +231,6 @@ export function useGoalFlow({
     handleCreateBack,
     handleFormSubmit,
     handleCancel,
+    enterSwapForLink,
   ]);
 }

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -1,38 +1,34 @@
 import { DateTime } from "ts-luxon";
 import { Id, ItemStatus, EntityApiError } from "@/types/general";
 
-// ─── Active Goal Limit (409 Conflict) ───────────────────────────────
-// "Active" means InProgress ONLY — NotStarted does not count.
-// See ActiveGoalLimitError contract v4 on the coordination board.
+// ─── In-Progress Goal Limit (409 Conflict) ─────────────────────────
+// "Active" in FE-internal naming (e.g. DEFAULT_MAX_ACTIVE_GOALS) means
+// InProgress ONLY — NotStarted does not count.
+// Wire format documented in ActiveGoalLimitConflict v1 on the
+// coordination board. The 409 carries `error: "conflict"` (generic) and
+// the limit info nested under `details` — discriminate on the presence
+// of `details.max_in_progress_goals`, NOT on the `error` string.
 
 /** Default limit used when no 409 response has been received yet. */
 const DEFAULT_MAX_ACTIVE_GOALS = 3;
 
 /** Summary of an InProgress goal returned in the 409 response body. */
-export interface ActiveGoalSummary {
+export interface InProgressGoalSummary {
   id: Id;
   title: string;
 }
 
-/** Parsed result from a 409 active-goal-limit error. */
+/** Parsed result from a 409 in-progress-goal-limit error. */
 export interface ActiveGoalLimitInfo {
-  maxActiveGoals: number;
-  activeGoals: ActiveGoalSummary[];
-}
-
-/** Shape of the 409 response body when the active-goal limit is exceeded. */
-export interface ActiveGoalLimitErrorData {
-  status_code: 409;
-  error: "active_goal_limit_reached";
-  message: string;
-  max_active_goals: number;
-  active_goals: ActiveGoalSummary[];
+  maxInProgressGoals: number;
+  inProgressGoals: InProgressGoalSummary[];
 }
 
 /**
- * Extracts active-goal-limit info from an EntityApiError if it represents
- * a 409 active-goal-limit error. Returns the limit and active goals on match,
- * or null if the error is something else.
+ * Extracts in-progress-goal-limit info from an EntityApiError if it
+ * represents the active-goal-limit case (409 with the BE's
+ * `details.max_in_progress_goals` discriminator). Returns the limit
+ * and in-progress goals on match, or null otherwise.
  */
 export function extractActiveGoalLimitError(
   err: unknown
@@ -45,20 +41,50 @@ export function extractActiveGoalLimitError(
   }
 
   const data = err.data;
+  if (!data || typeof data !== "object") return null;
+
+  const details = (data as { details?: unknown }).details;
   if (
-    data &&
-    typeof data === "object" &&
-    data.error === "active_goal_limit_reached" &&
-    Array.isArray(data.active_goals) &&
-    typeof data.max_active_goals === "number"
+    details &&
+    typeof details === "object" &&
+    typeof (details as { max_in_progress_goals?: unknown }).max_in_progress_goals === "number" &&
+    Array.isArray((details as { in_progress_goals?: unknown }).in_progress_goals)
   ) {
+    const d = details as {
+      max_in_progress_goals: number;
+      in_progress_goals: InProgressGoalSummary[];
+    };
     return {
-      maxActiveGoals: data.max_active_goals,
-      activeGoals: data.active_goals as ActiveGoalSummary[],
+      maxInProgressGoals: d.max_in_progress_goals,
+      inProgressGoals: d.in_progress_goals,
     };
   }
 
   return null;
+}
+
+// ─── Cannot-Link-Completed-Goal (422) ───────────────────────────────
+// Returned by POST /coaching_sessions/:id/goals when the target goal is
+// Completed or WontDo. See goal_session_link_invariant decision on the
+// coordination board.
+
+/**
+ * Returns true when the error is a 422 cannot_link_completed_goal response
+ * from the link-goal-to-session endpoint.
+ */
+export function isCannotLinkCompletedGoalError(err: unknown): boolean {
+  if (
+    !(err instanceof EntityApiError) ||
+    err.status !== 422
+  ) {
+    return false;
+  }
+  const data = err.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    data.error === "cannot_link_completed_goal"
+  );
 }
 
 /**

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -1,13 +1,29 @@
 import { DateTime } from "ts-luxon";
 import { Id, ItemStatus, EntityApiError } from "@/types/general";
 
+// ─── Goal-endpoint error discriminators ────────────────────────────
+// Top-level `error` string values returned by structured-error
+// responses from goal-related endpoints. Centralized so wire-format
+// strings live in one place and additions are discoverable.
+
+export enum GoalErrorCode {
+  /** Generic conflict; the specific case is carried in `details`. */
+  Conflict = "conflict",
+  /** POST /coaching_sessions/:id/goals on a goal already linked. */
+  GoalAlreadyLinkedToSession = "goal_already_linked_to_session",
+  /** POST /coaching_sessions/:id/goals on a Completed/WontDo goal. */
+  CannotLinkCompletedGoal = "cannot_link_completed_goal",
+}
+
 // ─── In-Progress Goal Limit (409 Conflict) ─────────────────────────
 // "Active" in FE-internal naming (e.g. DEFAULT_MAX_ACTIVE_GOALS) means
 // InProgress ONLY — NotStarted does not count.
 // Wire format documented in ActiveGoalLimitConflict v1 on the
 // coordination board. The 409 carries `error: "conflict"` (generic) and
-// the limit info nested under `details` — discriminate on the presence
-// of `details.max_in_progress_goals`, NOT on the `error` string.
+// the limit info nested under `details`. Discriminate on BOTH the error
+// code AND the presence of `details.max_in_progress_goals` so a future
+// 409 variant that happens to carry similar details fields can't be
+// misclassified.
 
 /** Default limit used when no 409 response has been received yet. */
 const DEFAULT_MAX_ACTIVE_GOALS = 3;
@@ -26,9 +42,9 @@ export interface ActiveGoalLimitInfo {
 
 /**
  * Extracts in-progress-goal-limit info from an EntityApiError if it
- * represents the active-goal-limit case (409 with the BE's
- * `details.max_in_progress_goals` discriminator). Returns the limit
- * and in-progress goals on match, or null otherwise.
+ * represents the active-goal-limit case (409 with `error: "conflict"`
+ * and the BE's `details.max_in_progress_goals` discriminator). Returns
+ * the limit and in-progress goals on match, or null otherwise.
  */
 export function extractActiveGoalLimitError(
   err: unknown
@@ -42,6 +58,10 @@ export function extractActiveGoalLimitError(
 
   const data = err.data;
   if (!data || typeof data !== "object") return null;
+
+  if ((data as { error?: unknown }).error !== GoalErrorCode.Conflict) {
+    return null;
+  }
 
   const details = (data as { details?: unknown }).details;
   if (
@@ -83,7 +103,7 @@ export function isCannotLinkCompletedGoalError(err: unknown): boolean {
   return (
     !!data &&
     typeof data === "object" &&
-    data.error === "cannot_link_completed_goal"
+    (data as { error?: unknown }).error === GoalErrorCode.CannotLinkCompletedGoal
   );
 }
 
@@ -108,7 +128,7 @@ export function isGoalAlreadyLinkedToSessionError(err: unknown): boolean {
   return (
     !!data &&
     typeof data === "object" &&
-    data.error === "goal_already_linked_to_session"
+    (data as { error?: unknown }).error === GoalErrorCode.GoalAlreadyLinkedToSession
   );
 }
 

--- a/src/types/goal.ts
+++ b/src/types/goal.ts
@@ -87,6 +87,31 @@ export function isCannotLinkCompletedGoalError(err: unknown): boolean {
   );
 }
 
+// ─── Goal Already Linked To Session (409) ──────────────────────────
+// Wire format documented in GoalAlreadyLinkedToSessionError v1 on the
+// coordination board. Distinct from the cap-collision 409 — this one
+// uses the specific-discriminator pattern (top-level `error` string),
+// no `details` envelope. See feedback_error_variant_shape on BE side.
+
+/**
+ * Returns true when the error is a 409 goal_already_linked_to_session
+ * response from POST /coaching_sessions/:id/goals.
+ */
+export function isGoalAlreadyLinkedToSessionError(err: unknown): boolean {
+  if (
+    !(err instanceof EntityApiError) ||
+    err.status !== 409
+  ) {
+    return false;
+  }
+  const data = err.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    data.error === "goal_already_linked_to_session"
+  );
+}
+
 /**
  * Whether the active goal limit has been reached.
  * True when either the coaching relationship has the max number of


### PR DESCRIPTION
## Description

Aligns the FE goal-link error handling with the actual on-the-wire shapes the backend ships, removes a client-side pre-promotion that would race the BE's atomic auto-promote on link, and wires a continuous swap-dialog recovery flow when the link endpoint returns the cap-collision 409.

Four threads bundled because they share types and consumers:

1. **Pre-existing 409 silent regression.** `extractActiveGoalLimitError` checked `error === "active_goal_limit_reached"` and read top-level `max_active_goals` / `active_goals`. None of those have been on the wire since the BE switched to a generic `Conflict` variant on 2026-03-12 (BE commit `45e9431`). The parser has been silently returning `null` for every cap-collision 409 since then — masked in normal UX because `useGoalFlow` opens the swap dialog proactively from the FE's own `atLimit` state, but the race-condition fallback path was dead. This PR rewrites the parser to match the verified `ActiveGoalLimitConflict` v1 contract.

2. **New 409/422 error handling on the goal-link path.** Backend PR adds atomic auto-promote + cap enforcement on `POST /coaching_sessions/:id/goals` (`ActiveGoalLimitConflict` v1, `CannotLinkCompletedGoalError` v1). FE removes the now-redundant client-side OnHold→InProgress pre-promote per the `goal_session_link_invariant` decision and surfaces specific UX for both error classes.

3. **Swap-dialog re-entry on link 409 (cap-collision).** When the link endpoint returns 409 with `details.in_progress_goals`, the FE re-opens the swap dialog seeded with the BE's authoritative InProgress list. The user picks a demote candidate; the flow resolves via `handleSwapAndLink(originalGoalId, demoteGoalId)` without leaving the interaction. Same UX as the proactive `+Add → atLimit` path.

4. **Duplicate-link 409 (`GoalAlreadyLinkedToSessionError` v1).** Backend commit `375f424` replaces the prior 503 plain-text fallback with a structured 409 carrying `error: "goal_already_linked_to_session"`. FE now detects this distinct shape, refreshes session+all goals (the visible linkable list was stale — race with another tab), and surfaces a soft "already linked" toast. The Undo path uses a non-destructive sonner toast since the user's intent is already satisfied.

### Changes

* Rewrite `extractActiveGoalLimitError` in `src/types/goal.ts` to discriminate on `details.max_in_progress_goals` presence and parse `details.in_progress_goals` (per `ActiveGoalLimitConflict` v1). Rename `ActiveGoalSummary` → `InProgressGoalSummary`. Drop the stale `ActiveGoalLimitErrorData` interface.
* Add `isCannotLinkCompletedGoalError` helper for the BE's 422 (`CannotLinkCompletedGoalError` v1 — top-level `error` discriminator).
* Add `isGoalAlreadyLinkedToSessionError` helper for the BE's new duplicate-link 409 (`GoalAlreadyLinkedToSessionError` v1 — also top-level `error` discriminator, distinct from the cap-collision 409 shape).
* Update `handleLink` in `coaching-session-panel.tsx`: remove the OnHold→InProgress pre-promote (BE handles it atomically); on cap-collision 409 → call `goalFlow.enterSwapForLink(goalId, limitInfo.inProgressGoals)`; on duplicate-link 409 → refresh + soft "already linked" toast; on 422 → "Goal is completed" toast naming the specific goal.
* Extend `GoalFlowState.SelectingSwap` with optional `pendingLinkGoalId` and `candidateOverrides`. Add `enterSwapForLink(goalId, candidates)` to the hook. `handleSwapSelected` resolves via `onSwapAndLink` when a pending link target is set; otherwise transitions to Browsing as before. Expose derived `swapCandidates: Goal[]` (resolves overrides via `allGoals`, falls back to session-linked goals).
* Update SelectingSwap UI to render `goalFlow.swapCandidates` and tweak prompt copy for the 409-recovery case.
* Upgrade the unlink Undo path to detect all three structured errors with matching specific messages instead of generic "Failed to undo."
* Update the three existing `limitInfo.maxActiveGoals` consumers in the panel to `limitInfo.maxInProgressGoals`.
* Update unit tests in `__tests__/types/goal.test.ts` to use the verified BE shapes; add disambiguation tests asserting each parser matches exactly one structured-error shape and rejects the others (guards against future contract drift at FE-test-time).
* Add `__tests__/components/ui/coaching-sessions/goal-flow.test.ts` covering both proactive and 409-recovery swap paths, the stale-cache filter on candidate resolution, and cancel-from-recovery.

### Screenshots / Videos Showing UI Changes (if applicable)

UI changes are toast copy on rare error paths and a re-opened swap dialog after a cap-collision 409. Screenshots that would help:

* Goal-create at the cap → "Goal limit reached" toast (race condition or DevTools-forced 409). Validates the parser-fix half independently of the link-endpoint changes.
* Click `+Add` → pick existing OnHold goal → DevTools-forced cap-collision 409 → swap dialog re-opens with BE-supplied candidates and prompt "Pick one to put on hold so this one can replace it." Pick one → original link completes via `handleSwapAndLink`.
* DevTools-forced duplicate-link 409 → "Already linked" destructive toast naming the goal; the linkable list refreshes and the goal disappears from the picker.
* DevTools-forced 422 on a link → "Goal is completed" toast naming the goal.
* Unlink → click Undo → forced 409s/422 → matching specific toast.

### Testing Strategy

**Automated:**
* `npx tsc --noEmit` — clean.
* `npx vitest run __tests__/types __tests__/lib/api __tests__/components/ui/coaching-sessions` — all pass, including new disambiguation coverage that pins each structured-error wire format and asserts the parsers are mutually exclusive.

**Manual (against current BE — testable today; BE has the latest changes deployed):**
1. **Pre-existing regression coverage:** in two browser tabs, push a coaching relationship to 3 InProgress goals in tab A, then race-create a 4th in tab B. **Expected:** "Goal limit reached" toast (was a silent `console.error` before this PR).
2. **Normal link/unlink flow:** still works.
3. **Cap-collision 409:** open `+Add` against a relationship at the InProgress cap → swap dialog re-opens with BE-supplied candidates → pick one → original link completes after the swap.
4. **Duplicate-link 409:** synthesize via direct API call (the linker UI filters already-linked goals) → "Already linked" toast surfaces; linkable list refreshes.
5. **422 completed-goal:** synthesize via direct API call against a Completed/WontDo goal → "Goal is completed" toast names the goal.
6. **Undo path:** unlink → force the relink response to a 409/422 → click Undo → matching specific toast (or the soft "already restored" sonner for duplicate-link).

### Concerns

* **Deployment skew during the BE PR rollout window.** Linking an OnHold goal against a backend that hasn't yet shipped `fix/auto-promote-goal-on-session-link` will leave the goal OnHold (the FE no longer pre-promotes). Self-corrects once the BE deploys. Either hold this PR until the BE merges or merge them concurrently. (BE is currently running the latest changes in dev.)