### PR TITLE
Keep in-progress sessions in Upcoming tab until duration elapses

### DIFF
--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -258,6 +258,60 @@ describe("CoachingSessionsCard", () => {
     expect(screen.queryByTestId("session-row-s-future")).not.toBeInTheDocument();
   });
 
+  // Boundary: a session whose start is in the past but whose end
+  // (start + DEFAULT_SESSION_DURATION_MINUTES = 60) is still in the future
+  // remains in Upcoming. Pin the clock per the project's testing rule for
+  // duration-boundary assertions.
+  it("keeps an in-progress session in Upcoming until its full duration elapses", async () => {
+    const user = userEvent.setup();
+    setupBaseAuth();
+
+    const fakeNow = DateTime.fromISO("2026-03-26T17:00:00.000Z");
+    const originalNow = LuxonSettings.now;
+    LuxonSettings.now = () => fakeNow.toMillis();
+    try {
+      const inProgressDate =
+        fakeNow.minus({ minutes: 30 }).toUTC().toISO() ?? "";
+      const endedDate =
+        fakeNow.minus({ minutes: 90 }).toUTC().toISO() ?? "";
+
+      setupSessionWindows({
+        upcoming: {
+          enrichedSessions: [
+            createMockEnrichedSession({
+              id: "s-in-progress",
+              date: inProgressDate,
+            }),
+          ],
+        },
+        previous: {
+          enrichedSessions: [
+            createMockEnrichedSession({ id: "s-ended", date: endedDate }),
+          ],
+        },
+      });
+
+      render(<CoachingSessionsCard onReschedule={vi.fn()} />);
+
+      // Started 30 min ago, 30 min still to go → Upcoming.
+      expect(
+        screen.getByTestId("session-row-s-in-progress")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("session-row-s-ended")
+      ).not.toBeInTheDocument();
+
+      // Ended 30 min ago (90 min after start) → Previous.
+      await user.click(screen.getByRole("tab", { name: /previous/i }));
+      expect(screen.getByTestId("session-row-s-ended")).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("session-row-s-in-progress")
+      ).not.toBeInTheDocument();
+    } finally {
+      LuxonSettings.now = originalNow;
+    }
+  });
+
   it("shows Reschedule for a coach viewer inside the row's kebab menu and fires the callback", async () => {
     const user = userEvent.setup();
     const onReschedule = vi.fn();

--- a/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx
@@ -270,10 +270,11 @@ describe("CoachingSessionsCard", () => {
     const originalNow = LuxonSettings.now;
     LuxonSettings.now = () => fakeNow.toMillis();
     try {
-      const inProgressDate =
-        fakeNow.minus({ minutes: 30 }).toUTC().toISO() ?? "";
-      const endedDate =
-        fakeNow.minus({ minutes: 90 }).toUTC().toISO() ?? "";
+      const inProgressDate = fakeNow.minus({ minutes: 30 }).toUTC().toISO();
+      const endedDate = fakeNow.minus({ minutes: 90 }).toUTC().toISO();
+      if (!inProgressDate || !endedDate) {
+        throw new Error("Luxon returned null ISO from a valid fixed DateTime");
+      }
 
       setupSessionWindows({
         upcoming: {

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -210,13 +210,11 @@ export function CoachingSessionsCard({
   }, [onRefreshNeeded]);
 
   // A session stays in Upcoming until its full duration has elapsed.
-  // `now` keeps the memo recomputing on the minute tick; `isPastSession`
-  // reads `DateTime.now()` itself.
   const { upcomingSessions, previousSessions } = useMemo(() => {
     const upcoming: EnrichedCoachingSession[] = [];
     const previous: EnrichedCoachingSession[] = [];
     for (const session of allSessions) {
-      if (isPastSession(session)) {
+      if (isPastSession(session, { now })) {
         previous.push(session);
       } else {
         upcoming.push(session);
@@ -224,7 +222,6 @@ export function CoachingSessionsCard({
     }
     previous.reverse();
     return { upcomingSessions: upcoming, previousSessions: previous };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allSessions, now]);
 
   // Hover state is owned here — not in `CoachingSessionsListView` — so the

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -26,6 +26,7 @@ import { getBrowserTimezone } from "@/lib/timezone-utils";
 import { getSessionParticipantInfo } from "@/lib/utils/session";
 import {
   CoachingSessionInclude,
+  isPastSession,
   type CoachingSession,
   type EnrichedCoachingSession,
 } from "@/types/coaching-session";
@@ -208,24 +209,22 @@ export function CoachingSessionsCard({
     onRefreshNeeded?.(() => refreshSessionsRef.current());
   }, [onRefreshNeeded]);
 
-  // Sessions starting exactly at `now` belong in Upcoming. Previous is reversed
-  // so the most recent session appears first, matching the prior `desc` fetch.
-  // `{ zone: "utc" }` matches the row formatter (`coaching-sessions-row.tsx`)
-  // because the backend ships naive ISO datetime strings — without it Luxon
-  // parses in the viewer's local zone, shifting the absolute time by the user's
-  // UTC offset and bucketing boundary sessions into the wrong tab.
+  // A session stays in Upcoming until its full duration has elapsed.
+  // `now` keeps the memo recomputing on the minute tick; `isPastSession`
+  // reads `DateTime.now()` itself.
   const { upcomingSessions, previousSessions } = useMemo(() => {
     const upcoming: EnrichedCoachingSession[] = [];
     const previous: EnrichedCoachingSession[] = [];
     for (const session of allSessions) {
-      if (DateTime.fromISO(session.date, { zone: "utc" }) >= now) {
-        upcoming.push(session);
-      } else {
+      if (isPastSession(session)) {
         previous.push(session);
+      } else {
+        upcoming.push(session);
       }
     }
     previous.reverse();
     return { upcomingSessions: upcoming, previousSessions: previous };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allSessions, now]);
 
   // Hover state is owned here — not in `CoachingSessionsListView` — so the

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -169,12 +169,16 @@ export function coachingSessionsToString(
  * start plus {@link DEFAULT_SESSION_DURATION_MINUTES}. Callers that need a
  * different boundary — for example end-of-day in the user's timezone — can
  * supply a custom `cutoff` DateTime that overrides the default calculation.
+ *
+ * Callers driving recomputation off a ticking React state (e.g. the dashboard
+ * partition that re-buckets on the minute) can pass an explicit `now` so the
+ * memo's dependency array actually reflects the time read by this helper.
  */
 export function isPastSession(
   session: CoachingSession,
-  options?: { cutoff: DateTime }
+  options?: { cutoff?: DateTime; now?: DateTime }
 ): boolean {
-  const now = DateTime.now();
+  const now = options?.now ?? DateTime.now();
   if (options?.cutoff) {
     return now > options.cutoff;
   }


### PR DESCRIPTION
## Summary
- Dashboard Coaching Sessions card was moving sessions to **Previous** the moment their start time passed, even while they were still under way.
- Switch the tab partition to `isPastSession`, which uses `start + DEFAULT_SESSION_DURATION_MINUTES` as the boundary — matching the `SessionUrgency.Past` semantics used elsewhere in the app.
- A session now stays in **Upcoming** for its full scheduled duration, then moves to **Previous**.
- This enables a last minute reschedule to still work, because once a session makes it into the Previous tab, it's no longer editable.

## Test plan
- [x] `vitest` — `__tests__/components/ui/dashboard/coaching-sessions-card.test.tsx` passes (28 tests), including new boundary case asserting a 30-min-in session stays in Upcoming and a 90-min-old session lands in Previous.
- [x] `tsc --noEmit` clean.
- [ ] Manual: deploy a PR preview, schedule a session for the next few minutes, verify it remains in **Upcoming** for ~60 min after its start, then moves to **Previous**.