### PR TITLE
Persist user-picked due date when adding a new action

### DIFF
--- a/__tests__/components/ui/coaching-sessions/action-card-compact.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-card-compact.test.tsx
@@ -9,6 +9,43 @@ import { ItemStatus } from "@/types/general";
 import { Some } from "@/types/option";
 import { createMockAction, createMockGoal } from "../../../test-utils";
 
+// Mock DueDatePicker to avoid coupling tests to the react-day-picker calendar
+// DOM. The mock exposes a stable test button that simulates picking a date
+// 60 days from "now" — deliberately relative so the test stays meaningful as
+// time passes — plus a label that reflects the current `value` prop so we
+// can assert that local state updates are reflected back into the picker.
+function pickedDate(): DateTime {
+  return DateTime.now().plus({ days: 60 }).startOf("day");
+}
+vi.mock("@/components/ui/coaching-sessions/action-card-parts", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/ui/coaching-sessions/action-card-parts")
+  >("@/components/ui/coaching-sessions/action-card-parts");
+  return {
+    ...actual,
+    DueDatePicker: ({
+      value,
+      onChange,
+    }: {
+      value: DateTime;
+      onChange: (date: DateTime) => void;
+      locale: string;
+      variant?: "button" | "text";
+    }) => (
+      <div>
+        <span data-testid="mock-due-date-value">{value.toISODate()}</span>
+        <button
+          type="button"
+          data-testid="mock-due-date-pick"
+          onClick={() => onChange(pickedDate())}
+        >
+          pick
+        </button>
+      </div>
+    ),
+  };
+});
+
 function Wrapper({ children }: { children: ReactNode }) {
   return <TooltipProvider>{children}</TooltipProvider>;
 }
@@ -327,7 +364,8 @@ describe("CompactActionCard", () => {
           "action-1",
           "Updated action text",
           expect.any(Array),
-          undefined // goalId — no goal selected
+          undefined, // goalId — no goal selected
+          undefined // dueBy — only passed for new (initialEditing) actions
         );
       });
     });
