### PR TITLE
test: pin clock for calendar-boundary assertions to prevent flakiness

### DIFF
--- a/.claude/coding-standards.md
+++ b/.claude/coding-standards.md
@@ -304,6 +304,76 @@ function MyCard() {
 - Explain *why* something is done, not just *what* is being done
 - Document external state synchronization patterns (like forceUpdate mechanisms)
 
+## Testing
+
+### No Wall-Clock Time in Time-Sensitive Tests
+
+**Tests must not depend on the real wall clock for any assertion that compares
+against calendar boundaries, day-of-week, AM/PM, timezone offsets, or
+similar.** A test that passes most of the year but fails at 23:59 local time —
+or 04:59 UTC when the user's timezone has just rolled past midnight — is a
+broken test, not "flaky CI." It will eventually fail in CI, on a contributor's
+laptop in another timezone, or on DST transition days.
+
+**Rules:**
+
+1. **Relative offsets are fine** — `DateTime.now().plus({ minutes: 30 })` for a
+   "session 30 minutes from now" is stable, because the assertion only cares
+   about the offset, not where on the calendar "now" sits.
+
+2. **Pin the clock whenever the assertion depends on a calendar position** —
+   "is this today / tomorrow / yesterday", "is this past end-of-day in
+   timezone X", "what day of the week is this", "is this before noon",
+   "does this cross a DST boundary". Use `Settings.now` from `ts-luxon`
+   (or `vi.useFakeTimers()` + `vi.setSystemTime()`) to make "now" deterministic:
+
+   ```typescript
+   import { describe, it, expect, beforeEach, afterEach } from "vitest";
+   import { DateTime, Settings } from "ts-luxon";
+
+   describe("day-relative behaviour", () => {
+     const originalNow = Settings.now;
+     const fakeNow = DateTime.fromISO("2026-03-26T12:00:00.000Z", { zone: "utc" });
+
+     beforeEach(() => {
+       Settings.now = () => fakeNow.toMillis();
+     });
+
+     afterEach(() => {
+       Settings.now = originalNow;
+     });
+
+     it("treats a session 24h later as tomorrow", () => {
+       // Both createSessionAt and the code under test now see the same
+       // fixed "now", so the assertion is stable.
+       const session = createSessionAt(24 * 60);
+       expect(getUrgencyMessage(session, calculateSessionUrgency(session)))
+         .toContain("tomorrow");
+     });
+   });
+   ```
+
+3. **Pin the zone too when timezone-specific behaviour matters.** Either pin
+   `Settings.defaultZone`, or build inputs from an explicit ISO string with
+   `{ zone: "..." }` rather than relying on the host's system timezone.
+   `DateTime.now()` in Node respects `process.env.TZ`, which varies between
+   CI and developer machines.
+
+4. **Anti-pattern — defensive fallbacks that hide flakiness.** If a test
+   needs a `try/catch`, an `if-else` around `urgency`, or "skip the
+   assertion when timing is unlucky" logic, the test is wrong. Pin time
+   instead and assert unconditionally.
+
+5. **`DateTime.now()` is OK for opaque metadata** — `created_at`/`updated_at`
+   on mock objects that nothing in the assertion compares against can use
+   real now without issue.
+
+**Symptom to watch for:** a test creates data with `DateTime.now()`,
+then calls a function that *also* reads `DateTime.now()`, then asserts on
+calendar-day semantics. The two `now`s can land on different calendar days
+(or sides of a DST boundary) — the test passes 99% of the time and fails
+in CI exactly once a year per timezone.
+
 ## Code Review Checklist
 
 When reviewing or writing code, ensure:
@@ -315,3 +385,4 @@ When reviewing or writing code, ensure:
 - [ ] TypeScript types are properly defined and used
 - [ ] Leaf components receive `locale` and config values via props, not `siteConfig` imports
 - [ ] No `|| ""` fallbacks for nullable IDs or dates -- use render guards instead
+- [ ] Tests with calendar-boundary assertions pin `Settings.now` instead of relying on real time

--- a/__tests__/coaching-session.test.ts
+++ b/__tests__/coaching-session.test.ts
@@ -59,14 +59,23 @@ describe("isPastSession", () => {
 
   it("end-of-day cutoff in a specific user timezone keeps same-day session editable", () => {
     // Simulate the exact pattern used in the coaching session page:
-    // session date → convert to user timezone → end of that calendar day
+    // session date → convert to user timezone → end of that calendar day.
+    // Pin "now" to noon Chicago time so the session (3h earlier = 9 AM Chicago)
+    // and "now" are safely on the same Chicago calendar day — without this the
+    // test is flaky when run near midnight Chicago time.
     const userTimezone = "America/Chicago";
-    const session = createSessionAt(-180); // 3 hours ago, well past default 60-min window
-    const cutoff = DateTime.fromISO(session.date, { zone: 'utc' })
-      .setZone(userTimezone)
-      .endOf('day');
-    // Still the same calendar day in the user's timezone
-    expect(isPastSession(session, { cutoff })).toBe(false);
+    const fakeNow = DateTime.fromISO("2026-03-26T17:00:00.000Z"); // noon CDT
+    Settings.now = () => fakeNow.toMillis();
+    try {
+      const session = createSessionAt(-180); // 3 hours ago, well past default 60-min window
+      const cutoff = DateTime.fromISO(session.date, { zone: 'utc' })
+        .setZone(userTimezone)
+        .endOf('day');
+      // Still the same calendar day in the user's timezone
+      expect(isPastSession(session, { cutoff })).toBe(false);
+    } finally {
+      Settings.now = () => Date.now();
+    }
   });
 
   it("end-of-day cutoff marks yesterday's session as past", () => {

--- a/__tests__/session.test.ts
+++ b/__tests__/session.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { DateTime } from "ts-luxon";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { DateTime, Settings } from "ts-luxon";
 import {
   calculateSessionUrgency,
   getUrgencyMessage,
@@ -134,47 +134,56 @@ describe("getUrgencyMessage", () => {
     expect(message).toContain("Scheduled for");
   });
 
-  it("returns 'tomorrow' prefix for sessions scheduled tomorrow", () => {
-    // Create a session 24 hours from now
-    const session = createSessionAt(24 * 60);
-    const urgency = calculateSessionUrgency(session);
-    const message = getUrgencyMessage(session, urgency);
+  // The "today / tomorrow / yesterday" branches of getUrgencyMessage compare
+  // calendar days using DateTime.now(), so they're sensitive to where the
+  // wall clock sits relative to midnight. Pin "now" to noon UTC for the
+  // remainder of this describe block so the day-prefix assertions are stable
+  // regardless of when CI happens to run.
+  describe("day-relative prefixes", () => {
+    const originalNow = Settings.now;
+    const fakeNow = DateTime.fromISO("2026-03-26T12:00:00.000Z", { zone: "utc" });
 
-    expect(message).toContain("Scheduled for tomorrow");
-  });
-
-  it("returns 'yesterday' prefix for past sessions from yesterday", () => {
-    // Create a session 24 hours ago
-    const session = createSessionAt(-24 * 60);
-    const urgency = calculateSessionUrgency(session);
-    const message = getUrgencyMessage(session, urgency);
-
-    expect(message).toContain("Ended");
-  });
-
-  it("returns 'this morning/afternoon/evening' for sessions today", () => {
-    // Create a session at 2 PM today to ensure it's beyond the 2 hour threshold
-    // and still definitely today regardless of when the test runs
-    const now = DateTime.now();
-    const todayAt2PM = now.startOf('day').set({ hour: 14 }); // 2:00 PM today
-
-    const session = createMockSession({
-      date: todayAt2PM.toUTC().toISO(),
+    beforeEach(() => {
+      Settings.now = () => fakeNow.toMillis();
     });
 
-    const urgency = calculateSessionUrgency(session);
-    const message = getUrgencyMessage(session, urgency);
+    afterEach(() => {
+      Settings.now = originalNow;
+    });
 
-    // If we're testing before noon, it should say "this afternoon"
-    // Only assert if it's actually in the "Later" category (> 2 hours away)
-    if (urgency === SessionUrgency.Later) {
+    it("returns 'tomorrow' prefix for sessions scheduled tomorrow", () => {
+      // Create a session 24 hours from now
+      const session = createSessionAt(24 * 60);
+      const urgency = calculateSessionUrgency(session);
+      const message = getUrgencyMessage(session, urgency);
+
+      expect(message).toContain("Scheduled for tomorrow");
+    });
+
+    it("returns 'yesterday' prefix for past sessions from yesterday", () => {
+      // Create a session 24 hours ago
+      const session = createSessionAt(-24 * 60);
+      const urgency = calculateSessionUrgency(session);
+      const message = getUrgencyMessage(session, urgency);
+
+      expect(message).toContain("Ended");
+    });
+
+    it("returns 'this morning/afternoon/evening' for sessions today", () => {
+      // Session at 6 PM UTC; "now" is pinned at noon UTC, so the session is
+      // safely later today (> 2 hour threshold) → Later urgency.
+      const todayAt6PM = fakeNow.set({ hour: 18 });
+
+      const session = createMockSession({
+        date: todayAt6PM.toUTC().toISO(),
+      });
+
+      const urgency = calculateSessionUrgency(session);
+      const message = getUrgencyMessage(session, urgency);
+
+      expect(urgency).toBe(SessionUrgency.Later);
       expect(message).toContain("Scheduled for this");
-    } else {
-      // If it's not Later urgency (because test ran too close to 2 PM),
-      // at least verify it's not tomorrow/yesterday
-      expect(message).not.toContain("tomorrow");
-      expect(message).not.toContain("yesterday");
-    }
+    });
   });
 });
 


### PR DESCRIPTION
## Description
Fix a flaky unit test on `main` that depended on the real wall clock. `isPastSession` in `coaching-session.test.ts` combined `createSessionAt(-180)` (real `DateTime.now()` − 3h) with an `endOf('day')` cutoff in `America/Chicago`. When CI happened to run just past midnight Chicago time (as it did in [run 25779296550](https://github.com/refactor-group/refactor-platform-fe/actions/runs/25779296550/job/75718290990)), the session 3 hours earlier landed on the *previous* calendar day in Chicago, so the cutoff was already in the past — `isPastSession` correctly returned `true` while the test expected `false`.

Pin `Settings.now` to a fixed point so the calendar-day comparison is deterministic. Apply the same fix to the "tomorrow / yesterday / this morning" prefix tests in `session.test.ts`, which had the identical fragile pattern.

### Changes
* `__tests__/coaching-session.test.ts` — pin `Settings.now` around the `endOf('day')` cutoff test in `America/Chicago`.
* `__tests__/session.test.ts` — wrap the day-relative prefix tests (`tomorrow`, `yesterday`, `this morning/afternoon/evening`) in a shared `describe` block with `beforeEach`/`afterEach` that pins `Settings.now`. Removed the defensive `if (urgency === SessionUrgency.Later)` branch that was hiding flakiness instead of fixing it.
* `.claude/coding-standards.md` — add a "Testing" section codifying the rule: relative offsets are fine; pin the clock (and the zone) for any assertion that depends on a calendar position, day-of-week, AM/PM, timezone offsets, or DST; defensive fallbacks that hide flakiness are an anti-pattern. New checklist item to match.

### Testing Strategy
* `npx vitest run` — 943 tests pass, including the 17 in `coaching-session.test.ts` and 40 in `session.test.ts`.
* The previously failing test now passes when executed at 05:07 UTC (i.e. right in the window that originally broke it).
* Conceptual: with `Settings.now` pinned to a fixed instant, neither `createSessionAt(...)` nor the production code's internal `DateTime.now()` can disagree about which calendar day "now" sits on — the assertion is invariant to when the test actually runs.

### Concerns
None. The production code is unchanged; this is a test-stability fix plus a coding-standards update.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYMpCRdenP5QGFmWn9Tiah)_