### PR TITLE
Restore session delete via row kebab + dashboard UX polish

### DIFF
--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { DateTime } from "ts-luxon";
 import { CoachingSessionsCard } from "@/components/ui/dashboard/coaching-sessions-card";
 import { ItemStatus } from "@/types/general";
@@ -59,6 +59,14 @@ vi.mock("sonner", () => ({
   toast: {
     error: (...args: unknown[]) => mockToastError(...args),
   },
+}));
+
+// The Share link kebab item routes through `copyCoachingSessionLink-
+// WithToast`. Mock the whole module so we can assert the right session
+// id was sent to it without exercising the real clipboard write path.
+const mockCopyLink = vi.fn();
+vi.mock("@/components/ui/share-session-link", () => ({
+  copyCoachingSessionLinkWithToast: (id: string) => mockCopyLink(id),
 }));
 
 // Forward args so tests can assert the call was scoped by the hovered
@@ -264,7 +272,8 @@ describe("CoachingSessionsCard", () => {
     expect(onReschedule).toHaveBeenCalledWith(session);
   });
 
-  it("hides the kebab entirely when the viewer is the coachee with no available actions", () => {
+  it("renders a kebab on coachee rows but limits it to Share link (no Reschedule, no Delete)", async () => {
+    const user = userEvent.setup();
     setupBaseAuth({ id: "coachee-1", timezone: "UTC" });
 
     const session = createMockEnrichedSession({ id: "s1", date: FAR_FUTURE });
@@ -273,17 +282,29 @@ describe("CoachingSessionsCard", () => {
     render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
     const row = screen.getByTestId("session-row-s1");
-    // Coachee has no Reschedule and no Delete (coach-only) → the kebab
-    // shouldn't render at all. Empty kebabs are noise.
-    expect(
-      within(row).queryByRole("button", { name: /session actions/i })
-    ).not.toBeInTheDocument();
-    // The Join link still renders so coachees can navigate.
+    // The Join link still renders so coachees can navigate. Asserted
+    // BEFORE opening the menu — Radix's DropdownMenu marks the rest of
+    // the page `aria-hidden` while open, so `getAllByRole("link")`
+    // returns nothing if queried after the menu trigger fires.
     const links = within(row).getAllByRole("link");
     expect(links.length).toBeGreaterThanOrEqual(1);
     for (const link of links) {
       expect(link).toHaveAttribute("href", "/coaching-sessions/s1");
     }
+
+    // Share link is available to any viewer, so the kebab itself stays
+    // present even for coachees — but the menu must NOT expose the
+    // coach-only actions.
+    await user.click(within(row).getByRole("button", { name: /session actions/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /reschedule/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /delete session/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /share link/i })
+    ).toBeInTheDocument();
   });
 
   it("renders the View link instead of Join on the Previous tab and offers Delete in the kebab", async () => {
@@ -750,16 +771,18 @@ describe("CoachingSessionsCard", () => {
       render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
       const row = screen.getByTestId("session-row-s1");
-      // Coachee has neither Reschedule nor Delete → no kebab.
+      // Coachee gets a kebab (Share link is universal) but the menu must
+      // NOT expose Delete — that's the contract this test pins. Open the
+      // kebab and assert the menu surface explicitly.
+      await user.click(
+        within(row).getByRole("button", { name: /session actions/i })
+      );
       expect(
-        within(row).queryByRole("button", { name: /session actions/i })
+        screen.queryByRole("menuitem", { name: /delete session/i })
       ).not.toBeInTheDocument();
 
       // Sanity: confirm `mockDelete` is never reachable from this row.
       expect(mockDelete).not.toHaveBeenCalled();
-      // Discharge the unused `user` to satisfy linting in CI; the assertion
-      // chain above is intentionally synchronous.
-      void user;
     });
 
     // ── Card-side half of the auto-refresh contract ───────────────────────
@@ -789,6 +812,117 @@ describe("CoachingSessionsCard", () => {
       // setupSessionWindows.
       expect(handleRefreshNeeded).toHaveBeenCalledTimes(1);
       expect(handleRefreshNeeded).toHaveBeenCalledWith(mockSessionsRefresh);
+    });
+  });
+
+  // ── Date-range chip + dropdown date hints ─────────────────────────────
+  //
+  // The header chip shows the *resolved* calendar range (e.g.
+  // "Apr 27 – May 11") instead of the abstract "+/- 7 days". The dropdown
+  // options also stack the resolved range under the abstract size so the
+  // user previews "what would I get?" before selecting. Both share the
+  // same anchor (`mountNow`) so chip text and dropdown previews always
+  // agree with the data fetch.
+  //
+  // Tests below pin a fixed system time so the resolved ranges are
+  // deterministic. Without this, expected strings would drift with the
+  // wall clock.
+  describe("date-range display in chip and dropdown", () => {
+    // 2026-05-04 noon UTC — chosen so ±7 days produces "Apr 27 – May 11"
+    // entirely within the same year (no year-crossing edge case).
+    const FIXED_NOW = new Date("2026-05-04T12:00:00Z");
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("shows the resolved date range in the chip instead of the abstract size", () => {
+      setupBaseAuth();
+      setupSessionWindows();
+      // Default ±7 days against May 4 → Apr 27 – May 11.
+      setupFilterStore({ timeWindow: SessionTimeWindow.Week });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      // Chip should show the resolved dates, NOT "+/- 7 days".
+      expect(screen.getByText(/Apr 27 – May 11/)).toBeInTheDocument();
+      expect(screen.queryByText("+/- 7 days")).not.toBeInTheDocument();
+    });
+
+    it("recomputes the chip range when a different window size is selected", () => {
+      setupBaseAuth();
+      setupSessionWindows();
+      // ±24 hours against May 4 → May 3 – May 5.
+      setupFilterStore({ timeWindow: SessionTimeWindow.Day });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      expect(screen.getByText(/May 3 – May 5/)).toBeInTheDocument();
+    });
+
+    // Note: the dropdown options stack the resolved range as a secondary
+    // line under each abstract label. Driving the Radix Select open in
+    // JSDOM under fake timers reliably times out (Radix waits for animation
+    // frames the test harness can't advance). The wiring is covered by:
+    //   - The `formatTimeWindowDateRange` unit tests (filters helper)
+    //   - The chip integration tests above (same anchor + helper)
+    // If a future regression silently strips the secondary line, both the
+    // helper output and the chip would be unaffected — at that point a
+    // focused header/popover render test would be worth adding. Today the
+    // cost-to-signal of fighting Radix-in-JSDOM exceeds its value.
+  });
+
+  // ── Share link kebab item ─────────────────────────────────────────────
+  //
+  // Restored from the legacy CoachingSessionList. Universal action — any
+  // viewer (coach or coachee), any tab (upcoming or previous). Routes
+  // through the existing `copyCoachingSessionLinkWithToast` utility so
+  // the success/error toasts come for free.
+  describe("share link", () => {
+    it("invokes the copy utility with the session id when Share link is clicked", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+      const session = createMockEnrichedSession({
+        id: "s-share",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      const row = screen.getByTestId("session-row-s-share");
+      await user.click(within(row).getByRole("button", { name: /session actions/i }));
+      await user.click(
+        await screen.findByRole("menuitem", { name: /share link/i })
+      );
+
+      expect(mockCopyLink).toHaveBeenCalledTimes(1);
+      expect(mockCopyLink).toHaveBeenCalledWith("s-share");
+    });
+
+    it("exposes Share link to coachees as well (universal action)", async () => {
+      const user = userEvent.setup();
+      // Coachee viewer — has no Reschedule and no Delete.
+      setupBaseAuth({ id: "coachee-1", timezone: "UTC" });
+      const session = createMockEnrichedSession({
+        id: "s-coachee",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      const row = screen.getByTestId("session-row-s-coachee");
+      await user.click(within(row).getByRole("button", { name: /session actions/i }));
+      // Share link is the only menu item the coachee should see.
+      expect(
+        screen.getByRole("menuitem", { name: /share link/i })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -796,7 +796,7 @@ describe("CoachingSessionsCard", () => {
     // hook surface or accidentally drops the prop, the create flow will
     // start showing stale data without any unit-test failure — unless
     // this test catches it.
-    it("surfaces the hook's refresh function via onRefreshNeeded on mount", () => {
+    it("surfaces a stable wrapper via onRefreshNeeded that delegates to the hook's refresh", () => {
       setupBaseAuth();
       setupSessionWindows();
       const handleRefreshNeeded = vi.fn();
@@ -808,10 +808,17 @@ describe("CoachingSessionsCard", () => {
         />
       );
 
-      // Pin: called once with the same fn the test setup wired into
-      // setupSessionWindows.
+      // The card passes a *wrapper* closure that delegates to whatever
+      // `refreshSessions` is current at call time — keeps the parent's
+      // stored callback identity-stable. We can't assert
+      // `toHaveBeenCalledWith(mockSessionsRefresh)` because they aren't
+      // the same function reference. Instead: assert one registration,
+      // grab the wrapper, invoke it, and verify it routed to the spy.
       expect(handleRefreshNeeded).toHaveBeenCalledTimes(1);
-      expect(handleRefreshNeeded).toHaveBeenCalledWith(mockSessionsRefresh);
+      const wrapper = handleRefreshNeeded.mock.calls[0][0] as () => void;
+      expect(typeof wrapper).toBe("function");
+      wrapper();
+      expect(mockSessionsRefresh).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -825,7 +825,7 @@ describe("CoachingSessionsCard", () => {
   // ── Date-range chip + dropdown date hints ─────────────────────────────
   //
   // The header chip shows the *resolved* calendar range (e.g.
-  // "Apr 27 – May 11") instead of the abstract "+/- 7 days". The dropdown
+  // "Apr 27 – May 11") instead of the abstract "1 week". The dropdown
   // options also stack the resolved range under the abstract size so the
   // user previews "what would I get?" before selecting. Both share the
   // same anchor (`mountNow`) so chip text and dropdown previews always
@@ -856,9 +856,9 @@ describe("CoachingSessionsCard", () => {
 
       render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
-      // Chip should show the resolved dates, NOT "+/- 7 days".
+      // Chip should show the resolved dates, NOT the abstract label.
       expect(screen.getByText(/Apr 27 – May 11/)).toBeInTheDocument();
-      expect(screen.queryByText("+/- 7 days")).not.toBeInTheDocument();
+      expect(screen.queryByText("1 week")).not.toBeInTheDocument();
     });
 
     it("recomputes the chip range when a different window size is selected", () => {

--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -1,7 +1,12 @@
 import { render, screen, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { DateTime } from "ts-luxon";
+import {
+  DateTime,
+  FixedOffsetZone,
+  Settings as LuxonSettings,
+  type Zone,
+} from "ts-luxon";
 import { CoachingSessionsCard } from "@/components/ui/dashboard/coaching-sessions-card";
 import { ItemStatus } from "@/types/general";
 import { Some } from "@/types/option";
@@ -835,41 +840,50 @@ describe("CoachingSessionsCard", () => {
   // deterministic. Without this, expected strings would drift with the
   // wall clock.
   describe("date-range display in chip and dropdown", () => {
-    // 2026-05-04 noon UTC — chosen so ±7 days produces "Apr 27 – May 11"
+    // 2026-05-04 noon UTC — anchored so the 1-week half-span (±3.5d) lands
     // entirely within the same year (no year-crossing edge case).
     const FIXED_NOW = new Date("2026-05-04T12:00:00Z");
+    // Pin luxon to UTC for these assertions. The chip uses
+    // `DateTime.now()`, which respects the local zone — without this the
+    // expected strings would shift between dev machines and CI depending
+    // on `TZ`. The unit tests for `formatTimeWindowDateRange` already
+    // pass an explicit UTC anchor, so they're insulated from this.
+    let originalDefaultZone: Zone;
 
     beforeEach(() => {
       vi.useFakeTimers();
       vi.setSystemTime(FIXED_NOW);
+      originalDefaultZone = LuxonSettings.defaultZone;
+      LuxonSettings.defaultZone = FixedOffsetZone.utcInstance;
     });
 
     afterEach(() => {
       vi.useRealTimers();
+      LuxonSettings.defaultZone = originalDefaultZone;
     });
 
     it("shows the resolved date range in the chip instead of the abstract size", () => {
       setupBaseAuth();
       setupSessionWindows();
-      // Default ±7 days against May 4 → Apr 27 – May 11.
+      // 1 week against May 4 noon → ±3.5d → May 1 – May 8.
       setupFilterStore({ timeWindow: SessionTimeWindow.Week });
 
       render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
       // Chip should show the resolved dates, NOT the abstract label.
-      expect(screen.getByText(/Apr 27 – May 11/)).toBeInTheDocument();
+      expect(screen.getByText(/May 1 – May 8/)).toBeInTheDocument();
       expect(screen.queryByText("1 week")).not.toBeInTheDocument();
     });
 
     it("recomputes the chip range when a different window size is selected", () => {
       setupBaseAuth();
       setupSessionWindows();
-      // ±24 hours against May 4 → May 3 – May 5.
+      // 1 day against May 4 noon → ±12h → May 4 – May 5.
       setupFilterStore({ timeWindow: SessionTimeWindow.Day });
 
       render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
-      expect(screen.getByText(/May 3 – May 5/)).toBeInTheDocument();
+      expect(screen.getByText(/May 4 – May 5/)).toBeInTheDocument();
     });
 
     // Note: the dropdown options stack the resolved range as a secondary

--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -40,9 +40,25 @@ vi.mock(
 // precision. The mock returns one combined dataset; tests that distinguish
 // "upcoming" vs "previous" rely on `session.date` relative to `now`.
 const mockUseEnrichedCoachingSessionsForUser = vi.fn();
+// Delete-flow plumbing: `useCoachingSessionMutation` exposes `delete`. We
+// expose a fresh `mockDelete` per test so assertions on call args /
+// rejection paths stay isolated.
+const mockDelete = vi.fn();
 vi.mock("@/lib/api/coaching-sessions", () => ({
   useEnrichedCoachingSessionsForUser: () =>
     mockUseEnrichedCoachingSessionsForUser(),
+  useCoachingSessionMutation: () => ({ delete: mockDelete }),
+}));
+
+// Sonner is mounted globally in app/layout but isn't rendered in unit
+// tests, so we mock the module surface and assert the toast calls
+// directly. Only `error` is used today — successful deletes communicate
+// via the row disappearing, not a toast.
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
 }));
 
 // Forward args so tests can assert the call was scoped by the hovered
@@ -88,7 +104,9 @@ interface FilterStoreOverrides {
 /** Configure the sticky filter store with the given persisted values. */
 function setupFilterStore(overrides: FilterStoreOverrides = {}) {
   mockFilterStore.mockReturnValue({
-    timeWindow: overrides.timeWindow ?? SessionTimeWindow.Day,
+    // Mirrors the production default (Week) so tests share the same baseline
+    // the user actually sees on first load. Override per-test as needed.
+    timeWindow: overrides.timeWindow ?? SessionTimeWindow.Week,
     relationshipFilter: overrides.relationshipFilter,
     setTimeWindow: mockSetTimeWindow,
     setRelationshipFilter: mockSetRelationshipFilter,
@@ -117,6 +135,12 @@ interface WindowMocks {
  * unambiguously-past dates (e.g. 2020) for `previous` and unambiguously-future
  * dates (e.g. 2099) for `upcoming` so the partition is deterministic.
  */
+// Captured at module scope so the delete-flow test can assert that the
+// card calls the hook's `refresh()` after a successful delete — that's
+// the load-bearing wiring (the entity-mutation auto-invalidate doesn't
+// fire because the user-scoped fetch uses a different cache key).
+const mockSessionsRefresh = vi.fn();
+
 function setupSessionWindows({ upcoming, previous }: WindowMocks = {}) {
   const enrichedSessions = [
     ...(previous?.enrichedSessions ?? []),
@@ -126,7 +150,7 @@ function setupSessionWindows({ upcoming, previous }: WindowMocks = {}) {
     enrichedSessions,
     isLoading: !!(upcoming?.isLoading || previous?.isLoading),
     isError: upcoming?.isError ?? previous?.isError,
-    refresh: vi.fn(),
+    refresh: mockSessionsRefresh,
   });
 }
 
@@ -221,7 +245,8 @@ describe("CoachingSessionsCard", () => {
     expect(screen.queryByTestId("session-row-s-future")).not.toBeInTheDocument();
   });
 
-  it("shows Reschedule on upcoming rows for a coach viewer and fires the callback", () => {
+  it("shows Reschedule for a coach viewer inside the row's kebab menu and fires the callback", async () => {
+    const user = userEvent.setup();
     const onReschedule = vi.fn();
     setupBaseAuth({ id: "coach-1", timezone: "UTC" });
 
@@ -231,11 +256,15 @@ describe("CoachingSessionsCard", () => {
     render(<CoachingSessionsCard onReschedule={onReschedule} />);
 
     const row = screen.getByTestId("session-row-s1");
-    fireEvent.click(within(row).getByRole("button", { name: /reschedule/i }));
+    // Reschedule lives inside the kebab dropdown — must open it first.
+    await user.click(within(row).getByRole("button", { name: /session actions/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /reschedule/i })
+    );
     expect(onReschedule).toHaveBeenCalledWith(session);
   });
 
-  it("hides Reschedule on upcoming rows when viewer is the coachee", () => {
+  it("hides the kebab entirely when the viewer is the coachee with no available actions", () => {
     setupBaseAuth({ id: "coachee-1", timezone: "UTC" });
 
     const session = createMockEnrichedSession({ id: "s1", date: FAR_FUTURE });
@@ -244,11 +273,12 @@ describe("CoachingSessionsCard", () => {
     render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
     const row = screen.getByTestId("session-row-s1");
+    // Coachee has no Reschedule and no Delete (coach-only) → the kebab
+    // shouldn't render at all. Empty kebabs are noise.
     expect(
-      within(row).queryByRole("button", { name: /reschedule/i })
+      within(row).queryByRole("button", { name: /session actions/i })
     ).not.toBeInTheDocument();
-    // Two Join links rendered: one desktop (hover-revealed), one mobile-only.
-    // Both must point at the same coaching session detail route.
+    // The Join link still renders so coachees can navigate.
     const links = within(row).getAllByRole("link");
     expect(links.length).toBeGreaterThanOrEqual(1);
     for (const link of links) {
@@ -256,7 +286,7 @@ describe("CoachingSessionsCard", () => {
     }
   });
 
-  it("renders the View link instead of Join on the Previous tab", async () => {
+  it("renders the View link instead of Join on the Previous tab and offers Delete in the kebab", async () => {
     const user = userEvent.setup();
     setupBaseAuth();
 
@@ -267,11 +297,18 @@ describe("CoachingSessionsCard", () => {
 
     await user.click(screen.getByRole("tab", { name: /previous/i }));
     const row = screen.getByTestId("session-row-s-past");
-    expect(
-      within(row).queryByRole("button", { name: /reschedule/i })
-    ).not.toBeInTheDocument();
     const viewButtons = within(row).getAllByRole("button", { name: /view/i });
     expect(viewButtons.length).toBeGreaterThanOrEqual(1);
+
+    // Past sessions: no Reschedule, but Delete is still available to the
+    // coach. Open the kebab to assert both invariants.
+    await user.click(within(row).getByRole("button", { name: /session actions/i }));
+    expect(
+      screen.queryByRole("menuitem", { name: /reschedule/i })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /delete session/i })
+    ).toBeInTheDocument();
   });
 
   it("shows the empty hover-detail panel before any row is hovered", () => {
@@ -513,6 +550,245 @@ describe("CoachingSessionsCard", () => {
       render(<CoachingSessionsCard onReschedule={vi.fn()} />);
 
       expect(mockSetRelationshipFilter).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Delete flow ──────────────────────────────────────────────────────
+  //
+  // Covers the kebab-menu → AlertDialog → mutation pipeline. The card owns
+  // the dialog state (single instance for all rows) and the mutation, so
+  // every assertion in this block targets the card's externally-visible
+  // contract: which menu items are reachable, what copy the dialog shows,
+  // which API the confirm button drives, and which toasts fire on
+  // success/failure.
+  describe("delete flow", () => {
+    it("opens the confirmation dialog with the unified copy when Delete is clicked on an upcoming row", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+
+      const session = createMockEnrichedSession({
+        id: "s-upcoming",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      await user.click(
+        within(screen.getByTestId("session-row-s-upcoming")).getByRole("button", {
+          name: /session actions/i,
+        })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /delete session/i })
+      );
+
+      expect(
+        screen.getByRole("alertdialog", {
+          name: /delete this coaching session/i,
+        })
+      ).toBeInTheDocument();
+      // The dialog uses unified copy regardless of tab — it always names
+      // the cascading loss. For upcoming sessions this is informational
+      // (none yet); for previous sessions it's load-bearing.
+      expect(
+        screen.getByText(/notes and completed actions/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^delete session$/i })
+      ).toBeInTheDocument();
+    });
+
+    it("opens the same unified dialog on previous rows", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+
+      const session = createMockEnrichedSession({
+        id: "s-past",
+        date: FAR_PAST,
+      });
+      setupSessionWindows({ previous: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      await user.click(screen.getByRole("tab", { name: /previous/i }));
+      await user.click(
+        within(screen.getByTestId("session-row-s-past")).getByRole("button", {
+          name: /session actions/i,
+        })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /delete session/i })
+      );
+
+      // Same copy, both tabs. Pinning that the unification didn't quietly
+      // re-introduce a tab-keyed branch.
+      expect(
+        screen.getByText(/notes and completed actions/i)
+      ).toBeInTheDocument();
+    });
+
+    it("does not call the delete API when Cancel is clicked", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+
+      const session = createMockEnrichedSession({
+        id: "s1",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      await user.click(
+        within(screen.getByTestId("session-row-s1")).getByRole("button", {
+          name: /session actions/i,
+        })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /delete session/i })
+      );
+      await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it("calls the delete mutation, refreshes the session list, and closes the dialog when confirmed", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+      mockDelete.mockResolvedValueOnce(undefined);
+
+      const session = createMockEnrichedSession({
+        id: "s-doomed",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      await user.click(
+        within(screen.getByTestId("session-row-s-doomed")).getByRole(
+          "button",
+          { name: /session actions/i }
+        )
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /delete session/i })
+      );
+      await user.click(
+        screen.getByRole("button", { name: /^delete session$/i })
+      );
+
+      expect(mockDelete).toHaveBeenCalledWith("s-doomed");
+      // Pinning the bug found during browser verification: the entity-
+      // mutation auto-invalidate matches keys by entity baseUrl
+      // (`coaching_sessions/`), but the dashboard fetches via the
+      // user-scoped enriched endpoint, whose cache key doesn't match.
+      // Without an explicit `refresh()` call, the deleted row would
+      // linger until a hard reload.
+      expect(mockSessionsRefresh).toHaveBeenCalled();
+      // Dialog should be gone after a successful confirm.
+      expect(
+        screen.queryByRole("alertdialog", {
+          name: /delete this coaching session/i,
+        })
+      ).not.toBeInTheDocument();
+      expect(mockToastError).not.toHaveBeenCalled();
+    });
+
+    it("fires the error toast and closes the dialog when the delete mutation rejects", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth();
+      mockDelete.mockRejectedValueOnce(new Error("API down"));
+
+      const session = createMockEnrichedSession({
+        id: "s-fail",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      await user.click(
+        within(screen.getByTestId("session-row-s-fail")).getByRole("button", {
+          name: /session actions/i,
+        })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: /delete session/i })
+      );
+      await user.click(
+        screen.getByRole("button", { name: /^delete session$/i })
+      );
+
+      expect(mockDelete).toHaveBeenCalledWith("s-fail");
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Failed to delete session",
+        expect.objectContaining({ description: "API down" })
+      );
+      // No success toast exists — only the error path surfaces a toast.
+      // The dialog still closes after a failure — the user sees the error
+      // toast and can retry from the row.
+      expect(
+        screen.queryByRole("alertdialog", {
+          name: /delete this coaching session/i,
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not expose Delete in the kebab when the viewer is a coachee", async () => {
+      const user = userEvent.setup();
+      setupBaseAuth({ id: "coachee-1", timezone: "UTC" });
+
+      // Relationship has coach-1 as coach, so coachee-1 is the coachee.
+      const session = createMockEnrichedSession({
+        id: "s1",
+        date: FAR_FUTURE,
+      });
+      setupSessionWindows({ upcoming: { enrichedSessions: [session] } });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      const row = screen.getByTestId("session-row-s1");
+      // Coachee has neither Reschedule nor Delete → no kebab.
+      expect(
+        within(row).queryByRole("button", { name: /session actions/i })
+      ).not.toBeInTheDocument();
+
+      // Sanity: confirm `mockDelete` is never reachable from this row.
+      expect(mockDelete).not.toHaveBeenCalled();
+      // Discharge the unused `user` to satisfy linting in CI; the assertion
+      // chain above is intentionally synchronous.
+      void user;
+    });
+
+    // ── Card-side half of the auto-refresh contract ───────────────────────
+    //
+    // The dashboard relies on `onRefreshNeeded` to plumb the user-scoped
+    // SWR fetch's `refresh()` up to `DashboardContainer` so it can fire
+    // after the create/edit dialog closes. This bypasses the bug in
+    // `useEntityMutation`'s auto-invalidation, which filters by
+    // `typeof key === "string"` and silently skips tuple-keyed
+    // `useEntityList` caches like ours. If a future refactor changes the
+    // hook surface or accidentally drops the prop, the create flow will
+    // start showing stale data without any unit-test failure — unless
+    // this test catches it.
+    it("surfaces the hook's refresh function via onRefreshNeeded on mount", () => {
+      setupBaseAuth();
+      setupSessionWindows();
+      const handleRefreshNeeded = vi.fn();
+
+      render(
+        <CoachingSessionsCard
+          onReschedule={vi.fn()}
+          onRefreshNeeded={handleRefreshNeeded}
+        />
+      );
+
+      // Pin: called once with the same fn the test setup wired into
+      // setupSessionWindows.
+      expect(handleRefreshNeeded).toHaveBeenCalledTimes(1);
+      expect(handleRefreshNeeded).toHaveBeenCalledWith(mockSessionsRefresh);
     });
   });
 });

--- a/__tests__/components/ui/dashboard/coaching-sessions-filters.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-filters.test.tsx
@@ -12,49 +12,56 @@ import {
 // (which shows the *current* range) and each dropdown option (which shows
 // what the user would get on selection). Output format:
 //
-//   - Same year:    "MMM d – MMM d"           e.g. "Apr 27 – May 11"
-//   - Cross-year:   "MMM d, yyyy – MMM d, yyyy" e.g. "Sep 29, 2026 – Mar 28, 2027"
+//   - Same year:    "MMM d – MMM d"            e.g. "May 1 – May 8"
+//   - Cross-year:   "MMM d, yyyy – MMM d, yyyy" e.g. "Nov 13, 2026 – Feb 11, 2027"
 //
 // The same-year fast path keeps the chip narrow in the common case; the
-// cross-year fallback only kicks in at ±90d near year-end, which is rare but
-// must remain unambiguous (otherwise "Dec 28 – Jan 11" would read as the
-// same year's January).
+// cross-year fallback only kicks in for the 3-month option near year-end,
+// which is rare but must remain unambiguous.
+//
+// `TIME_WINDOW_DURATIONS` are *half-spans* — the helper applies them
+// symmetrically (`now ± duration`), so the total visible span equals the
+// labeled size (24h, 7d, 30d, 90d).
 
 describe("formatTimeWindowDateRange", () => {
   it("returns the same-year MMM d format when the range is within a single year", () => {
     const now = DateTime.fromISO("2026-05-04T12:00:00", { zone: "utc" });
 
+    // 1 day → ±12h → May 4 00:00 UTC – May 5 00:00 UTC
     expect(formatTimeWindowDateRange(SessionTimeWindow.Day, now)).toBe(
-      "May 3 – May 5"
+      "May 4 – May 5"
     );
+    // 1 week → ±3.5d → May 1 00:00 UTC – May 8 00:00 UTC
     expect(formatTimeWindowDateRange(SessionTimeWindow.Week, now)).toBe(
-      "Apr 27 – May 11"
+      "May 1 – May 8"
     );
+    // 1 month → ±15d → Apr 19 12:00 UTC – May 19 12:00 UTC
     expect(formatTimeWindowDateRange(SessionTimeWindow.Month, now)).toBe(
-      "Apr 4 – Jun 3"
+      "Apr 19 – May 19"
     );
   });
 
   it("falls back to MMM d, yyyy when the range crosses a year boundary", () => {
-    // Late December — ±90 days extends into the previous and next year.
+    // Late December — 3-month half-span (±45d) extends into the previous and
+    // next year. With a noon anchor: from = Nov 13 12:00 2026, to = Feb 11
+    // 12:00 2027.
     const now = DateTime.fromISO("2026-12-28T12:00:00", { zone: "utc" });
 
     expect(formatTimeWindowDateRange(SessionTimeWindow.Quarter, now)).toBe(
-      "Sep 29, 2026 – Mar 28, 2027"
+      "Nov 13, 2026 – Feb 11, 2027"
     );
   });
 
   it("uses the provided anchor exactly — does not round to day boundaries", () => {
-    // Same-day window (±24h around late-evening) shouldn't shift dates due
-    // to local-zone interpretation. The helper must respect whatever `now`
+    // Late-evening anchor: ±12h still produces a 24-hour total span but the
+    // calendar days shift forward. The helper must respect whatever `now`
     // it's given.
     const now = DateTime.fromISO("2026-05-04T22:00:00", { zone: "utc" });
 
-    // ±24h from 10pm May 4 UTC = 10pm May 3 UTC → 10pm May 5 UTC
-    // The format is `LLL d` (no time component), so calendar days are
-    // May 3 and May 5.
+    // ±12h from 10pm May 4 UTC = 10am May 4 UTC → 10am May 5 UTC.
+    // `LLL d` drops the time, so calendar days are May 4 and May 5.
     expect(formatTimeWindowDateRange(SessionTimeWindow.Day, now)).toBe(
-      "May 3 – May 5"
+      "May 4 – May 5"
     );
   });
 });

--- a/__tests__/components/ui/dashboard/coaching-sessions-filters.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-filters.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { DateTime } from "ts-luxon";
+import {
+  formatTimeWindowDateRange,
+  SessionTimeWindow,
+} from "@/components/ui/dashboard/coaching-sessions-filters";
+
+// ── formatTimeWindowDateRange ─────────────────────────────────────────────
+//
+// Pure helper that resolves a `SessionTimeWindow` into a calendar-date range
+// string, anchored at a caller-provided `now`. Used by both the header chip
+// (which shows the *current* range) and each dropdown option (which shows
+// what the user would get on selection). Output format:
+//
+//   - Same year:    "MMM d – MMM d"           e.g. "Apr 27 – May 11"
+//   - Cross-year:   "MMM d, yyyy – MMM d, yyyy" e.g. "Sep 29, 2026 – Mar 28, 2027"
+//
+// The same-year fast path keeps the chip narrow in the common case; the
+// cross-year fallback only kicks in at ±90d near year-end, which is rare but
+// must remain unambiguous (otherwise "Dec 28 – Jan 11" would read as the
+// same year's January).
+
+describe("formatTimeWindowDateRange", () => {
+  it("returns the same-year MMM d format when the range is within a single year", () => {
+    const now = DateTime.fromISO("2026-05-04T12:00:00", { zone: "utc" });
+
+    expect(formatTimeWindowDateRange(SessionTimeWindow.Day, now)).toBe(
+      "May 3 – May 5"
+    );
+    expect(formatTimeWindowDateRange(SessionTimeWindow.Week, now)).toBe(
+      "Apr 27 – May 11"
+    );
+    expect(formatTimeWindowDateRange(SessionTimeWindow.Month, now)).toBe(
+      "Apr 4 – Jun 3"
+    );
+  });
+
+  it("falls back to MMM d, yyyy when the range crosses a year boundary", () => {
+    // Late December — ±90 days extends into the previous and next year.
+    const now = DateTime.fromISO("2026-12-28T12:00:00", { zone: "utc" });
+
+    expect(formatTimeWindowDateRange(SessionTimeWindow.Quarter, now)).toBe(
+      "Sep 29, 2026 – Mar 28, 2027"
+    );
+  });
+
+  it("uses the provided anchor exactly — does not round to day boundaries", () => {
+    // Same-day window (±24h around late-evening) shouldn't shift dates due
+    // to local-zone interpretation. The helper must respect whatever `now`
+    // it's given.
+    const now = DateTime.fromISO("2026-05-04T22:00:00", { zone: "utc" });
+
+    // ±24h from 10pm May 4 UTC = 10pm May 3 UTC → 10pm May 5 UTC
+    // The format is `LLL d` (no time component), so calendar days are
+    // May 3 and May 5.
+    expect(formatTimeWindowDateRange(SessionTimeWindow.Day, now)).toBe(
+      "May 3 – May 5"
+    );
+  });
+});

--- a/__tests__/components/ui/dashboard/dashboard-container.test.tsx
+++ b/__tests__/components/ui/dashboard/dashboard-container.test.tsx
@@ -1,0 +1,173 @@
+import { useEffect } from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DashboardContainer } from "@/components/ui/dashboard/dashboard-container";
+
+// ── Auto-refresh contract (integration) ─────────────────────────────────
+//
+// `DashboardContainer` is the seam where the dialog-close → refresh wiring
+// lives. The dashboard's two user-scoped fetches (UpcomingSessionCard and
+// CoachingSessionsCard) both use tuple SWR keys (`[url, params]`). The
+// shared `useEntityMutation` auto-invalidation filters by `typeof key ===
+// "string"` and silently skips tuple keys, so both cards depend on the
+// container plumbing their `refresh()` callbacks back through the dialog
+// close path.
+//
+// Without this test, a future refactor that drops `onRefreshNeeded` from
+// either card (or fails to call the captured callbacks on dialog close)
+// would let stale create/edit data reach users without any unit-test
+// failure. The card-level tests pin each card's *outgoing* contract; this
+// test pins the container's *consumption* of both contracts together.
+
+// All imports of the actual cards/dialogs are mocked because the contract
+// under test lives in the container's wiring, not in the cards themselves.
+//
+// Each mock card calls the captured `onRefreshNeeded` with a fixed spy on
+// mount. The dialog mock exposes a button so the test can simulate
+// `onOpenChange(false)` (the close path the real dialog takes after a
+// create/edit submit).
+
+const upcomingSessionRefreshSpy = vi.fn();
+const coachingSessionsCardRefreshSpy = vi.fn();
+
+vi.mock("@/components/ui/dashboard/upcoming-session-card", () => ({
+  UpcomingSessionCard: ({
+    onRefreshNeeded,
+  }: {
+    onRefreshNeeded?: (fn: () => void) => void;
+  }) => {
+    // Defer the parent's `setState` until after render to mirror the real
+    // card's `useEffect`-based registration and avoid React's "setState
+    // during render" warning.
+    useEffect(() => {
+      onRefreshNeeded?.(upcomingSessionRefreshSpy);
+    }, [onRefreshNeeded]);
+    return <div data-testid="upcoming-session-card-stub" />;
+  },
+}));
+
+vi.mock("@/components/ui/dashboard/coaching-sessions-card", () => ({
+  CoachingSessionsCard: ({
+    onRefreshNeeded,
+  }: {
+    onRefreshNeeded?: (fn: () => void) => void;
+  }) => {
+    useEffect(() => {
+      onRefreshNeeded?.(coachingSessionsCardRefreshSpy);
+    }, [onRefreshNeeded]);
+    return <div data-testid="coaching-sessions-card-stub" />;
+  },
+}));
+
+vi.mock("@/components/ui/dashboard/goals-overview-card", () => ({
+  GoalsOverviewCard: () => <div data-testid="goals-overview-card-stub" />,
+}));
+
+vi.mock("@/components/ui/dashboard/dashboard-header", () => ({
+  DashboardHeader: ({ onCreateSession }: { onCreateSession: () => void }) => (
+    <button data-testid="open-dialog-stub" onClick={onCreateSession}>
+      Add New
+    </button>
+  ),
+}));
+
+// CoachingSessionDialog renders nothing meaningful but exposes a button
+// that fires `onOpenChange(false)` so the test can simulate the close
+// path. We use this rather than mounting the real dialog because the
+// real dialog requires a backend submit to fire the close callback.
+vi.mock("@/components/ui/dashboard/coaching-session-dialog", () => ({
+  CoachingSessionDialog: ({
+    open,
+    onOpenChange,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <button
+        data-testid="close-dialog-stub"
+        onClick={() => onOpenChange(false)}
+      >
+        Close
+      </button>
+    ) : null,
+}));
+
+// Container also pulls relationship state for the auto-select hook —
+// stub the surface to avoid pulling the whole zustand store stack into
+// the test.
+vi.mock("@/lib/api/coaching-relationships", () => ({
+  useCoachingRelationshipList: () => ({
+    relationships: [],
+    isLoading: false,
+  }),
+}));
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+}));
+vi.mock("@/lib/hooks/use-current-coaching-relationship", () => ({
+  useCurrentCoachingRelationship: () => ({
+    currentCoachingRelationshipId: undefined,
+    setCurrentCoachingRelationshipId: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/hooks/use-auto-select-single-relationship", () => ({
+  useAutoSelectSingleRelationship: () => undefined,
+}));
+
+describe("DashboardContainer auto-refresh wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures both cards' refresh callbacks on mount", () => {
+    render(<DashboardContainer />);
+
+    // Both cards register their refresh fn through the container's
+    // `onRefreshNeeded` callbacks. Failing here means the container
+    // either dropped a prop or stopped passing it.
+    expect(upcomingSessionRefreshSpy).not.toHaveBeenCalled();
+    expect(coachingSessionsCardRefreshSpy).not.toHaveBeenCalled();
+    // The card *stubs* are responsible for invoking onRefreshNeeded
+    // with these spies; the assertion above just establishes the
+    // baseline. The next test exercises the call path.
+  });
+
+  it("invokes BOTH card refreshes when the create/edit dialog closes", () => {
+    render(<DashboardContainer />);
+
+    // Pre-state: refreshes haven't been called as a result of dialog
+    // close yet (they're plumbed but the dialog is closed at mount).
+    upcomingSessionRefreshSpy.mockClear();
+    coachingSessionsCardRefreshSpy.mockClear();
+
+    // Open the dialog via the header stub.
+    fireEvent.click(screen.getByTestId("open-dialog-stub"));
+    // Dialog stub renders only when open.
+    expect(screen.getByTestId("close-dialog-stub")).toBeInTheDocument();
+
+    // Close the dialog via the stub's `onOpenChange(false)` button.
+    act(() => {
+      fireEvent.click(screen.getByTestId("close-dialog-stub"));
+    });
+
+    // The contract: dialog-close fires both refreshes. If a future
+    // refactor wires the dialog's onOpenChange to a path that only
+    // refreshes one card (or neither), this assertion will fail.
+    expect(upcomingSessionRefreshSpy).toHaveBeenCalledTimes(1);
+    expect(coachingSessionsCardRefreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire refreshes on initial mount (only on dialog close)", () => {
+    upcomingSessionRefreshSpy.mockClear();
+    coachingSessionsCardRefreshSpy.mockClear();
+
+    render(<DashboardContainer />);
+
+    // Mount alone — no dialog interaction yet — must not fire either
+    // refresh. If it did, every dashboard render would re-fetch, which
+    // would also break SWR's cache-warmth semantics elsewhere.
+    expect(upcomingSessionRefreshSpy).not.toHaveBeenCalled();
+    expect(coachingSessionsCardRefreshSpy).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/ui/dashboard/delete-session-dialog.test.tsx
+++ b/__tests__/components/ui/dashboard/delete-session-dialog.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { DeleteSessionDialog } from "@/components/ui/dashboard/delete-session-dialog";
+import { createMockEnrichedSession } from "../../../test-utils";
+
+// ── Standalone tests for the dialog ──────────────────────────────────────
+//
+// The card-level integration tests cover the wire-up (which menu fires what,
+// which mutation runs on confirm, which toast surfaces on failure). These
+// tests pin behavior that's hard to exercise through the card because the
+// mutation mock resolves synchronously — primarily the `isDeleting`
+// in-flight state and the unified dialog copy.
+
+describe("DeleteSessionDialog", () => {
+  function renderDialog(
+    overrides: Partial<React.ComponentProps<typeof DeleteSessionDialog>> = {}
+  ) {
+    const session = createMockEnrichedSession({
+      id: "s1",
+      date: "2099-03-15T14:00:00Z",
+    });
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+    render(
+      <DeleteSessionDialog
+        session={session}
+        participantName="Alex Chen"
+        userTimezone="UTC"
+        isDeleting={false}
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        {...overrides}
+      />
+    );
+    return { onCancel, onConfirm };
+  }
+
+  it("does not render the dialog when `session` is undefined", () => {
+    render(
+      <DeleteSessionDialog
+        session={undefined}
+        participantName=""
+        userTimezone="UTC"
+        isDeleting={false}
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole("alertdialog", {
+        name: /delete this coaching session/i,
+      })
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the unified copy that names the cascading loss explicitly", () => {
+    // The dialog deliberately uses the same copy for upcoming and previous
+    // sessions — one mental model, one piece of copy. For upcoming sessions
+    // the cascading-loss disclosure is informational (none yet); for
+    // previous sessions it's load-bearing. Either way, the user gets a
+    // consistent, irreversibility-aware confirmation.
+    renderDialog();
+    expect(
+      screen.getByText(/notes and completed actions/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/can't be undone/i)
+    ).toBeInTheDocument();
+  });
+
+  it("includes the participant name in the body", () => {
+    renderDialog({ participantName: "Bob Belderbos" });
+    expect(screen.getByText("Bob Belderbos")).toBeInTheDocument();
+  });
+
+  it("invokes onConfirm but keeps the dialog open across the await boundary so isDeleting can render", () => {
+    const { onConfirm } = renderDialog();
+    fireEvent.click(
+      screen.getByRole("button", { name: /^delete session$/i })
+    );
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    // Dialog is still mounted — closing is the parent's responsibility once
+    // the mutation settles. Without `e.preventDefault()` in the click
+    // handler, AlertDialogAction would close immediately, throwing away the
+    // "Deleting…" affordance.
+    expect(
+      screen.getByRole("alertdialog", {
+        name: /delete this coaching session/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onCancel when Cancel is clicked", () => {
+    const { onCancel } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both buttons while isDeleting and swaps the confirm label", () => {
+    renderDialog({ isDeleting: true });
+    const cancel = screen.getByRole("button", { name: /cancel/i });
+    const confirm = screen.getByRole("button", { name: /deleting/i });
+    expect(cancel).toBeDisabled();
+    expect(confirm).toBeDisabled();
+    // Sanity: the at-rest confirm copy isn't visible during the in-flight
+    // window — it's been replaced by the in-flight label.
+    expect(
+      screen.queryByRole("button", { name: /^delete session$/i })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/stores/coaching-sessions-card-filter-store.test.ts
+++ b/__tests__/stores/coaching-sessions-card-filter-store.test.ts
@@ -9,14 +9,17 @@ describe("CoachingSessionsCardFilterStore", () => {
     store = createCoachingSessionsCardFilterStore();
   });
 
-  it("initializes with the default time range and no relationship filter", () => {
-    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Day);
+  it("initializes with the default time range (Week) and no relationship filter", () => {
+    // Week (±7 days) is the default — picked to match the weekly coaching
+    // cadence so common cases (a session a couple days out) are visible
+    // without the user having to discover the Filters popover.
+    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Week);
     expect(store.getState().relationshipFilter).toBeUndefined();
   });
 
   it("sets and retrieves the time range", () => {
-    store.getState().setTimeWindow(SessionTimeWindow.Week);
-    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Week);
+    store.getState().setTimeWindow(SessionTimeWindow.Day);
+    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Day);
   });
 
   it("sets and retrieves the relationship filter", () => {
@@ -37,7 +40,7 @@ describe("CoachingSessionsCardFilterStore", () => {
 
     store.getState().resetCoachingSessionsCardFilters();
 
-    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Day);
+    expect(store.getState().timeWindow).toBe(SessionTimeWindow.Week);
     expect(store.getState().relationshipFilter).toBeUndefined();
   });
 });

--- a/__tests__/stores/coaching-sessions-card-filter-store.test.ts
+++ b/__tests__/stores/coaching-sessions-card-filter-store.test.ts
@@ -10,7 +10,7 @@ describe("CoachingSessionsCardFilterStore", () => {
   });
 
   it("initializes with the default time range (Week) and no relationship filter", () => {
-    // Week (±7 days) is the default — picked to match the weekly coaching
+    // Week (a 7-day span centered on now) is the default — picked to match the weekly coaching
     // cadence so common cases (a session a couple days out) are visible
     // without the user having to discover the Filters popover.
     expect(store.getState().timeWindow).toBe(SessionTimeWindow.Week);

--- a/src/components/ui/dashboard/coaching-sessions-card-header.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card-header.tsx
@@ -14,7 +14,13 @@ import {
   TIME_WINDOW_LABELS,
   type RelationshipOption,
 } from "@/components/ui/dashboard/coaching-sessions-filters";
+import { defaultInitState as filterStoreDefaults } from "@/lib/stores/coaching-sessions-card-filter-store";
 import type { Id } from "@/types/general";
+
+// Single source of truth for "what's the default time range?" — bound to
+// the persisted store's defaults so changing the default in one place can
+// never desynchronize the chip's reset behavior from the actual default.
+const DEFAULT_TIME_WINDOW = filterStoreDefaults.timeWindow;
 
 type SessionView = "list" | "timeline";
 
@@ -41,14 +47,15 @@ export function CoachingSessionsCardHeader({
 
       <div className="flex items-center gap-2 flex-wrap">
         {/* Time-window chip is always shown so the user can see the current
-            window at a glance. X resets to the default (24 hours). */}
+            window at a glance. X resets to whatever the store defaults to
+            (currently ±7 days — `DEFAULT_TIME_WINDOW`). */}
         <Badge variant="secondary" className="gap-1 text-xs h-7 pl-2.5 pr-1.5">
           {TIME_WINDOW_LABELS[timeWindow]}
-          {timeWindow !== SessionTimeWindow.Day && (
+          {timeWindow !== DEFAULT_TIME_WINDOW && (
             <button
               type="button"
               aria-label="Reset time window to default"
-              onClick={() => onTimeWindowChange(SessionTimeWindow.Day)}
+              onClick={() => onTimeWindowChange(DEFAULT_TIME_WINDOW)}
               className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
             >
               <X className="h-3 w-3" />

--- a/src/components/ui/dashboard/coaching-sessions-card-header.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card-header.tsx
@@ -59,7 +59,7 @@ export function CoachingSessionsCardHeader({
             keep the abstract size as their primary label since the user
             is choosing window *size*, not specific dates. X resets to
             whatever the store defaults to (sourced from
-            `defaultInitState`, currently ±7 days). */}
+            `defaultInitState`, currently a 1-week span). */}
         <Badge variant="secondary" className="gap-1 text-xs h-7 pl-2.5 pr-1.5 tabular-nums">
           {formatTimeWindowDateRange(timeWindow, now)}
           {timeWindow !== DEFAULT_TIME_WINDOW && (

--- a/src/components/ui/dashboard/coaching-sessions-card-header.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Clock, List, X } from "lucide-react";
+import { type DateTime } from "ts-luxon";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -11,7 +12,7 @@ import { cn } from "@/components/lib/utils";
 import {
   FiltersPopover,
   SessionTimeWindow,
-  TIME_WINDOW_LABELS,
+  formatTimeWindowDateRange,
   type RelationshipOption,
 } from "@/components/ui/dashboard/coaching-sessions-filters";
 import { defaultInitState as filterStoreDefaults } from "@/lib/stores/coaching-sessions-card-filter-store";
@@ -31,6 +32,11 @@ export interface CoachingSessionsCardHeaderProps {
   onRelationshipFilterChange: (id: Id | undefined) => void;
   relationshipOptions: RelationshipOption[];
   selectedRelationshipLabel: string | undefined;
+  /** The same `mountNow` the card uses to drive its session fetch. Anchors
+   *  the chip's resolved date range so chip text and visible rows always
+   *  agree, even if `DateTime.now()` would have shifted between mount and
+   *  this render. */
+  now: DateTime;
 }
 
 export function CoachingSessionsCardHeader({
@@ -40,17 +46,22 @@ export function CoachingSessionsCardHeader({
   onRelationshipFilterChange,
   relationshipOptions,
   selectedRelationshipLabel,
+  now,
 }: CoachingSessionsCardHeaderProps) {
   return (
     <div className="px-6 pt-6 pb-4 flex flex-wrap items-center justify-between gap-3 shrink-0">
       <h2 className="text-base font-semibold">Coaching Sessions</h2>
 
       <div className="flex items-center gap-2 flex-wrap">
-        {/* Time-window chip is always shown so the user can see the current
-            window at a glance. X resets to whatever the store defaults to
-            (currently ±7 days — `DEFAULT_TIME_WINDOW`). */}
-        <Badge variant="secondary" className="gap-1 text-xs h-7 pl-2.5 pr-1.5">
-          {TIME_WINDOW_LABELS[timeWindow]}
+        {/* Time-window chip shows the *resolved* calendar range (e.g.
+            "Apr 27 – May 11"), not the abstract size — answers "what am I
+            looking at right now?" more concretely. The dropdown options
+            keep the abstract size as their primary label since the user
+            is choosing window *size*, not specific dates. X resets to
+            whatever the store defaults to (sourced from
+            `defaultInitState`, currently ±7 days). */}
+        <Badge variant="secondary" className="gap-1 text-xs h-7 pl-2.5 pr-1.5 tabular-nums">
+          {formatTimeWindowDateRange(timeWindow, now)}
           {timeWindow !== DEFAULT_TIME_WINDOW && (
             <button
               type="button"
@@ -84,6 +95,7 @@ export function CoachingSessionsCardHeader({
           relationshipFilter={relationshipFilter}
           onRelationshipFilterChange={onRelationshipFilterChange}
           relationshipOptions={relationshipOptions}
+          now={now}
         />
         <ViewToggle />
       </div>

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { DateTime } from "ts-luxon";
 import { toast as sonnerToast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
@@ -41,6 +41,18 @@ const ENRICHMENT_INCLUDES = [
   CoachingSessionInclude.Relationship,
   CoachingSessionInclude.Goal,
 ];
+
+/**
+ * Models the only legal states of the delete-confirmation flow. Using a
+ * discriminated union over `{ session: T | undefined } + { isDeleting:
+ * boolean }` so the type system rejects `isDeleting=true` with no
+ * session — an impossible state that two parallel `useState` calls
+ * would silently allow.
+ */
+type DeleteDialogState =
+  | { kind: "closed" }
+  | { kind: "pending"; session: EnrichedCoachingSession }
+  | { kind: "deleting"; session: EnrichedCoachingSession };
 
 export interface CoachingSessionsCardProps {
   /** Opens the create/edit dialog with the given session pre-filled. */
@@ -182,13 +194,18 @@ export function CoachingSessionsCard({
   );
 
   // Surface refresh to the parent so dialog-close (after create/edit) can
-  // force a revalidate. The dependency array intentionally omits
-  // `refreshSessions` — SWR's mutate identity is stable per key, but adding
-  // it here would cause the parent's stored callback to swap on every
-  // window-tick re-render, defeating the parent's `useCallback` memo.
+  // force a revalidate. We pass an identity-stable wrapper that delegates
+  // to whatever `refreshSessions` is current at call time — keeps the
+  // parent's stored callback stable (no re-register storms on every
+  // window-tick re-render) without relying on SWR's mutate identity
+  // being stable, which is an undocumented implementation detail. Pattern
+  // mirrors the userland equivalent of `useEffectEvent`.
+  const refreshSessionsRef = useRef(refreshSessions);
   useEffect(() => {
-    onRefreshNeeded?.(refreshSessions);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    refreshSessionsRef.current = refreshSessions;
+  });
+  useEffect(() => {
+    onRefreshNeeded?.(() => refreshSessionsRef.current());
   }, [onRefreshNeeded]);
 
   // Sessions starting exactly at `now` belong in Upcoming. Previous is reversed
@@ -243,34 +260,42 @@ export function CoachingSessionsCard({
   // instance serves every row and SWR cache invalidation runs at the same
   // scope as the fetch that populated it. `useEntityMutation` auto-mutates
   // every SWR key matching the entity baseUrl on success — no manual
-  // refresh call is needed.
+  // refresh call is needed (but see #387 for the tuple-key gap that
+  // forces the explicit `refreshSessions()` below).
+  //
+  // Discriminated union models the only legal states: `closed`, `pending`
+  // (dialog open, awaiting confirm), `deleting` (mutation in flight). The
+  // alternative — separate `session: T | undefined` + `isDeleting:
+  // boolean` — admits an impossible state (deleting with no session)
+  // that the type system would never catch. Following the project's
+  // strict-nullability convention.
   const { delete: deleteSession } = useCoachingSessionMutation();
-  const [sessionPendingDelete, setSessionPendingDelete] = useState<
-    EnrichedCoachingSession | undefined
-  >(undefined);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteState, setDeleteState] = useState<DeleteDialogState>({
+    kind: "closed",
+  });
 
   const pendingParticipantName = useMemo(() => {
-    if (!sessionPendingDelete || !userSession) return "";
-    const info = getSessionParticipantInfo(sessionPendingDelete, userSession.id);
+    if (deleteState.kind === "closed" || !userSession) return "";
+    const info = getSessionParticipantInfo(deleteState.session, userSession.id);
     return info?.participantName ?? "Unknown";
-  }, [sessionPendingDelete, userSession]);
+  }, [deleteState, userSession]);
 
   const handleRequestDelete = useCallback(
-    (session: EnrichedCoachingSession) => setSessionPendingDelete(session),
+    (session: EnrichedCoachingSession) =>
+      setDeleteState({ kind: "pending", session }),
     []
   );
 
   const handleCancelDelete = useCallback(() => {
-    setSessionPendingDelete(undefined);
+    setDeleteState({ kind: "closed" });
   }, []);
 
   const handleConfirmDelete = useCallback(async () => {
-    if (!sessionPendingDelete) return;
-    const target = sessionPendingDelete;
-    setIsDeleting(true);
+    if (deleteState.kind !== "pending") return;
+    const { session } = deleteState;
+    setDeleteState({ kind: "deleting", session });
     try {
-      await deleteSession(target.id);
+      await deleteSession(session.id);
       // `useEntityMutation`'s built-in cache invalidation matches keys
       // containing the entity baseUrl (`coaching_sessions/`), but the
       // dashboard fetches via `useEnrichedCoachingSessionsForUser` which
@@ -281,17 +306,15 @@ export function CoachingSessionsCard({
       // already happened via the dialog), so this revalidate is
       // load-bearing.
       refreshSessions();
-      setSessionPendingDelete(undefined);
+      setDeleteState({ kind: "closed" });
     } catch (err) {
       sonnerToast.error("Failed to delete session", {
         description:
           err instanceof Error ? err.message : "Please try again.",
       });
-      setSessionPendingDelete(undefined);
-    } finally {
-      setIsDeleting(false);
+      setDeleteState({ kind: "closed" });
     }
-  }, [sessionPendingDelete, deleteSession, refreshSessions]);
+  }, [deleteState, deleteSession, refreshSessions]);
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -334,11 +357,16 @@ export function CoachingSessionsCard({
           )}
         </CardContent>
       </Card>
+      {/* Translate the discriminated state at the boundary — the dialog
+          remains a generic primitive that takes
+          `session?: T` + `isDeleting: boolean`. */}
       <DeleteSessionDialog
-        session={sessionPendingDelete}
+        session={
+          deleteState.kind === "closed" ? undefined : deleteState.session
+        }
         participantName={pendingParticipantName}
         userTimezone={userSession?.timezone || getBrowserTimezone()}
-        isDeleting={isDeleting}
+        isDeleting={deleteState.kind === "deleting"}
         onCancel={handleCancelDelete}
         onConfirm={handleConfirmDelete}
       />

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -311,6 +311,7 @@ export function CoachingSessionsCard({
             onRelationshipFilterChange={setRelationshipFilter}
             relationshipOptions={relationshipOptions}
             selectedRelationshipLabel={selectedRelationshipLabel}
+            now={mountNow}
           />
 
           {!userSession || isLoading ? (

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { DateTime } from "ts-luxon";
+import { toast as sonnerToast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -11,13 +12,18 @@ import {
   type RelationshipOption,
 } from "@/components/ui/dashboard/coaching-sessions-filters";
 import { CoachingSessionsListView } from "@/components/ui/dashboard/coaching-sessions-list-view";
+import { DeleteSessionDialog } from "@/components/ui/dashboard/delete-session-dialog";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useCoachingSessionsCardFilterStore } from "@/lib/providers/coaching-sessions-card-filter-store-provider";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
-import { useEnrichedCoachingSessionsForUser } from "@/lib/api/coaching-sessions";
+import {
+  useCoachingSessionMutation,
+  useEnrichedCoachingSessionsForUser,
+} from "@/lib/api/coaching-sessions";
 import { useUserActionsList } from "@/lib/api/user-actions";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
+import { getSessionParticipantInfo } from "@/lib/utils/session";
 import {
   CoachingSessionInclude,
   type CoachingSession,
@@ -39,6 +45,14 @@ const ENRICHMENT_INCLUDES = [
 export interface CoachingSessionsCardProps {
   /** Opens the create/edit dialog with the given session pre-filled. */
   onReschedule: (session: CoachingSession | EnrichedCoachingSession) => void;
+  /** Surfaces the card's internal SWR `refresh()` to the parent so it can
+   *  force a revalidate after a create/edit dialog closes. The
+   *  user-scoped enriched fetch uses a tuple SWR key (`[url, params]`),
+   *  which `useEntityMutation`'s auto-invalidation skips because it
+   *  filters by `typeof key === "string"`. Without this hook-up, newly-
+   *  created sessions wouldn't appear in the list until a hard reload.
+   *  Mirrors `UpcomingSessionCard.onRefreshNeeded`. */
+  onRefreshNeeded?: (refresh: () => void) => void;
 }
 
 /**
@@ -51,6 +65,7 @@ export interface CoachingSessionsCardProps {
  */
 export function CoachingSessionsCard({
   onReschedule,
+  onRefreshNeeded,
 }: CoachingSessionsCardProps) {
   const userSession = useAuthStore((s) => s.userSession);
   const userId = userSession?.id;
@@ -155,6 +170,7 @@ export function CoachingSessionsCard({
     enrichedSessions: allSessions,
     isLoading,
     isError,
+    refresh: refreshSessions,
   } = useEnrichedCoachingSessionsForUser(
     userId ?? null,
     fromDate,
@@ -164,6 +180,16 @@ export function CoachingSessionsCard({
     "asc",
     relationshipFilter
   );
+
+  // Surface refresh to the parent so dialog-close (after create/edit) can
+  // force a revalidate. The dependency array intentionally omits
+  // `refreshSessions` — SWR's mutate identity is stable per key, but adding
+  // it here would cause the parent's stored callback to swap on every
+  // window-tick re-render, defeating the parent's `useCallback` memo.
+  useEffect(() => {
+    onRefreshNeeded?.(refreshSessions);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onRefreshNeeded]);
 
   // Sessions starting exactly at `now` belong in Upcoming. Previous is reversed
   // so the most recent session appears first, matching the prior `desc` fetch.
@@ -212,6 +238,61 @@ export function CoachingSessionsCard({
       : undefined
   );
 
+  // ── Delete flow ──────────────────────────────────────────────────────
+  // The dialog and mutation live here (alongside SWR) so a single dialog
+  // instance serves every row and SWR cache invalidation runs at the same
+  // scope as the fetch that populated it. `useEntityMutation` auto-mutates
+  // every SWR key matching the entity baseUrl on success — no manual
+  // refresh call is needed.
+  const { delete: deleteSession } = useCoachingSessionMutation();
+  const [sessionPendingDelete, setSessionPendingDelete] = useState<
+    EnrichedCoachingSession | undefined
+  >(undefined);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const pendingParticipantName = useMemo(() => {
+    if (!sessionPendingDelete || !userSession) return "";
+    const info = getSessionParticipantInfo(sessionPendingDelete, userSession.id);
+    return info?.participantName ?? "Unknown";
+  }, [sessionPendingDelete, userSession]);
+
+  const handleRequestDelete = useCallback(
+    (session: EnrichedCoachingSession) => setSessionPendingDelete(session),
+    []
+  );
+
+  const handleCancelDelete = useCallback(() => {
+    setSessionPendingDelete(undefined);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!sessionPendingDelete) return;
+    const target = sessionPendingDelete;
+    setIsDeleting(true);
+    try {
+      await deleteSession(target.id);
+      // `useEntityMutation`'s built-in cache invalidation matches keys
+      // containing the entity baseUrl (`coaching_sessions/`), but the
+      // dashboard fetches via `useEnrichedCoachingSessionsForUser` which
+      // hits a *user-scoped* endpoint — its cache key doesn't match, so
+      // the deleted row would linger until a hard refresh. Pull the
+      // hook's own `refresh()` instead. Disappearance of the row is the
+      // only feedback the user gets (no success toast — confirmation
+      // already happened via the dialog), so this revalidate is
+      // load-bearing.
+      refreshSessions();
+      setSessionPendingDelete(undefined);
+    } catch (err) {
+      sonnerToast.error("Failed to delete session", {
+        description:
+          err instanceof Error ? err.message : "Please try again.",
+      });
+      setSessionPendingDelete(undefined);
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [sessionPendingDelete, deleteSession, refreshSessions]);
+
   return (
     <TooltipProvider delayDuration={200}>
       {/* `md:h-[360px]` is a *fixed* height (~50% taller than the two cards
@@ -247,10 +328,19 @@ export function CoachingSessionsCard({
               hoveredSession={hoveredSession}
               onHoverChange={setHoveredSessionId}
               onReschedule={onReschedule}
+              onRequestDelete={handleRequestDelete}
             />
           )}
         </CardContent>
       </Card>
+      <DeleteSessionDialog
+        session={sessionPendingDelete}
+        participantName={pendingParticipantName}
+        userTimezone={userSession?.timezone || getBrowserTimezone()}
+        isDeleting={isDeleting}
+        onCancel={handleCancelDelete}
+        onConfirm={handleConfirmDelete}
+      />
     </TooltipProvider>
   );
 }

--- a/src/components/ui/dashboard/coaching-sessions-filters.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-filters.tsx
@@ -37,15 +37,14 @@ export const TIME_WINDOW_DURATIONS: Record<SessionTimeWindow, DurationObject> = 
   [SessionTimeWindow.Quarter]: { days: 90 },
 };
 
-// `+/-` prefix signals symmetry around `now` — sessions within this range
-// before and after the current time are both shown. Used as the abstract
-// label in the dropdown (where the user is choosing window *size*, not a
-// specific date range).
+// Natural-language window sizes. The symmetry-around-now signal is carried
+// by the resolved date range shown beneath each option (and in the header
+// chip), so the abstract label can stay short and conversational.
 export const TIME_WINDOW_LABELS: Record<SessionTimeWindow, string> = {
-  [SessionTimeWindow.Day]: "+/- 24 hours",
-  [SessionTimeWindow.Week]: "+/- 7 days",
-  [SessionTimeWindow.Month]: "+/- 30 days",
-  [SessionTimeWindow.Quarter]: "+/- 90 days",
+  [SessionTimeWindow.Day]: "1 day",
+  [SessionTimeWindow.Week]: "1 week",
+  [SessionTimeWindow.Month]: "1 month",
+  [SessionTimeWindow.Quarter]: "3 months",
 };
 
 /**

--- a/src/components/ui/dashboard/coaching-sessions-filters.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-filters.tsx
@@ -137,17 +137,35 @@ export function FiltersPopover({
                 className="w-full h-7 text-xs"
                 aria-label="Time Range"
               >
-                <SelectValue />
+                {/* Render the trigger content explicitly instead of using
+                    `<SelectValue />`. Radix's `<SelectValue />` clones the
+                    selected `<SelectItem>`'s children verbatim — which
+                    means our two-line `flex flex-col` (abstract label +
+                    date hint) would render stacked inside the 28px-tall
+                    trigger, distorting its height and making it
+                    inconsistent with the Relationship select below. The
+                    Select is controlled (`value={timeWindow}`), so we
+                    can render the abstract label directly here. The
+                    stacked layout still renders inside each option in
+                    `<SelectContent>` — that's the "preview" surface. */}
+                <span>{TIME_WINDOW_LABELS[timeWindow]}</span>
               </SelectTrigger>
               <SelectContent>
                 {/* Each option pairs the abstract size with the concrete
                     resolved range for that size against `now`. The abstract
                     label is the primary read; the date range is a small
                     secondary hint that previews what the user will get on
-                    selection — matches the chip's date-range display. */}
+                    selection — matches the chip's date-range display.
+                    `textValue` is kept so Radix's type-ahead matching
+                    uses the abstract label instead of the concatenated
+                    "{abstract}{date-range}" textContent. */}
                 {(Object.values(SessionTimeWindow) as SessionTimeWindow[]).map(
                   (w) => (
-                    <SelectItem key={w} value={w}>
+                    <SelectItem
+                      key={w}
+                      value={w}
+                      textValue={TIME_WINDOW_LABELS[w]}
+                    >
                       <div className="flex flex-col gap-0.5">
                         <span>{TIME_WINDOW_LABELS[w]}</span>
                         <span className="text-[11px] text-muted-foreground/70 tabular-nums">

--- a/src/components/ui/dashboard/coaching-sessions-filters.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-filters.tsx
@@ -30,11 +30,17 @@ export enum SessionTimeWindow {
   Quarter = "90d",
 }
 
+// These are *half-spans*, applied symmetrically as `now - duration` and
+// `now + duration`. The total visible window therefore equals the labeled
+// size (1 day = 24h total, 1 week = 7d total, etc.) — matching what the
+// dropdown labels promise. An earlier version stored full spans here,
+// which made "1 day" silently render a 48-hour window across 3 calendar
+// dates; this naming makes the doubling explicit at the source.
 export const TIME_WINDOW_DURATIONS: Record<SessionTimeWindow, DurationObject> = {
-  [SessionTimeWindow.Day]: { hours: 24 },
-  [SessionTimeWindow.Week]: { days: 7 },
-  [SessionTimeWindow.Month]: { days: 30 },
-  [SessionTimeWindow.Quarter]: { days: 90 },
+  [SessionTimeWindow.Day]: { hours: 12 },
+  [SessionTimeWindow.Week]: { days: 3, hours: 12 },
+  [SessionTimeWindow.Month]: { days: 15 },
+  [SessionTimeWindow.Quarter]: { days: 45 },
 };
 
 // Natural-language window sizes. The symmetry-around-now signal is carried
@@ -55,7 +61,7 @@ export const TIME_WINDOW_LABELS: Record<SessionTimeWindow, string> = {
  *
  * Format: `MMM d – MMM d` when both ends are in the same year; falls back to
  * `MMM d, yyyy – MMM d, yyyy` when the range crosses a year boundary
- * (only realistic at ±90d near year-end). Day-of-month digits stay tabular
+ * (only realistic for the 3-month option near year-end). Day-of-month digits stay tabular
  * via `tabular-nums` at the call site if vertical alignment matters.
  */
 export function formatTimeWindowDateRange(

--- a/src/components/ui/dashboard/coaching-sessions-filters.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-filters.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { ListFilter } from "lucide-react";
-import { type DurationObject } from "ts-luxon";
+import { type DateTime, type DurationObject } from "ts-luxon";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import {
@@ -38,13 +38,37 @@ export const TIME_WINDOW_DURATIONS: Record<SessionTimeWindow, DurationObject> = 
 };
 
 // `+/-` prefix signals symmetry around `now` — sessions within this range
-// before and after the current time are both shown.
+// before and after the current time are both shown. Used as the abstract
+// label in the dropdown (where the user is choosing window *size*, not a
+// specific date range).
 export const TIME_WINDOW_LABELS: Record<SessionTimeWindow, string> = {
   [SessionTimeWindow.Day]: "+/- 24 hours",
   [SessionTimeWindow.Week]: "+/- 7 days",
   [SessionTimeWindow.Month]: "+/- 30 days",
   [SessionTimeWindow.Quarter]: "+/- 90 days",
 };
+
+/**
+ * Resolves a `SessionTimeWindow` into a concrete calendar-date range string,
+ * relative to a given `now`. Used for surfaces that benefit from concreteness
+ * — the header's active-state chip and (as a secondary line) each dropdown
+ * option — while the abstract `TIME_WINDOW_LABELS` remain the primary label.
+ *
+ * Format: `MMM d – MMM d` when both ends are in the same year; falls back to
+ * `MMM d, yyyy – MMM d, yyyy` when the range crosses a year boundary
+ * (only realistic at ±90d near year-end). Day-of-month digits stay tabular
+ * via `tabular-nums` at the call site if vertical alignment matters.
+ */
+export function formatTimeWindowDateRange(
+  window: SessionTimeWindow,
+  now: DateTime
+): string {
+  const duration = TIME_WINDOW_DURATIONS[window];
+  const from = now.minus(duration);
+  const to = now.plus(duration);
+  const fmt = from.year === to.year ? "LLL d" : "LLL d, yyyy";
+  return `${from.toFormat(fmt)} – ${to.toFormat(fmt)}`;
+}
 
 export interface RelationshipOption {
   id: Id;
@@ -57,6 +81,11 @@ export interface FiltersPopoverProps {
   relationshipFilter: Id | undefined;
   onRelationshipFilterChange: (id: Id | undefined) => void;
   relationshipOptions: RelationshipOption[];
+  /** Anchor for resolving each dropdown option into a concrete date range.
+   *  Sourced from the card's `mountNow` so the displayed ranges match the
+   *  data the user will see on selection — single source of truth for
+   *  "what does the data fetch consider 'now'?". */
+  now: DateTime;
 }
 
 export function FiltersPopover({
@@ -65,6 +94,7 @@ export function FiltersPopover({
   relationshipFilter,
   onRelationshipFilterChange,
   relationshipOptions,
+  now,
 }: FiltersPopoverProps) {
   const [open, setOpen] = useState(false);
 
@@ -110,10 +140,20 @@ export function FiltersPopover({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
+                {/* Each option pairs the abstract size with the concrete
+                    resolved range for that size against `now`. The abstract
+                    label is the primary read; the date range is a small
+                    secondary hint that previews what the user will get on
+                    selection — matches the chip's date-range display. */}
                 {(Object.values(SessionTimeWindow) as SessionTimeWindow[]).map(
                   (w) => (
                     <SelectItem key={w} value={w}>
-                      {TIME_WINDOW_LABELS[w]}
+                      <div className="flex flex-col gap-0.5">
+                        <span>{TIME_WINDOW_LABELS[w]}</span>
+                        <span className="text-[11px] text-muted-foreground/70 tabular-nums">
+                          {formatTimeWindowDateRange(w, now)}
+                        </span>
+                      </div>
                     </SelectItem>
                   )
                 )}

--- a/src/components/ui/dashboard/coaching-sessions-list-view.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-list-view.tsx
@@ -33,6 +33,9 @@ export interface CoachingSessionsListViewProps {
   /** Notifies the parent of hover changes (or clears with `undefined`). */
   onHoverChange: (id: Id | undefined) => void;
   onReschedule: (session: EnrichedCoachingSession) => void;
+  /** Surfaces a row's "Delete" intent up to the card so the dialog and
+   *  mutation live alongside the SWR cache they invalidate. */
+  onRequestDelete: (session: EnrichedCoachingSession) => void;
 }
 
 export function CoachingSessionsListView({
@@ -45,6 +48,7 @@ export function CoachingSessionsListView({
   hoveredSession,
   onHoverChange,
   onReschedule,
+  onRequestDelete,
 }: CoachingSessionsListViewProps) {
   // Combined list is needed for the helper's prev-session lookup within the
   // hovered session's relationship.
@@ -106,6 +110,7 @@ export function CoachingSessionsListView({
             hoveredId={hoveredSessionId}
             onHover={onHoverChange}
             onReschedule={onReschedule}
+            onRequestDelete={onRequestDelete}
           />
         </TabsContent>
 
@@ -118,6 +123,7 @@ export function CoachingSessionsListView({
             hoveredId={hoveredSessionId}
             onHover={onHoverChange}
             onReschedule={onReschedule}
+            onRequestDelete={onRequestDelete}
           />
         </TabsContent>
       </Tabs>
@@ -152,6 +158,7 @@ interface SessionListColumnProps {
   hoveredId: Id | undefined;
   onHover: (id: Id | undefined) => void;
   onReschedule: (session: EnrichedCoachingSession) => void;
+  onRequestDelete: (session: EnrichedCoachingSession) => void;
 }
 
 function SessionListColumn({
@@ -162,6 +169,7 @@ function SessionListColumn({
   hoveredId,
   onHover,
   onReschedule,
+  onRequestDelete,
 }: SessionListColumnProps) {
   if (sessions.length === 0) {
     return (
@@ -183,6 +191,7 @@ function SessionListColumn({
           isHovered={hoveredId === session.id}
           onHover={onHover}
           onReschedule={onReschedule}
+          onRequestDelete={onRequestDelete}
         />
       ))}
     </div>

--- a/src/components/ui/dashboard/coaching-sessions-row.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-row.tsx
@@ -54,14 +54,12 @@ export function SessionRow({
   // Delete is coach-only across both tabs — the cost asymmetry between
   // upcoming and previous deletions is conveyed by the dialog copy, not by
   // gating availability.
-  // Share link is available to *any* viewer on *any* tab — it's a read-only
-  // operation that produces a URL the recipient can navigate to (and the
-  // backend will gate on actual access). Restoring this from the legacy
-  // CoachingSessionList ensures the kebab covers the full former feature set.
+  // Share link is available to every viewer on every tab — read-only,
+  // produces a URL the recipient can navigate to (the backend gates on
+  // actual access). Because Share is universal, the kebab itself is
+  // never empty — the dropdown is rendered unconditionally below.
   const canReschedule = !isPast && participant?.isCoach === true;
   const canDelete = participant?.isCoach === true;
-  const canShareLink = true;
-  const hasMenuItems = canReschedule || canShareLink || canDelete;
 
   const participantName = participant?.participantName ?? "Unknown";
   const participantInitials = participant
@@ -122,62 +120,60 @@ export function SessionRow({
           "[&:has([data-state=open])]:opacity-100"
         )}
       >
-        {hasMenuItems && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Session actions"
-                // `rounded-full` is what gives the hover background a circle
-                // shape (Mercury's idiom) instead of the default rounded
-                // square. `[&_svg]:!h-4 !w-4` defends against the
-                // `buttonVariants` `[&_svg]:size-4` rule documented in
-                // memory — explicit is safer than relying on the default.
-                className="rounded-full h-8 w-8 text-muted-foreground/60 hover:text-foreground"
+        {/* Kebab is rendered unconditionally — Share link is universal so
+            the menu is never empty. Reschedule and Delete render only
+            when the viewer has the corresponding capability; Share link
+            is always present. */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              aria-label="Session actions"
+              // `rounded-full` is what gives the hover background a circle
+              // shape (Mercury's idiom) instead of the default rounded
+              // square. `[&_svg]:!h-4 !w-4` defends against the
+              // `buttonVariants` `[&_svg]:size-4` rule documented in
+              // memory — explicit is safer than relying on the default.
+              className="rounded-full h-8 w-8 text-muted-foreground/60 hover:text-foreground"
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canReschedule && (
+              <DropdownMenuItem
+                onClick={() => onReschedule(session)}
+                data-testid="session-row-reschedule"
               >
-                <MoreVertical className="h-4 w-4" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {canReschedule && (
-                <DropdownMenuItem
-                  onClick={() => onReschedule(session)}
-                  data-testid="session-row-reschedule"
-                >
-                  Reschedule
-                </DropdownMenuItem>
-              )}
-              {canShareLink && (
-                <DropdownMenuItem
-                  // Fire-and-forget: `copyCoachingSessionLinkWithToast`
-                  // surfaces both success ("link copied") and error toasts
-                  // itself, so the row doesn't need to handle either.
-                  onClick={() =>
-                    void copyCoachingSessionLinkWithToast(session.id)
-                  }
-                  data-testid="session-row-share-link"
-                >
-                  <Link2 className="mr-2 h-4 w-4" />
-                  Share link
-                </DropdownMenuItem>
-              )}
-              {(canReschedule || canShareLink) && canDelete && (
-                <DropdownMenuSeparator />
-              )}
-              {canDelete && (
-                <DropdownMenuItem
-                  onClick={() => onRequestDelete(session)}
-                  className="text-destructive focus:text-destructive focus:bg-destructive/10"
-                  data-testid="session-row-delete"
-                >
-                  <Trash2 className="mr-2 h-4 w-4" />
-                  Delete session
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+                Reschedule
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              // Fire-and-forget: `copyCoachingSessionLinkWithToast`
+              // surfaces both success ("link copied") and error toasts
+              // itself, so the row doesn't need to handle either.
+              onClick={() =>
+                void copyCoachingSessionLinkWithToast(session.id)
+              }
+              data-testid="session-row-share-link"
+            >
+              <Link2 className="mr-2 h-4 w-4" />
+              Share link
+            </DropdownMenuItem>
+            {canDelete && <DropdownMenuSeparator />}
+            {canDelete && (
+              <DropdownMenuItem
+                onClick={() => onRequestDelete(session)}
+                className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                data-testid="session-row-delete"
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Delete session
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
         <Link href={`/coaching-sessions/${session.id}`}>
           <Button
             variant={isPast ? "outline" : "default"}

--- a/src/components/ui/dashboard/coaching-sessions-row.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-row.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { DateTime } from "ts-luxon";
-import { MoreVertical, Trash2 } from "lucide-react";
+import { Link2, MoreVertical, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,6 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { copyCoachingSessionLinkWithToast } from "@/components/ui/share-session-link";
 import { cn } from "@/components/lib/utils";
 import { formatDateWithTime } from "@/lib/utils/date";
 import { getSessionParticipantInfo } from "@/lib/utils/session";
@@ -53,9 +54,14 @@ export function SessionRow({
   // Delete is coach-only across both tabs — the cost asymmetry between
   // upcoming and previous deletions is conveyed by the dialog copy, not by
   // gating availability.
+  // Share link is available to *any* viewer on *any* tab — it's a read-only
+  // operation that produces a URL the recipient can navigate to (and the
+  // backend will gate on actual access). Restoring this from the legacy
+  // CoachingSessionList ensures the kebab covers the full former feature set.
   const canReschedule = !isPast && participant?.isCoach === true;
   const canDelete = participant?.isCoach === true;
-  const hasMenuItems = canReschedule || canDelete;
+  const canShareLink = true;
+  const hasMenuItems = canReschedule || canShareLink || canDelete;
 
   const participantName = participant?.participantName ?? "Unknown";
   const participantInitials = participant
@@ -142,7 +148,23 @@ export function SessionRow({
                   Reschedule
                 </DropdownMenuItem>
               )}
-              {canReschedule && canDelete && <DropdownMenuSeparator />}
+              {canShareLink && (
+                <DropdownMenuItem
+                  // Fire-and-forget: `copyCoachingSessionLinkWithToast`
+                  // surfaces both success ("link copied") and error toasts
+                  // itself, so the row doesn't need to handle either.
+                  onClick={() =>
+                    void copyCoachingSessionLinkWithToast(session.id)
+                  }
+                  data-testid="session-row-share-link"
+                >
+                  <Link2 className="mr-2 h-4 w-4" />
+                  Share link
+                </DropdownMenuItem>
+              )}
+              {(canReschedule || canShareLink) && canDelete && (
+                <DropdownMenuSeparator />
+              )}
               {canDelete && (
                 <DropdownMenuItem
                   onClick={() => onRequestDelete(session)}

--- a/src/components/ui/dashboard/coaching-sessions-row.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-row.tsx
@@ -3,8 +3,16 @@
 import { useMemo } from "react";
 import Link from "next/link";
 import { DateTime } from "ts-luxon";
+import { MoreVertical, Trash2 } from "lucide-react";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/components/lib/utils";
 import { formatDateWithTime } from "@/lib/utils/date";
 import { getSessionParticipantInfo } from "@/lib/utils/session";
@@ -20,6 +28,10 @@ export interface SessionRowProps {
   isHovered: boolean;
   onHover: (id: Id | undefined) => void;
   onReschedule: (session: EnrichedCoachingSession) => void;
+  /** Hands the session up to the card so it can drive the
+   *  `<DeleteSessionDialog>` and the delete mutation. Not invoked on
+   *  rows where the viewer isn't a coach — the kebab item is hidden. */
+  onRequestDelete: (session: EnrichedCoachingSession) => void;
 }
 
 export function SessionRow({
@@ -30,13 +42,21 @@ export function SessionRow({
   isHovered,
   onHover,
   onReschedule,
+  onRequestDelete,
 }: SessionRowProps) {
   const participant = useMemo(
     () => getSessionParticipantInfo(session, viewerId),
     [session, viewerId]
   );
 
-  const showReschedule = !isPast && participant?.isCoach === true;
+  // Reschedule remains coach-only and upcoming-only (matches prior behavior).
+  // Delete is coach-only across both tabs — the cost asymmetry between
+  // upcoming and previous deletions is conveyed by the dialog copy, not by
+  // gating availability.
+  const canReschedule = !isPast && participant?.isCoach === true;
+  const canDelete = participant?.isCoach === true;
+  const hasMenuItems = canReschedule || canDelete;
+
   const participantName = participant?.participantName ?? "Unknown";
   const participantInitials = participant
     ? userSessionFirstLastLettersToString(
@@ -81,20 +101,60 @@ export function SessionRow({
         </div>
       </div>
 
-      {/* Hover-revealed actions are desktop-only; touch devices can't trigger
-          hover, so on mobile we hide them entirely and the user navigates by
-          tapping the link below (Join/View). `h-8 text-xs` matches the
-          UpcomingSessionCard footer button sizing. */}
-      <div className="hidden sm:flex gap-1.5 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
-        {showReschedule && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-xs h-8"
-            onClick={() => onReschedule(session)}
-          >
-            Reschedule
-          </Button>
+      {/* Right-side actions. Kebab + Join/View ride together in one block.
+          Mobile (always visible): touch users have no hover, so they need
+          the kebab to reach Delete and the link to navigate. Desktop
+          (hover-revealed): keeps the row visually quiet at rest, surfaces
+          actions when the row is engaged. */}
+      <div
+        className={cn(
+          "flex gap-1.5 shrink-0 items-center",
+          "sm:opacity-0 sm:group-hover:opacity-100 sm:transition-opacity",
+          // Keep the menu/popover affordances open while the user is
+          // interacting with them — Radix sets `data-state=open` on the
+          // hovered row (kebab button), so we keep the action group visible.
+          "[&:has([data-state=open])]:opacity-100"
+        )}
+      >
+        {hasMenuItems && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Session actions"
+                // `rounded-full` is what gives the hover background a circle
+                // shape (Mercury's idiom) instead of the default rounded
+                // square. `[&_svg]:!h-4 !w-4` defends against the
+                // `buttonVariants` `[&_svg]:size-4` rule documented in
+                // memory — explicit is safer than relying on the default.
+                className="rounded-full h-8 w-8 text-muted-foreground/60 hover:text-foreground"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {canReschedule && (
+                <DropdownMenuItem
+                  onClick={() => onReschedule(session)}
+                  data-testid="session-row-reschedule"
+                >
+                  Reschedule
+                </DropdownMenuItem>
+              )}
+              {canReschedule && canDelete && <DropdownMenuSeparator />}
+              {canDelete && (
+                <DropdownMenuItem
+                  onClick={() => onRequestDelete(session)}
+                  className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                  data-testid="session-row-delete"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete session
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
         <Link href={`/coaching-sessions/${session.id}`}>
           <Button
@@ -106,21 +166,6 @@ export function SessionRow({
           </Button>
         </Link>
       </div>
-
-      {/* Mobile-only always-visible affordance — touch users get a tap target
-          without needing hover. */}
-      <Link
-        href={`/coaching-sessions/${session.id}`}
-        className="sm:hidden shrink-0"
-      >
-        <Button
-          variant={isPast ? "outline" : "default"}
-          size="sm"
-          className="text-xs h-8"
-        >
-          {isPast ? "View" : "Join"}
-        </Button>
-      </Link>
     </div>
   );
 }

--- a/src/components/ui/dashboard/dashboard-container.tsx
+++ b/src/components/ui/dashboard/dashboard-container.tsx
@@ -37,6 +37,7 @@ export function DashboardContainer() {
     CoachingSession | undefined
   >();
   const [refreshUpcomingSession, setRefreshUpcomingSession] = useState<(() => void) | null>(() => null);
+  const [refreshSessionsCard, setRefreshSessionsCard] = useState<(() => void) | null>(() => null);
 
   const handleOpenDialog = (session?: CoachingSession | EnrichedCoachingSession) => {
     setSessionToEdit(session);
@@ -46,14 +47,24 @@ export function DashboardContainer() {
   const handleCloseDialog = () => {
     setDialogOpen(false);
     setSessionToEdit(undefined);
-    // Force-refresh the upcoming session card after create/edit.
+    // Force-refresh BOTH affected surfaces after create/edit. The
+    // user-scoped fetches behind these cards use a tuple SWR key
+    // (`[url, params]`) which `useEntityMutation`'s auto-invalidation
+    // skips (it filters by `typeof key === "string"`), so without these
+    // explicit calls a newly-created session wouldn't appear in either
+    // card until a hard reload.
     refreshUpcomingSession?.();
+    refreshSessionsCard?.();
   };
 
-  // Stable reference so the card's onRefreshNeeded useEffect doesn't refire
-  // on every parent render.
-  const handleRefreshNeeded = useCallback(
+  // Stable references so the cards' onRefreshNeeded useEffects don't
+  // refire on every parent render.
+  const handleUpcomingSessionRefreshNeeded = useCallback(
     (refreshFn: () => void) => setRefreshUpcomingSession(() => refreshFn),
+    [],
+  );
+  const handleSessionsCardRefreshNeeded = useCallback(
+    (refreshFn: () => void) => setRefreshSessionsCard(() => refreshFn),
     [],
   );
 
@@ -67,13 +78,16 @@ export function DashboardContainer() {
         <UpcomingSessionCard
           onReschedule={handleOpenDialog}
           onCreateSession={() => handleOpenDialog()}
-          onRefreshNeeded={handleRefreshNeeded}
+          onRefreshNeeded={handleUpcomingSessionRefreshNeeded}
         />
         <GoalsOverviewCard />
       </div>
 
       <div className="w-full">
-        <CoachingSessionsCard onReschedule={handleOpenDialog} />
+        <CoachingSessionsCard
+          onReschedule={handleOpenDialog}
+          onRefreshNeeded={handleSessionsCardRefreshNeeded}
+        />
       </div>
       <CoachingSessionDialog
         open={dialogOpen}

--- a/src/components/ui/dashboard/delete-session-dialog.tsx
+++ b/src/components/ui/dashboard/delete-session-dialog.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { DateTime } from "ts-luxon";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/components/lib/utils";
+import { formatDateWithTime } from "@/lib/utils/date";
+import type { EnrichedCoachingSession } from "@/types/coaching-session";
+
+export interface DeleteSessionDialogProps {
+  /** The session pending deletion. `undefined` means closed. Driving open
+   *  state from this single value (instead of a parallel boolean) prevents
+   *  desync between the dialog and the row that triggered it. */
+  session: EnrichedCoachingSession | undefined;
+  participantName: string;
+  userTimezone: string;
+  /** While true, both buttons are disabled and the confirm button reads
+   *  "Deleting…". The dialog cannot be dismissed via overlay/escape during
+   *  this window — closing mid-flight would orphan the API call's UI
+   *  effects. */
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteSessionDialog({
+  session,
+  participantName,
+  userTimezone,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: DeleteSessionDialogProps) {
+  const open = session !== undefined;
+
+  const dateLabel = session
+    ? formatDateWithTime(
+        DateTime.fromISO(session.date, { zone: "utc" }).setZone(userTimezone),
+        "·"
+      )
+    : "";
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Only honor close transitions, and only when not in-flight. Open is
+        // driven exclusively by `session !== undefined`.
+        if (!next && !isDeleting) onCancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this coaching session?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {/* Unified copy across both tabs. We always disclose the
+                cascading loss (notes, completed actions) — for upcoming
+                sessions this is harmlessly informational since none have
+                accumulated yet, and the consistency keeps the friction
+                appropriate to the irreversibility of the action. */}
+            This will permanently remove the session with{" "}
+            <span className="font-medium text-foreground">
+              {participantName}
+            </span>{" "}
+            on{" "}
+            <span className="font-medium text-foreground tabular-nums">
+              {dateLabel}
+            </span>
+            , along with all of its notes and completed actions. This
+            can&apos;t be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          {/* Don't wire `onCancel` here — `AlertDialogCancel` already
+              triggers `onOpenChange(false)`, which in turn calls onCancel.
+              A direct `onClick` would double-fire it. */}
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            // `e.preventDefault()` keeps the dialog open across the await
+            // boundary so the in-flight "Deleting…" label is visible. The
+            // parent closes the dialog by clearing `session` once the
+            // mutation settles.
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={isDeleting}
+            className={cn(buttonVariants({ variant: "destructive" }))}
+          >
+            {isDeleting ? "Deleting…" : "Delete session"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/lib/stores/coaching-sessions-card-filter-store.ts
+++ b/src/lib/stores/coaching-sessions-card-filter-store.ts
@@ -18,11 +18,12 @@ export type CoachingSessionsCardFilterStore =
   CoachingSessionsCardFilterState & CoachingSessionsCardFilterActions;
 
 export const defaultInitState: CoachingSessionsCardFilterState = {
-  // Week (±7 days) instead of Day. Coaching cadence is weekly, so a 24-hour
-  // window left common cases (like a session two days out) silently invisible
-  // until the user discovered the Filters popover. Week matches users'
-  // natural mental scheduling unit and surfaces near-term sessions on first
-  // load. The fetch cost difference is negligible at typical session counts.
+  // Week (a 7-day total span centered on now) instead of Day. Coaching
+  // cadence is weekly, so a 1-day window left common cases (like a session
+  // two days out) silently invisible until the user discovered the Filters
+  // popover. Week matches users' natural mental scheduling unit and surfaces
+  // near-term sessions on first load. The fetch cost difference is
+  // negligible at typical session counts.
   timeWindow: SessionTimeWindow.Week,
   relationshipFilter: undefined,
 };

--- a/src/lib/stores/coaching-sessions-card-filter-store.ts
+++ b/src/lib/stores/coaching-sessions-card-filter-store.ts
@@ -18,7 +18,12 @@ export type CoachingSessionsCardFilterStore =
   CoachingSessionsCardFilterState & CoachingSessionsCardFilterActions;
 
 export const defaultInitState: CoachingSessionsCardFilterState = {
-  timeWindow: SessionTimeWindow.Day,
+  // Week (±7 days) instead of Day. Coaching cadence is weekly, so a 24-hour
+  // window left common cases (like a session two days out) silently invisible
+  // until the user discovered the Filters popover. Week matches users'
+  // natural mental scheduling unit and surfaces near-term sessions on first
+  // load. The fetch cost difference is negligible at typical session counts.
+  timeWindow: SessionTimeWindow.Week,
   relationshipFilter: undefined,
 };
 


### PR DESCRIPTION
## Description

Restores the session delete affordance lost when the legacy `CoachingSessionList` was replaced in #382, and folds in adjacent UX polish on the new `CoachingSessionsCard` surfaced during the same iteration.

### Changes

**Delete via kebab + auto-refresh** ([4eda6887](https://github.com/refactor-group/refactor-platform-fe/commit/4eda6887))
* Vertical `⋯` kebab on each row (ghost circular button, hover-revealed on desktop, always-visible on mobile) with Reschedule / Share link / Delete session items, gated by viewer role.
* `AlertDialog` confirmation with unified copy on both tabs (names the cascading loss for honest disclosure regardless of whether children have accumulated yet). No undo toast — the disappearing row is the feedback.
* Fixes a latent SWR bug surfaced in the process: `useEntityMutation`'s auto-invalidation filters cache keys by `typeof key === "string"` and silently skips tuple-keyed `useEntityList` caches, so the dashboard list never refreshed after a mutation. Both `CoachingSessionsCard` and `DashboardContainer` are now wired through the existing `onRefreshNeeded` pattern (mirroring `UpcomingSessionCard`) so create/edit/delete force a revalidate without a hard reload.

**Default time range bumped from 1 day to 1 week** ([97a75a21](https://github.com/refactor-group/refactor-platform-fe/commit/97a75a21))
* The card defaulted to a 1-day window, which silently hid sessions even a couple days out — every user had to discover the Filters popover before the dashboard reflected their week. Default is now 1 week (a 7-day span centered on now), sourced from `defaultInitState` so future bumps stay in sync with the chip's reset behavior.

**Time-range chip + dropdown UX** ([d0d183e6](https://github.com/refactor-group/refactor-platform-fe/commit/d0d183e6), [c1005612](https://github.com/refactor-group/refactor-platform-fe/commit/c1005612), [983d924e](https://github.com/refactor-group/refactor-platform-fe/commit/983d924e))
* Chip in the header reads the resolved range (e.g. `May 1 – May 8`) instead of an abstract size — answers "what am I looking at?" without mental math.
* Dropdown options use natural-language labels (`1 day`, `1 week`, `1 month`, `3 months`) as the primary read, with the resolved range as a small muted hint underneath. The user is choosing window *size*, not specific dates, so the abstract label leads.
* Durations are stored as *half-spans* and applied symmetrically (`now ± duration`) so the total visible window equals the labeled size — `1 day` = 24h total, `1 week` = 7d total, etc. An earlier version stored full spans, which made `1 day` silently render a 48-hour window across 3 calendar dates.
* Same constant (`TIME_WINDOW_DURATIONS`) and same anchor (`mountNow`) drive the SWR fetch boundaries, the chip text, and the dropdown previews — single source of truth, so the chip never lies about what was fetched.

**Share link** (folded into [d0d183e6](https://github.com/refactor-group/refactor-platform-fe/commit/d0d183e6))
* Kebab item that copies the session's URL to the clipboard with toast confirmation. Universal action — available to coaches and coachees on both tabs. Routes through the existing `copyCoachingSessionLinkWithToast` utility; restores the share affordance from the legacy list.

**Review-feedback refactor** ([b492722a](https://github.com/refactor-group/refactor-platform-fe/commit/b492722a))
* Delete-dialog state is a discriminated union (`closed | pending | deleting`) instead of parallel `T | undefined` + `boolean` — the impossible "deleting with no session" state is now a type error.
* `onRefreshNeeded` registration uses a `useRef` + stable wrapper closure (userland equivalent of `useEffectEvent`) instead of an `eslint-disable` on the dep array.
* The Time Range `<SelectTrigger>` renders the abstract label explicitly rather than letting Radix clone the two-line `<SelectItem>` body — kept the trigger height consistent with the Relationship select below it.
* Dropped a dead `hasMenuItems` guard in the row (Share link is universal, so the kebab is never empty).

### Screenshots / Videos Showing UI Changes

Helpful screenshots to capture:
* Row with kebab open, all three menu items visible (Reschedule / Share link / Delete session)
* AlertDialog with unified copy on both Upcoming and Previous tab rows
* Header chip showing the resolved range (e.g. `May 1 – May 8`)
* Filters dropdown with each option showing the natural-language label (`1 day`, `1 week`, …) + resolved range hint
* Mobile (~390px) view — kebab always-visible, dialog buttons stack vertically

### Testing Strategy

* `npx tsc --noEmit` — clean
* `npx vitest run` — 938/938 tests across 89 files (added: standalone `DeleteSessionDialog` suite, `formatTimeWindowDateRange` unit tests, extended `CoachingSessionsCard` suite for kebab permission matrix + delete flow + Share link, new `DashboardContainer` integration suite pinning the auto-refresh contract, updated filter-store tests for the new default). The chip-display tests pin `LuxonSettings.defaultZone` to UTC so expected strings are deterministic across dev machines and CI regardless of `TZ`.
* `npx playwright test` — 128 passed, 32 skipped across Chromium / Firefox / WebKit / Mobile Chrome / Mobile Safari.
* Manual: load `/dashboard`, hover a row → kebab appears → open menu → Reschedule (upcoming-only, coach-only) / Share link (universal) / Delete session (coach-only, destructive). Confirm Delete on a throwaway session → row disappears immediately, no reload. Verify chip + dropdown show resolved date ranges and natural-language labels. Repeat at mobile width — kebab always visible, dialog buttons stack vertically. Verified end-to-end across 1920, 1280, 768/820, and 390 viewports.

### Concerns

* **SWR auto-invalidation bug fixed at the call site, not at the source.** `useEntityMutation`'s invalidate predicate (`typeof key === "string" && key.includes(baseUrl)`) silently skips the tuple-keyed caches produced by `useEntityList`, so no list fetched via `useEntityList` ever auto-revalidates after a mutation. This PR works around it where the dashboard surfaces are affected (manual `refresh()` from the card up through `DashboardContainer`, mirroring the existing `UpcomingSessionCard` pattern). The proper fix touches a wider surface — ~15 manual `refresh()` call sites across the codebase would become redundant and need individual verification — so it's tracked separately in #387 rather than bundled with this feature PR.