@@ -360,6 +398,64 @@ describe("CompactActionCard", () => {
 
       // Should show a textarea immediately, no flip needed
       expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("tracks due-date selection locally and passes dueBy to onBodyChange on save", async () => {
+      const user = userEvent.setup();
+      const onBodyChange = vi.fn().mockResolvedValue(undefined);
+      // The non-editing onDueDateChange must NOT be called for new (unsaved)
+      // actions, because the action has no id yet.
+      const onDueDateChange = vi.fn();
+
+      // Relative initial date so the test remains meaningful over time.
+      const initialDueBy = DateTime.now().plus({ days: 1 }).startOf("day");
+      render(
+        <Wrapper>
+          <CompactActionCard
+            {...baseProps({
+              action: createMockAction({ id: "", body: "", due_by: initialDueBy }),
+              initialEditing: true,
+              onBodyChange,
+              onDueDateChange,
+            })}
+          />
+        </Wrapper>
+      );
+
+      // The picker initially reflects the placeholder's due_by.
+      expect(
+        screen.getByTestId("mock-due-date-value").textContent
+      ).toBe(initialDueBy.toISODate());
+
+      // Simulate picking a new date in the calendar.
+      await user.click(screen.getByTestId("mock-due-date-pick"));
+
+      // The picker re-renders with the locally tracked due-date — the bug
+      // was that selections silently no-op'd because action.id is "".
+      const expectedPickedIso = pickedDate().toISODate();
+      expect(
+        screen.getByTestId("mock-due-date-value").textContent
+      ).toBe(expectedPickedIso);
+
+      // The non-editing handler is bypassed for new actions.
+      expect(onDueDateChange).not.toHaveBeenCalled();
+
+      // Type a body so Save isn't disabled, then save.
+      const textarea = screen.getByRole("textbox");
+      await user.type(textarea, "New action body");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(onBodyChange).toHaveBeenCalled();
+      });
+
+      // Last arg is the locally picked dueBy DateTime.
+      const callArgs = onBodyChange.mock.calls[0];
+      expect(callArgs[0]).toBe(""); // empty id for new action
+      expect(callArgs[1]).toBe("New action body");
+      const passedDueBy = callArgs[4] as DateTime;
+      expect(passedDueBy).toBeInstanceOf(DateTime);
+      expect(passedDueBy.toISODate()).toBe(expectedPickedIso);
     });
 
     it("calls onDismiss when Cancel is clicked in initial editing mode", async () => {

--- a/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { DateTime } from "ts-luxon";
@@ -7,6 +7,41 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { ActionSectionContent } from "@/components/ui/coaching-sessions/action-section-content";
 import { ItemStatus } from "@/types/general";
 import { createMockAction } from "../../../test-utils";
+
+// Same DueDatePicker mock as in the action-card test — exposes a stable
+// "pick" button that simulates selecting a date 60 days from "now"
+// (relative so the test stays meaningful as time passes).
+function pickedDate(): DateTime {
+  return DateTime.now().plus({ days: 60 }).startOf("day");
+}
+vi.mock("@/components/ui/coaching-sessions/action-card-parts", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/components/ui/coaching-sessions/action-card-parts")
+  >("@/components/ui/coaching-sessions/action-card-parts");
+  return {
+    ...actual,
+    DueDatePicker: ({
+      value,
+      onChange,
+    }: {
+      value: DateTime;
+      onChange: (date: DateTime) => void;
+      locale: string;
+      variant?: "button" | "text";
+    }) => (
+      <div>
+        <span data-testid="mock-due-date-value">{value.toISODate()}</span>
+        <button
+          type="button"
+          data-testid="mock-due-date-pick"
+          onClick={() => onChange(pickedDate())}
+        >
+          pick
+        </button>
+      </div>
+    ),
+  };
+});
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <TooltipProvider>{children}</TooltipProvider>;
@@ -205,6 +240,50 @@ describe("ActionSectionContent", () => {
 
       // Should show a textarea immediately for the new action
       expect(screen.getByRole("textbox")).toBeInTheDocument();
+    });
+
+    it("forwards a user-picked due date through onActionCreate", async () => {
+      const user = userEvent.setup();
+      const onActionCreate = vi.fn().mockResolvedValue(undefined);
+      const onAddingActionChange = vi.fn();
+
+      render(
+        <Wrapper>
+          <ActionSectionContent
+            {...baseProps({
+              isAddingAction: true,
+              onActionCreate,
+              onAddingActionChange,
+            })}
+          />
+        </Wrapper>
+      );
+
+      // Pick a new date in the mocked DueDatePicker.
+      await user.click(screen.getByTestId("mock-due-date-pick"));
+
+      // The picker reflects the new local value (proves state update wiring).
+      const expectedPickedIso = pickedDate().toISODate();
+      expect(
+        screen.getByTestId("mock-due-date-value").textContent
+      ).toBe(expectedPickedIso);
+
+      // Type a body, then save.
+      await user.type(screen.getByRole("textbox"), "Action with picked date");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(onActionCreate).toHaveBeenCalledTimes(1);
+      });
+
+      const [body, _assigneeIds, _goalId, dueBy] =
+        onActionCreate.mock.calls[0] as [string, unknown, unknown, DateTime];
+      expect(body).toBe("Action with picked date");
+      expect(dueBy).toBeInstanceOf(DateTime);
+      expect(dueBy.toISODate()).toBe(expectedPickedIso);
+
+      // After save, parent is notified that adding is done.
+      expect(onAddingActionChange).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/__tests__/lib/hooks/use-panel-actions.test.ts
+++ b/__tests__/lib/hooks/use-panel-actions.test.ts
@@ -233,6 +233,42 @@ describe("handleCreate — goal linking", () => {
 
     expect(mockGlobalMutate).not.toHaveBeenCalled();
   });
+
+  // ── Due date plumbing ──────────────────────────────────────────────
+  // Regression: previously handleCreate hard-coded due_by to now()+7 days,
+  // discarding any value picked in the UI when adding a new action.
+
+  it("uses the provided dueBy when creating an action", async () => {
+    const { result } = renderHook(() => usePanelActions(PARAMS));
+    const picked = DateTime.now().plus({ days: 60 }).startOf("day");
+
+    await act(async () => {
+      await result.current.handleCreate("New action", [], undefined, picked);
+    });
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const created = mockCreate.mock.calls[0][0] as Action;
+    expect(created.due_by.toISO()).toBe(picked.toISO());
+  });
+
+  it("falls back to now()+7 days when dueBy is omitted", async () => {
+    const { result } = renderHook(() => usePanelActions(PARAMS));
+    const before = DateTime.now();
+
+    await act(async () => {
+      await result.current.handleCreate("New action");
+    });
+
+    const after = DateTime.now();
+    const created = mockCreate.mock.calls[0][0] as Action;
+    // due_by should fall in [before+7d, after+7d] (a few-ms window).
+    expect(created.due_by.toMillis()).toBeGreaterThanOrEqual(
+      before.plus({ days: 7 }).toMillis()
+    );
+    expect(created.due_by.toMillis()).toBeLessThanOrEqual(
+      after.plus({ days: 7 }).toMillis()
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -58,7 +58,7 @@ export interface CompactActionCardProps {
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
-  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id) => Promise<void>;
+  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   onDelete?: (id: Id) => void;
   /** "review" makes body read-only and hides delete. Defaults to "current". */
   variant?: "current" | "review";
@@ -106,11 +106,16 @@ export function CompactActionCard({
 
   const { linkedGoalId, linkedGoalTitle, resolvedGoals } = useLinkedGoalDisplay(action, goals);
 
-  // For new (unsaved) actions, track goal and assignee changes locally
-  // because the action doesn't exist in the backend yet.
+  // For new (unsaved) actions, track goal, assignee, and due-date changes
+  // locally because the action doesn't exist in the backend yet.
   const [localGoalId, setLocalGoalId] = useState<Id | undefined>(undefined);
   const [localAssigneeIds, setLocalAssigneeIds] = useState<Id[]>(
     action.assignee_ids ?? []
+  );
+  const [localDueBy, setLocalDueBy] = useState<DateTime>(action.due_by);
+  const displayedAction = useMemo(
+    () => (initialEditing ? { ...action, due_by: localDueBy } : action),
+    [initialEditing, action, localDueBy]
   );
   const assigneeIds = useMemo(
     () => initialEditing ? localAssigneeIds : (action.assignee_ids ?? []),
@@ -165,7 +170,7 @@ export function CompactActionCard({
       renderBack={({ onDone, isEditing, onEditStart, onEditEnd }) =>
         isEditing ? (
           <ActionEditForm
-            action={action}
+            action={displayedAction}
             locale={locale}
             initialBody={body}
             allAssignees={allAssignees}
@@ -174,7 +179,13 @@ export function CompactActionCard({
             goals={resolvedGoals}
             selectedGoalId={initialEditing ? localGoalId : linkedGoalId}
             onStatusChange={(newStatus) => onStatusChange(action.id, newStatus)}
-            onDueDateChange={(newDueBy) => onDueDateChange(action.id, newDueBy)}
+            onDueDateChange={(newDueBy) => {
+              if (initialEditing) {
+                setLocalDueBy(newDueBy);
+              } else {
+                onDueDateChange(action.id, newDueBy);
+              }
+            }}
             onAssigneeToggle={handleAssigneeToggle}
             onGoalSelect={resolvedGoals ? (goalId) => {
               if (initialEditing) {
@@ -184,7 +195,13 @@ export function CompactActionCard({
               }
             } : undefined}
             onSave={async (newBody, savedAssigneeIds, goalId) => {
-              await onBodyChange(action.id, newBody, savedAssigneeIds, goalId);
+              await onBodyChange(
+                action.id,
+                newBody,
+                savedAssigneeIds,
+                goalId,
+                initialEditing ? localDueBy : undefined
+              );
               if (!initialEditing) onEditEnd();
             }}
             onCancel={onDismiss ? onDone : onEditEnd}

--- a/src/components/ui/coaching-sessions/action-section-content.tsx
+++ b/src/components/ui/coaching-sessions/action-section-content.tsx
@@ -34,12 +34,12 @@ export interface ActionSectionContentProps {
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
-  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[]) => Promise<void>;
+  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   /** Session goals for the goal picker on action cards */
   goals?: Goal[];
   /** Called when user links/unlinks a goal on an action */
   onGoalChange?: (id: Id, goalId: Id | undefined) => void;
-  onActionCreate?: (body: string, assigneeIds?: Id[], goalId?: Id) => Promise<void>;
+  onActionCreate?: (body: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   onActionDelete?: (id: Id) => void;
   readOnly?: boolean;
   /** Called when the active tab changes so the parent can react (e.g. disable Add button) */
@@ -148,8 +148,13 @@ export function ActionSectionContent({
     return () => clearTimeout(timer);
   }, [highlightTargetId]);
 
-  // Lazy-init placeholder so defaultAction() isn't called at module scope
-  const newActionPlaceholder = useMemo(() => defaultAction(), []);
+  // Lazy-init placeholder so defaultAction() isn't called at module scope.
+  // Seed due_by to +7 days so the picker initially shows the same default
+  // that the backend create handler falls back to when none is selected.
+  const newActionPlaceholder = useMemo(
+    () => ({ ...defaultAction(), due_by: DateTime.now().plus({ days: 7 }) }),
+    []
+  );
 
   const sharedCardProps = {
     locale,
@@ -220,8 +225,8 @@ export function ActionSectionContent({
               onDelete={undefined}
               onDismiss={() => onAddingActionChange(false)}
               {...sharedCardProps}
-              onBodyChange={async (_id, body, assigneeIds, goalId) => {
-                await onActionCreate(body, assigneeIds, goalId);
+              onBodyChange={async (_id, body, assigneeIds, goalId, dueBy) => {
+                await onActionCreate(body, assigneeIds, goalId, dueBy);
                 onAddingActionChange(false);
               }}
             />

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -84,13 +84,13 @@ export interface CoachingSessionPanelSharedProps {
   coachName: string | undefined;
   coacheeId: Id | undefined;
   coacheeName: string | undefined;
-  onActionCreate?: (body: string, assigneeIds?: Id[], goalId?: Id) => Promise<void>;
+  onActionCreate?: (body: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   onActionDelete?: (id: Id) => void;
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
   onGoalChange?: (id: Id, goalId: Id | undefined) => void;
-  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id) => Promise<void>;
+  onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
   locale: string;

--- a/src/lib/hooks/use-panel-actions.ts
+++ b/src/lib/hooks/use-panel-actions.ts
@@ -230,7 +230,7 @@ function useActionCrud(
   }, [globalMutate]);
 
   const handleCreate = useCallback(
-    async (body: string, assigneeIds?: Id[], goalId?: Id) => {
+    async (body: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => {
       try {
         const newAction: Action = {
           ...defaultAction(),
@@ -239,7 +239,7 @@ function useActionCrud(
           body,
           goal_id: goalId ? Some(goalId) : None,
           status: ItemStatus.NotStarted,
-          due_by: DateTime.now().plus({ days: 7 }),
+          due_by: dueBy ?? DateTime.now().plus({ days: 7 }),
           assignee_ids: assigneeIds ?? [],
         };
         await create(newAction);


### PR DESCRIPTION
## Description
Fixes a production bug on the coaching session Actions panel: when adding a new action, picking a "Due date" in the calendar appeared to do nothing — the picker UI didn't update and the saved action always landed on `now() + 7 days` regardless of what the user clicked. (Editing an existing action's due date worked, only the add-new flow was broken.)

#### GitHub Issue: N/A — reported directly by @jhodapp from production

### Root cause
Two compounding issues in the new-action flow:
1. `DueDatePicker` calls `onDueDateChange(action.id, newDueBy)`, but `action.id` is `""` for unsaved actions. `handleDueDateChange` then does `findActionById("")`, returns `undefined`, and silently no-ops — both the picker UI (bound to the unchanging `action.due_by` prop) and the underlying state stayed put.
2. `handleCreate` hard-coded `due_by: DateTime.now().plus({ days: 7 })`, discarding any picked value even if it had reached the save call.

### Changes
* `action-card-compact.tsx` — track `localDueBy` for new actions (mirroring the existing `localGoalId` / `localAssigneeIds` pattern), route picker changes locally when `initialEditing`, and forward the value on save. Add an optional `dueBy?: DateTime` to the `onBodyChange` signature.
* `action-section-content.tsx` — forward the picked `dueBy` from `onBodyChange` → `onActionCreate`. Seed the new-action placeholder's `due_by` to `now() + 7 days` so the picker's initial value matches the server-side fallback.
* `coaching-session-panel.tsx` — extend the shared `onActionCreate` / `onBodyChange` prop signatures with the optional `dueBy`.
* `use-panel-actions.ts` — `handleCreate` honors a provided `dueBy`, falls back to `now() + 7 days` only when omitted.
* Tests — new unit/integration tests cover: local due-date tracking + `onBodyChange` arg passthrough in `CompactActionCard`, end-to-end flow into `onActionCreate` from `ActionSectionContent`, and `handleCreate`'s `dueBy` plumbing (uses provided value; falls back to +7d). All use dates relative to `now()` so they remain meaningful as time passes.

### Screenshots / Videos Showing UI Changes (if applicable)
A short before/after of the new-action card flow would be helpful: open the Actions panel → click **+ Add** → click the **Due date** button → pick a future date → confirm the button label updates → **Save** → confirm the persisted card shows the picked date (not +7 days).

### Testing Strategy
- **Automated:** `npx vitest run` (943 tests pass, including 4 new ones); `npx tsc --noEmit` clean.
- **Manual / Playwright (already done):** opened a real coaching session, switched to Actions, clicked **+ Add**, navigated calendar to June 2026, clicked the 30th → picker updated to **Jun 30, 2026** → typed body → **Save** → card persisted with **Jun 30, 2026** (not the +7-day fallback).

### Concerns
- Behavior change for users who relied on the (buggy) +7-day default: previously the picker showed "today" but the save silently used +7 days; now the picker shows +7 days from the start and saves whatever you see. This is the intended fix — calling it out so reviewers know to expect a "default due date" UI shift.