### PR TITLE
Show weekday on upcoming session rows

### DIFF
--- a/__tests__/lib/utils/date.test.ts
+++ b/__tests__/lib/utils/date.test.ts
@@ -12,4 +12,10 @@ describe("formatDateWithTime", () => {
   it("accepts a custom separator", () => {
     expect(formatDateWithTime(date, "·")).toBe("Mar 5, 2026 · 2:00 PM");
   });
+
+  it("prefixes the abbreviated weekday when includeWeekday is true", () => {
+    expect(formatDateWithTime(date, "·", true)).toBe(
+      "Thu, Mar 5, 2026 · 2:00 PM"
+    );
+  });
 });

--- a/src/components/ui/dashboard/coaching-sessions-row.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-row.tsx
@@ -75,8 +75,8 @@ export function SessionRow({
     const dt = DateTime.fromISO(session.date, { zone: "utc" }).setZone(
       userTimezone
     );
-    return formatDateWithTime(dt, "·");
-  }, [session.date, userTimezone]);
+    return formatDateWithTime(dt, "·", !isPast);
+  }, [session.date, userTimezone, isPast]);
 
   return (
     <div

--- a/src/lib/utils/date.ts
+++ b/src/lib/utils/date.ts
@@ -22,13 +22,16 @@ export function formatLongDate(date: DateTime): string {
 /**
  * Format a DateTime with time, using a configurable separator between the
  * date and time (e.g., "Jan 3, 2026 at 2:30 PM" by default, or
- * "Jan 3, 2026 · 2:30 PM" when separator is "·").
+ * "Jan 3, 2026 · 2:30 PM" when separator is "·"). Pass `includeWeekday`
+ * to prefix the abbreviated weekday (e.g., "Tue, May 6, 2026 · 2:30 PM").
  */
 export function formatDateWithTime(
   date: DateTime,
-  separator: string = "at"
+  separator: string = "at",
+  includeWeekday: boolean = false
 ): string {
-  return `${date.toFormat("MMM d, yyyy")} ${separator} ${date.toFormat("h:mm a")}`;
+  const dateFormat = includeWeekday ? "EEE, MMM d, yyyy" : "MMM d, yyyy";
+  return `${date.toFormat(dateFormat)} ${separator} ${date.toFormat("h:mm a")}`;
 }
 
 /**


### PR DESCRIPTION
## Description
Prefix the abbreviated weekday on the date label of upcoming session rows so users can see what day a session falls on without having to map a date in their head. Past-tab rows are unchanged — the weekday is more useful for forward planning than retrospection.

Before: `May 6, 2026 · 2:30 PM`
After:  `Tue, May 6, 2026 · 2:30 PM`

### Changes
* Added an optional `includeWeekday` flag to `formatDateWithTime` in `src/lib/utils/date.ts`
* `coaching-sessions-row.tsx` passes `!isPast` so the weekday only renders on the upcoming tab
* Added a unit test covering the new option

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: a screenshot of the upcoming sessions card on the dashboard showing the new `Tue, May 6, 2026 · 2:30 PM` label.

### Testing Strategy
* `npx vitest run` — full suite green (89 files / 939 tests)
* `npx tsc --noEmit` — clean
* Manual: load the dashboard and confirm upcoming-tab rows show the weekday and past-tab rows do not.