### PR TITLE
Add user-initiated password reset flow

### DIFF
--- a/__tests__/app/reset-password-page.test.tsx
+++ b/__tests__/app/reset-password-page.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import ResetPasswordPage from '@/app/reset-password/[token]/page'
+import { PasswordResetApi } from '@/lib/api/password-reset'
+import { EntityApiError } from '@/types/general'
+
+// next/navigation is already mocked globally in setup.ts; override useParams
+const mockUseParams = vi.fn<() => Record<string, string | string[] | undefined>>(() => ({ token: 'valid-token' }))
+vi.mock('next/navigation', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('next/navigation')
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+    useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), forward: vi.fn(), refresh: vi.fn(), prefetch: vi.fn() }),
+  }
+})
+
+// Auth store mock — toggle isLoggedIn per test.
+const mockAuthState = { isLoggedIn: false, userSession: { email: '' } }
+vi.mock('@/lib/providers/auth-store-provider', () => ({
+  useAuthStore: (sel: (s: typeof mockAuthState) => unknown) => sel(mockAuthState),
+}))
+
+// Logout hook mock — assert it's called or not called depending on the path.
+const mockLogout = vi.fn(() => Promise.resolve())
+vi.mock('@/lib/hooks/use-logout-user', () => ({
+  useLogoutUser: () => mockLogout,
+}))
+
+// API client mock.
+vi.mock('@/lib/api/password-reset', () => ({
+  PasswordResetApi: {
+    validate: vi.fn(),
+    complete: vi.fn(),
+    request: vi.fn(),
+  },
+}))
+
+const mockedApi = vi.mocked(PasswordResetApi, true)
+
+function makeApiError(status: number, data: unknown, path = '/password-reset/complete'): EntityApiError {
+  const axiosLike = Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { status, statusText: 'Error', data },
+  })
+  return new EntityApiError('POST', path, axiosLike)
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockUseParams.mockReturnValue({ token: 'valid-token' })
+  mockAuthState.isLoggedIn = false
+  mockAuthState.userSession.email = ''
+})
+
+describe('ResetPasswordPage — validate step', () => {
+  it('shows the validating spinner before validate resolves', () => {
+    mockedApi.validate.mockReturnValueOnce(new Promise(() => {})) // never resolves
+    render(<ResetPasswordPage />)
+    expect(screen.getByText(/Validating your reset link/i)).toBeInTheDocument()
+  })
+
+  it('transitions to ready state with personalized greeting on validate success', async () => {
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    render(<ResetPasswordPage />)
+    expect(await screen.findByText(/Hi Jane, set a new password below/i)).toBeInTheDocument()
+  })
+
+  it('transitions to error state on 400 invalid_or_expired_token', async () => {
+    mockedApi.validate.mockRejectedValueOnce(
+      makeApiError(400, { error: 'invalid_or_expired_token' }, '/password-reset/validate')
+    )
+    render(<ResetPasswordPage />)
+    expect(
+      await screen.findByText(/This reset link is invalid or has expired/i)
+    ).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Request a new reset link/i })).toBeInTheDocument()
+  })
+
+  it('renders error state immediately when token param is missing (no API call)', async () => {
+    mockUseParams.mockReturnValue({ token: undefined })
+    render(<ResetPasswordPage />)
+    expect(
+      await screen.findByText(/This reset link is invalid or has expired/i)
+    ).toBeInTheDocument()
+    expect(mockedApi.validate).not.toHaveBeenCalled()
+  })
+})
+
+describe('ResetPasswordPage — complete step', () => {
+  it('shows the success card after a successful complete (logged-out user)', async () => {
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    mockedApi.complete.mockResolvedValueOnce(undefined)
+
+    render(<ResetPasswordPage />)
+    await screen.findByText(/Hi Jane, set a new password below/i)
+
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.click(screen.getByRole('button', { name: /Update password/i }))
+
+    expect(
+      await screen.findByText(/Your password has been updated\. Please sign in with your new password/i)
+    ).toBeInTheDocument()
+    // Logged-out: renders a Link, NOT a button-click-logout path.
+    expect(screen.getByRole('link', { name: /Go to Sign In/i })).toBeInTheDocument()
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+
+  // Fix #1: logged-in user MUST see the success card before logout. Previously
+  // logoutUser() was awaited inside complete()'s success path and its
+  // router.replace("/") fired before setPageState({ kind: "success" }) could
+  // render — so the success UI was never visible.
+  it('shows the success card to a logged-in user (no auto-logout)', async () => {
+    mockAuthState.isLoggedIn = true
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    mockedApi.complete.mockResolvedValueOnce(undefined)
+
+    render(<ResetPasswordPage />)
+    await screen.findByText(/Hi Jane, set a new password below/i)
+
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.click(screen.getByRole('button', { name: /Update password/i }))
+
+    expect(
+      await screen.findByText(/Your password has been updated\. Please sign in with your new password/i)
+    ).toBeInTheDocument()
+    // Critical: logout has NOT been auto-fired. It runs only on Sign-In click.
+    expect(mockLogout).not.toHaveBeenCalled()
+  })
+
+  it('logs the user out when they click Sign In on the success card (logged-in)', async () => {
+    mockAuthState.isLoggedIn = true
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    mockedApi.complete.mockResolvedValueOnce(undefined)
+
+    render(<ResetPasswordPage />)
+    await screen.findByText(/Hi Jane, set a new password below/i)
+
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.click(screen.getByRole('button', { name: /Update password/i }))
+
+    const signInBtn = await screen.findByRole('button', { name: /Go to Sign In/i })
+    fireEvent.click(signInBtn)
+    await waitFor(() => expect(mockLogout).toHaveBeenCalledTimes(1))
+  })
+
+  it('returns to ready state with inline error on 422 validation_error', async () => {
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    mockedApi.complete.mockRejectedValueOnce(
+      makeApiError(422, {
+        error: 'validation_error',
+        message: 'Password must be at least 12 characters',
+      })
+    )
+
+    render(<ResetPasswordPage />)
+    await screen.findByText(/Hi Jane/i)
+
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.click(screen.getByRole('button', { name: /Update password/i }))
+
+    // Surfaces BE message verbatim.
+    expect(
+      await screen.findByText(/Password must be at least 12 characters/i)
+    ).toBeInTheDocument()
+    // Stays on the form (ready state), does NOT transition to the terminal error card.
+    expect(screen.getByLabelText("New password")).toBeInTheDocument()
+  })
+
+  it('transitions to terminal error state on 400 invalid_or_expired_token from complete', async () => {
+    mockedApi.validate.mockResolvedValueOnce({ first_name: 'Jane', last_name: 'Doe' })
+    mockedApi.complete.mockRejectedValueOnce(
+      makeApiError(400, { error: 'invalid_or_expired_token' })
+    )
+
+    render(<ResetPasswordPage />)
+    await screen.findByText(/Hi Jane/i)
+
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: 'longenoughpassword' } })
+    fireEvent.click(screen.getByRole('button', { name: /Update password/i }))
+
+    expect(
+      await screen.findByText(/This reset link is invalid or has expired/i)
+    ).toBeInTheDocument()
+    // Form is replaced by the terminal error card.
+    expect(screen.queryByLabelText("New password")).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Request a new reset link/i })).toBeInTheDocument()
+  })
+})

--- a/__tests__/lib/api/password-reset.test.ts
+++ b/__tests__/lib/api/password-reset.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import axios from 'axios'
+import { PasswordResetApi } from '@/lib/api/password-reset'
+import { EntityApiError } from '@/types/general'
+
+vi.mock('axios')
+vi.mock('@/site.config', () => ({
+  siteConfig: {
+    env: {
+      backendServiceURL: 'http://localhost:4000',
+      backendApiVersion: '1.0.0-beta1',
+    },
+  },
+}))
+
+const mockedAxios = vi.mocked(axios, true)
+
+function makeAxiosError(status: number, data: unknown) {
+  return Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { status, statusText: 'Error', data },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('PasswordResetApi.request', () => {
+  it('POSTs the email to /password-reset/request', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { status_code: 200, data: null } })
+
+    await PasswordResetApi.request({ email: 'jane@example.com' })
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://localhost:4000/password-reset/request',
+      { email: 'jane@example.com' },
+      expect.objectContaining({
+        headers: { 'X-Version': '1.0.0-beta1' },
+        timeout: 15000,
+      })
+    )
+  })
+
+  it('rewraps an axios error as EntityApiError with the right path/method', async () => {
+    mockedAxios.post.mockRejectedValueOnce(makeAxiosError(429, { error: 'password_reset_rate_limited' }))
+
+    await expect(PasswordResetApi.request({ email: 'a@b.c' })).rejects.toMatchObject({
+      name: 'EntityApiError',
+      method: 'POST',
+      url: '/password-reset/request',
+      status: 429,
+    })
+  })
+})
+
+describe('PasswordResetApi.validate (v1.1 — POST with token in body)', () => {
+  it('POSTs the token in the JSON body (NOT as a query param)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { status_code: 200, data: { first_name: 'Jane', last_name: 'Doe' } },
+    })
+
+    await PasswordResetApi.validate('raw-token-abc123')
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://localhost:4000/password-reset/validate',
+      { token: 'raw-token-abc123' },
+      expect.objectContaining({
+        headers: { 'X-Version': '1.0.0-beta1' },
+        timeout: 15000,
+      })
+    )
+    // Defense against contract regression: ensure no `params` (query string)
+    // was passed alongside, which would put the token back into the URL.
+    const config = mockedAxios.post.mock.calls[0][2] as Record<string, unknown>
+    expect(config).not.toHaveProperty('params')
+  })
+
+  it('unwraps response.data.data to return PasswordResetValidateData', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { status_code: 200, data: { first_name: 'Jane', last_name: 'Doe' } },
+    })
+
+    const result = await PasswordResetApi.validate('tok')
+
+    expect(result).toEqual({ first_name: 'Jane', last_name: 'Doe' })
+  })
+
+  it('does NOT call axios.get (v1.0 transport is forbidden)', async () => {
+    mockedAxios.post.mockResolvedValueOnce({
+      data: { status_code: 200, data: { first_name: 'J', last_name: 'D' } },
+    })
+
+    await PasswordResetApi.validate('tok')
+
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  it('rewraps a 400 invalid_or_expired_token as EntityApiError', async () => {
+    mockedAxios.post.mockRejectedValueOnce(
+      makeAxiosError(400, { error: 'invalid_or_expired_token', message: 'expired' })
+    )
+
+    let captured: unknown
+    try {
+      await PasswordResetApi.validate('tok')
+    } catch (err) {
+      captured = err
+    }
+
+    expect(captured).toBeInstanceOf(EntityApiError)
+    expect(captured).toMatchObject({
+      method: 'POST',
+      url: '/password-reset/validate',
+      status: 400,
+    })
+  })
+})
+
+describe('PasswordResetApi.complete', () => {
+  it('POSTs the token + password fields to /password-reset/complete', async () => {
+    mockedAxios.post.mockResolvedValueOnce({ data: { status_code: 200, data: null } })
+
+    await PasswordResetApi.complete({
+      token: 'tok',
+      password: 'verylongpassword',
+      confirm_password: 'verylongpassword',
+    })
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://localhost:4000/password-reset/complete',
+      { token: 'tok', password: 'verylongpassword', confirm_password: 'verylongpassword' },
+      expect.objectContaining({
+        headers: { 'X-Version': '1.0.0-beta1' },
+        timeout: 15000,
+      })
+    )
+  })
+
+  it('rewraps a 422 validation_error as EntityApiError', async () => {
+    mockedAxios.post.mockRejectedValueOnce(
+      makeAxiosError(422, { error: 'validation_error', message: 'Password must be at least 12 characters' })
+    )
+
+    await expect(
+      PasswordResetApi.complete({ token: 't', password: 'short', confirm_password: 'short' })
+    ).rejects.toMatchObject({
+      method: 'POST',
+      url: '/password-reset/complete',
+      status: 422,
+    })
+  })
+
+  it('rewraps a 400 invalid_or_expired_token as EntityApiError', async () => {
+    mockedAxios.post.mockRejectedValueOnce(
+      makeAxiosError(400, { error: 'invalid_or_expired_token' })
+    )
+
+    await expect(
+      PasswordResetApi.complete({ token: 't', password: 'p', confirm_password: 'p' })
+    ).rejects.toMatchObject({
+      status: 400,
+      url: '/password-reset/complete',
+    })
+  })
+})

--- a/__tests__/types/password-reset.test.ts
+++ b/__tests__/types/password-reset.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest'
+import { EntityApiError } from '@/types/general'
+import {
+  isInvalidOrExpiredTokenError,
+  isPasswordResetRateLimitedError,
+  isPasswordResetValidationError,
+  PasswordResetErrorCode,
+} from '@/types/password-reset'
+
+function makeEntityApiError(
+  status: number,
+  data: unknown,
+  url = '/password-reset/complete'
+): EntityApiError {
+  const axiosLikeError = Object.assign(new Error('Request failed'), {
+    isAxiosError: true,
+    response: { status, statusText: 'Error', data },
+  })
+  return new EntityApiError('POST', url, axiosLikeError)
+}
+
+describe('isInvalidOrExpiredTokenError', () => {
+  // Wire format: PasswordResetEndpoints v1 contract on the coordination board.
+  // The 400 is the canonical "token unusable" response across validate + complete.
+  // BE deliberately collapses "doesn't exist", "expired", and "wrong purpose"
+  // into one discriminator so attackers can't enumerate token state.
+
+  it('returns true for the BE 400 invalid_or_expired_token shape', () => {
+    const err = makeEntityApiError(400, {
+      status_code: 400,
+      error: 'invalid_or_expired_token',
+      message: 'This reset link is invalid or has expired. Please request a new one.',
+    })
+    expect(isInvalidOrExpiredTokenError(err)).toBe(true)
+  })
+
+  it('returns true regardless of endpoint that produced it (validate vs complete)', () => {
+    const validateErr = makeEntityApiError(
+      400,
+      { error: 'invalid_or_expired_token' },
+      '/password-reset/validate'
+    )
+    const completeErr = makeEntityApiError(
+      400,
+      { error: 'invalid_or_expired_token' },
+      '/password-reset/complete'
+    )
+    expect(isInvalidOrExpiredTokenError(validateErr)).toBe(true)
+    expect(isInvalidOrExpiredTokenError(completeErr)).toBe(true)
+  })
+
+  it('returns false for a 400 with a different error code', () => {
+    const err = makeEntityApiError(400, { error: 'something_else' })
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for a 401 with the same error code (wrong status)', () => {
+    const err = makeEntityApiError(401, { error: 'invalid_or_expired_token' })
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for a 422 validation error', () => {
+    const err = makeEntityApiError(422, { error: 'validation_error' })
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for a 429 rate-limit error', () => {
+    const err = makeEntityApiError(429, { error: 'password_reset_rate_limited' })
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for a 400 with no body', () => {
+    const err = makeEntityApiError(400, null)
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for a 400 with non-object body', () => {
+    const err = makeEntityApiError(400, 'plain text')
+    expect(isInvalidOrExpiredTokenError(err)).toBe(false)
+  })
+
+  it('returns false for non-EntityApiError input', () => {
+    expect(isInvalidOrExpiredTokenError(new Error('plain'))).toBe(false)
+    expect(isInvalidOrExpiredTokenError(null)).toBe(false)
+    expect(isInvalidOrExpiredTokenError(undefined)).toBe(false)
+  })
+})
+
+describe('isPasswordResetRateLimitedError', () => {
+  // 429 from POST /password-reset/request when per-email cap is exceeded
+  // (BE enforces 1/60s and 5/24h).
+
+  it('returns true for the BE 429 password_reset_rate_limited shape', () => {
+    const err = makeEntityApiError(
+      429,
+      {
+        status_code: 429,
+        error: 'password_reset_rate_limited',
+        message: 'Too many password reset requests. Please wait before trying again.',
+      },
+      '/password-reset/request'
+    )
+    expect(isPasswordResetRateLimitedError(err)).toBe(true)
+  })
+
+  it('returns false for a 429 with a different error code', () => {
+    const err = makeEntityApiError(429, { error: 'too_many_requests' })
+    expect(isPasswordResetRateLimitedError(err)).toBe(false)
+  })
+
+  it('returns false for a 400 with the same error code (wrong status)', () => {
+    const err = makeEntityApiError(400, { error: 'password_reset_rate_limited' })
+    expect(isPasswordResetRateLimitedError(err)).toBe(false)
+  })
+
+  it('returns false for non-EntityApiError input', () => {
+    expect(isPasswordResetRateLimitedError(new Error('plain'))).toBe(false)
+    expect(isPasswordResetRateLimitedError(null)).toBe(false)
+    expect(isPasswordResetRateLimitedError(undefined)).toBe(false)
+  })
+})
+
+describe('isPasswordResetValidationError', () => {
+  // 422 from POST /password-reset/complete when password !== confirm_password.
+  // FE blocks client-side, so server-side hits indicate a tampered request.
+
+  it('returns true for the BE 422 validation_error shape', () => {
+    const err = makeEntityApiError(422, {
+      status_code: 422,
+      error: 'validation_error',
+      message: 'Password confirmation does not match',
+    })
+    expect(isPasswordResetValidationError(err)).toBe(true)
+  })
+
+  it('returns false for a 422 with a different error code', () => {
+    const err = makeEntityApiError(422, { error: 'cannot_link_completed_goal' })
+    expect(isPasswordResetValidationError(err)).toBe(false)
+  })
+
+  it('returns false for a 400 invalid_or_expired_token error', () => {
+    const err = makeEntityApiError(400, { error: 'invalid_or_expired_token' })
+    expect(isPasswordResetValidationError(err)).toBe(false)
+  })
+
+  it('returns false for non-EntityApiError input', () => {
+    expect(isPasswordResetValidationError(new Error('plain'))).toBe(false)
+    expect(isPasswordResetValidationError(null)).toBe(false)
+    expect(isPasswordResetValidationError(undefined)).toBe(false)
+  })
+})
+
+describe('password-reset endpoint error disambiguation', () => {
+  // The three structured errors that the password-reset endpoints can
+  // emit must be mutually exclusive at the parser level. This suite pins
+  // that contract so future BE drift gets caught at FE-test-time, not
+  // user-rendering-time.
+
+  const invalidOrExpired400 = {
+    status_code: 400,
+    error: PasswordResetErrorCode.InvalidOrExpiredToken,
+    message: 'invalid or expired',
+  }
+  const validation422 = {
+    status_code: 422,
+    error: PasswordResetErrorCode.ValidationError,
+    message: 'mismatch',
+  }
+  const rateLimit429 = {
+    status_code: 429,
+    error: PasswordResetErrorCode.PasswordResetRateLimited,
+    message: 'too many',
+  }
+
+  it('isInvalidOrExpiredTokenError matches only the 400 invalid_or_expired_token', () => {
+    expect(
+      isInvalidOrExpiredTokenError(makeEntityApiError(400, invalidOrExpired400))
+    ).toBe(true)
+    expect(
+      isInvalidOrExpiredTokenError(makeEntityApiError(422, validation422))
+    ).toBe(false)
+    expect(
+      isInvalidOrExpiredTokenError(makeEntityApiError(429, rateLimit429))
+    ).toBe(false)
+  })
+
+  it('isPasswordResetValidationError matches only the 422 validation_error', () => {
+    expect(
+      isPasswordResetValidationError(makeEntityApiError(400, invalidOrExpired400))
+    ).toBe(false)
+    expect(
+      isPasswordResetValidationError(makeEntityApiError(422, validation422))
+    ).toBe(true)
+    expect(
+      isPasswordResetValidationError(makeEntityApiError(429, rateLimit429))
+    ).toBe(false)
+  })
+
+  it('isPasswordResetRateLimitedError matches only the 429 password_reset_rate_limited', () => {
+    expect(
+      isPasswordResetRateLimitedError(makeEntityApiError(400, invalidOrExpired400))
+    ).toBe(false)
+    expect(
+      isPasswordResetRateLimitedError(makeEntityApiError(422, validation422))
+    ).toBe(false)
+    expect(
+      isPasswordResetRateLimitedError(makeEntityApiError(429, rateLimit429))
+    ).toBe(true)
+  })
+})

--- a/docs/architecture/password-reset-flow.md
+++ b/docs/architecture/password-reset-flow.md
@@ -1,0 +1,243 @@
+# Password Reset Flow — Architecture & Design
+
+User-initiated password reset for users who have forgotten their password. Cross-repo coordination with backend captured in the `password_reset_design_v1` thread and `PasswordResetEndpoints` v1 contract on the coordinator board (2026-05-13).
+
+## Goals
+
+- Allow a logged-out user to recover account access via email-based reset.
+- Reuse the existing magic-link token infrastructure on the backend (no new token primitives).
+- Match the existing `/setup/[token]` UX pattern so the visual and interaction language is consistent.
+- Ship with strong security defaults — no enumeration vector, no token leakage, short-lived tokens.
+
+## Non-goals (v1)
+
+- Multi-device session invalidation on successful reset — deferred until the persistent session store migration. The existing `SessionCleanupProvider` handles graceful logout on `401` whenever this lands, so no FE code is required in v1.
+- Per-IP rate limiting — BE ships with per-email DB-based limits only.
+- Password strength enforcement beyond the current `min 8 chars + confirm match` — tracked in [#395](https://github.com/refactor-group/refactor-platform-fe/issues/395) as a cross-cutting improvement across setup, reset, and change-password flows.
+- Auto-login after successful reset — user is redirected to the login page to sign in fresh with the new password.
+
+## User Flow
+
+```
+[Login page]                                       [Email inbox]
+  │                                                       │
+  │  click "Forgot password?"                             │  click "Reset your password"
+  ▼                                                       ▼
+[/forgot-password]  ──submit email──▶  (BE sends email)  [/reset-password/[token]]
+  │                                                       │
+  │  generic success: "If an account exists,             │  validate token (GET)
+  │  we sent a link…"                                    │
+  │                                                       ▼
+  │                                                     [ready: "Hi {first_name}, set a new password"]
+  │                                                       │
+  │                                                       │  submit new password (POST)
+  │                                                       ▼
+  │                                                     [success: "Password updated. Sign in."]
+  │                                                       │
+  │                                                       │  click "Go to Sign In"
+  └◀──────────────────────────────────────────────────────┘
+                       [Login page — sign in with new password]
+```
+
+## Endpoints (Backend Contract `PasswordResetEndpoints` v1)
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/password-reset/request` | Generate token, email reset link. **Always 200**, regardless of whether the email maps to a real user (enumeration-safe). 429 on rate-limit. |
+| `GET` | `/password-reset/validate?token=<raw>` | Non-destructive token validity check. Returns sanitized `{ first_name, last_name }` only — no email, role, or other PII. |
+| `POST` | `/password-reset/complete` | Consume token + set new password. Returns updated user. Token is deleted atomically (single-use). |
+
+Full request/response/error schemas live in `PasswordResetEndpoints` v1 on the coordinator board.
+
+### Error Discriminators (Specific-Variant Pattern)
+
+| Status | `error` string | When |
+|---|---|---|
+| 400 | `invalid_or_expired_token` | Token doesn't exist OR expired OR has wrong `purpose` — collapsed deliberately so attackers can't distinguish the cases |
+| 422 | `validation_error` | `password !== confirm_password` on `/complete` |
+| 429 | `password_reset_rate_limited` | More than 1 request/60s or 5 requests/24h per email on `/request` |
+
+Type guards (`isInvalidOrExpiredTokenError`, `isPasswordResetRateLimitedError`) mirror the existing pattern from `src/types/goal.ts`.
+
+## Frontend Architecture
+
+### Routes
+
+- **`/forgot-password`** — request flow. Single-form state machine: `idle` / `submitting` / `sent` / `error`.
+- **`/reset-password/[token]`** — complete flow. Five-state machine mirroring `/setup/[token]`: `validating` / `ready` / `submitting` / `success` / `error`.
+
+### Module layout
+
+```
+src/
+├── app/
+│   ├── forgot-password/
+│   │   └── page.tsx                 # request form + sent confirmation
+│   └── reset-password/
+│       └── [token]/
+│           └── page.tsx             # validate → reset form → success
+├── components/ui/login/
+│   └── user-auth-form.tsx           # MODIFIED: add "Forgot password?" link
+├── lib/api/
+│   └── password-reset.ts            # PasswordResetApi { request, validate, complete }
+└── types/
+    └── password-reset.ts            # request/response types, error type guards
+```
+
+### State machines
+
+The complete-flow state machine follows the existing setup-flow discriminated union (`SetupPageState` in `src/types/magic-link.ts`):
+
+```typescript
+type PasswordResetPageState =
+  | { kind: "validating" }
+  | { kind: "ready"; firstName: string; lastName: string }
+  | { kind: "submitting" }
+  | { kind: "success" }
+  | { kind: "error"; message: string };
+```
+
+Aligns with the project's nullable-type discipline (CLAUDE.md memory: prefer discriminated unions over `T | null`).
+
+### Component Reuse
+
+- **Two-column auth shell** — extract from `/setup/[token]/page.tsx` if not already shared; if shared, reuse directly.
+- **Form input + error rendering** — match the inline-red-text pattern from setup page and login form.
+- **`useLogoutUser` hook** — invoked on the `success` state transition to clear the FE auth store + SWR cache before redirecting to `/`. Handles the edge case where a logged-in user completes a reset (theirs or another account's).
+
+## Security Decisions
+
+This section is the load-bearing part of the doc. Each decision is recorded with its rationale and a pointer to where it's enforced.
+
+### 1. Enumeration safety: always 200 on `/request`
+
+**Decision:** `POST /password-reset/request` returns 200 regardless of whether the email maps to a real user. FE shows generic "If an account exists for that email, we sent a reset link" copy on success.
+
+**Rationale:** Returning 404 for unknown emails would create a brand-new account-discovery oracle on a publicly-callable endpoint. Attackers mapping a coaching organization (scraping a website, brute-forcing names, etc.) would be able to confirm which emails belong to actual users. The existing login form is already enumeration-safe — returning generic "Invalid email or password" on 401 — so this preserves the platform-wide posture.
+
+**Cost:** Slight UX loss — a user who typos their email gets a "we sent it" confirmation but never receives the email. Mitigated by clear copy: *"Check your inbox (and your spam folder)"* and *"The link expires in 30 minutes"*.
+
+**Enforced at:** BE (`/password-reset/request` returns 200 in both code paths). FE displays generic copy regardless of response detail.
+
+### 2. Token in path segment, not query string
+
+**Decision:** Email link uses `https://app.example.com/reset-password/<raw_token>` — token in the URL path segment, not as `?token=<raw>` in the query string.
+
+**Rationale:**
+
+- **Server access logs** typically log query strings, but many web servers and reverse proxies log the full URL path too. Path-segment tokens aren't immune to log capture, but query-string tokens are *more* commonly logged by analytics and middleware that strip on path but preserve query.
+- **Browser history** stores query strings; some browsers treat them differently for autocomplete.
+- **Matches the existing `/setup/[token]` precedent** — the welcome email already uses path-segment token substitution (verified in backend `domain/src/emails.rs:198`).
+
+**Enforced at:** BE email template (`{token}` placeholder substituted into path segment). FE route at `app/reset-password/[token]/page.tsx`.
+
+### 3. Strict `Referrer-Policy: no-referrer` on token-bearing pages
+
+**Decision:** Apply `Referrer-Policy: no-referrer` to both `/setup/:path*` and `/reset-password/:path*` via `next.config.mjs` `headers()` block.
+
+**Rationale:** When a token is in the URL path, any outbound request from that page (to third-party fonts, CDNs, analytics, or even same-origin endpoints) sends the full referring URL — including the token — in the `Referer` HTTP header. That token then lives in third-party access logs.
+
+The Next.js default policy (`strict-origin-when-cross-origin`) already strips the path from cross-origin `Referer` headers, so the threat is partially mitigated today. But:
+
+1. The default isn't immutable; future browser changes or middleware could weaken it.
+2. Same-origin requests still get the full path with token in `Referer` — a future addition of internal analytics or a logging beacon would capture the token.
+3. Explicit security headers beat implicit defaults for auditability.
+
+**`no-referrer`** is chosen over `same-origin` because it's strictly stronger (no `Referer` sent at all) and costs nothing — these pages don't load any third-party resources that need referrer for legitimate reasons. Pinned per-route (not site-wide) so other pages (OAuth flows, settings, dashboard) keep normal referrer behavior.
+
+**Enforced at:** `next.config.mjs` `headers()` config. Asserted by an E2E test that fetches the page and checks the response header.
+
+### 4. Short token TTL (30 minutes)
+
+**Decision:** Reset tokens expire 30 minutes after issuance. (Backend-side config: `PASSWORD_RESET_TOKEN_EXPIRY_SECONDS=1800`.)
+
+**Rationale:** Reset tokens grant the ability to change a password — the highest-value action in the auth system. The TTL window must be short enough that a leaked or intercepted token has limited useful lifetime. 30 minutes is short enough to limit damage but long enough that a user who clicked the link, walked away to brew coffee, and came back can still complete the flow. Setup tokens have a 24-hour TTL because the use case (new user onboarding via email) tolerates longer delays.
+
+**Enforced at:** BE (`password_reset_token_expiry_seconds` config + token expiry check in domain layer). FE surfaces expired tokens as a uniform 400 error.
+
+### 5. Single-use tokens with atomic consumption
+
+**Decision:** Reset tokens are deleted from the database in the same transaction as the password update. A token cannot be used twice.
+
+**Rationale:** Prevents replay attacks where a leaked token could be used multiple times. Also prevents race conditions: if a user clicks the email link twice (e.g., once on phone, once on desktop), one will succeed and one will see the uniform `invalid_or_expired_token` error.
+
+**Enforced at:** BE domain transaction (`coaching_session_goal.rs`-style pattern — atomic delete + update).
+
+### 6. Token purpose separation (`Setup` vs `PasswordReset`)
+
+**Decision:** The `magic_link_tokens` table gains a `purpose` column. Tokens issued for account setup cannot be redeemed on the reset endpoint, and vice versa.
+
+**Rationale:** Defense in depth. A leaked or stale setup token shouldn't grant password-reset capability (and vice versa). Without this, the token's secret material is the only thing distinguishing the two flows — a code-path mixup or future endpoint addition could create a confusion vulnerability.
+
+**Enforced at:** BE migration adds the column with backfill to `Setup`; validation logic checks purpose match before allowing redemption. Mismatch → uniform `400 invalid_or_expired_token` (no leak of "wrong purpose" detail to attackers).
+
+### 7. Error discriminator collapse on `/complete` and `/validate` (400 only)
+
+**Decision:** Both endpoints return `400 invalid_or_expired_token` for **all** of: token doesn't exist, token expired, token has wrong purpose. The three sub-cases are deliberately indistinguishable from the wire.
+
+**Rationale:** Distinct status codes (404 vs 401 vs 422) would let an attacker enumerate token validity by timing or status — even with a random token, the response code would reveal whether they hit a non-existent token vs an expired one. Collapsing them into one shape removes that oracle. The FE renders a single message (*"This reset link is invalid or has expired. Request a new one."*) because there's no actionable difference for the user either.
+
+**Enforced at:** BE web layer maps three EntityErrorKind variants to the same `(400, "invalid_or_expired_token")` JSON. FE renders one message regardless.
+
+### 8. Sanitized `/validate` response (first_name + last_name only)
+
+**Decision:** `GET /password-reset/validate` returns `{ first_name, last_name }` only — not the full user object. No email, no role, no organization memberships, no other PII.
+
+**Rationale:** The validate endpoint is unauthenticated and callable by anyone holding the token. Returning the full user shape would mean a leaked token grants a PII read on the account — including the email address (useful for further attacks like phishing). Returning just first/last name gives enough for the UI greeting (*"Hi Jane, set a new password"*) without exposing additional account detail.
+
+**Enforced at:** BE controller projects user model down to the two-field response.
+
+### 9. Force-logout on successful reset
+
+**Decision:** When the FE transitions to the `success` state on `/reset-password/[token]`, it calls `useLogoutUser()` to clear the auth store, SWR cache, and BE session cookie before redirecting to `/`.
+
+**Rationale:** If a logged-in user (User A) completes a reset for a different account (User B, perhaps because A is helping B on a shared device), simply redirecting to login without clearing A's session would leave A signed in while B is expected to sign in fresh. Force-logout makes the post-reset state unambiguous: nobody is signed in, the user signs in with the new credentials.
+
+This also closes a subtle session-coherence gap when the reset is for the currently-signed-in account: the old session cookie is invalidated alongside the password change, so the user can't accidentally keep using a session that was created under the old password.
+
+**Enforced at:** `success` state transition in `/reset-password/[token]/page.tsx`.
+
+### 10. BE-side rate limiting (1/60s, 5/24h per email)
+
+**Decision:** Backend enforces per-email rate limits on `/password-reset/request`. Exceeding either triggers `429 password_reset_rate_limited`.
+
+**Rationale:** Without rate limiting, an attacker can flood a user's inbox with reset emails (annoyance + cover for phishing), or generate hundreds of valid tokens to brute-force the token space. Per-email is the minimum useful unit; per-IP would also help but is deferred to a follow-up. The FE renders the 429 with copy that's truthful but doesn't reveal the exact threshold.
+
+**Enforced at:** BE checks the most recent token's `created_at` for the user. FE detects via `isPasswordResetRateLimitedError` type guard.
+
+## Deferred Items & Follow-ups
+
+- **Multi-device session invalidation** — will land with persistent session store. FE's existing `SessionCleanupProvider` will handle the post-invalidation 401 gracefully on other devices.
+- **Per-IP rate limiting** — separate ticket, likely `tower_governor` middleware applied globally on BE.
+- **Password strength rules** — [#395](https://github.com/refactor-group/refactor-platform-fe/issues/395). Will apply uniformly across setup, reset, and change-password flows.
+- **Audit `/setup/[token]` for Referrer-Policy** — bundled into the same PR as this feature, since the same threat model applies and the fix is a one-line addition to the same config block.
+
+## Test Plan
+
+### Unit / Integration
+
+- Type guards: `isInvalidOrExpiredTokenError`, `isPasswordResetRateLimitedError` — happy path + negative cases (wrong status, wrong discriminator, malformed body).
+- Disambiguation suite: feed each error fixture through every parser, assert exactly one matches.
+- API client: mocked-axios tests for `request`, `validate`, `complete` covering 200, 400, 422, 429, 503, network error.
+
+### E2E (Playwright)
+
+- Happy path: request → mock email (or token-from-test-fixture) → reset → land on login → sign in with new password.
+- Invalid token path: navigate to `/reset-password/expired-token-123` → see error state → click "Request a new one" → land on `/forgot-password`.
+- Password mismatch: ready state → submit non-matching passwords → see inline 422 validation message.
+- Rate limit: trigger 429 → see rate-limit message.
+- **Referrer-Policy assertion**: fetch `/reset-password/anytoken` and `/setup/anytoken`, assert response header `referrer-policy: no-referrer`.
+
+### Manual
+
+- Send a real reset email via dev BE, click link from a real email client (Gmail, Outlook), confirm token survives email-renderer rewriting.
+- Verify `Referrer-Policy` header in browser DevTools on both token pages.
+
+## References
+
+- Coordinator board: `PasswordResetEndpoints` v1 contract (2026-05-13)
+- Coordinator board: `password_reset_design_v1` question thread (2026-05-12)
+- Coordinator board: `referrer_policy_token_pages` question thread (2026-05-13)
+- Related issue: [#395 — Strengthen password rules](https://github.com/refactor-group/refactor-platform-fe/issues/395)
+- Existing pattern: [src/app/setup/[token]/page.tsx](../../src/app/setup/[token]/page.tsx) — token-flow state machine to mirror
+- Existing pattern: [src/types/goal.ts](../../src/types/goal.ts) — error type-guard convention

--- a/docs/architecture/password-reset-flow.md
+++ b/docs/architecture/password-reset-flow.md
@@ -13,7 +13,7 @@ User-initiated password reset for users who have forgotten their password. Cross
 
 - Multi-device session invalidation on successful reset — deferred until the persistent session store migration. The existing `SessionCleanupProvider` handles graceful logout on `401` whenever this lands, so no FE code is required in v1.
 - Per-IP rate limiting — BE ships with per-email DB-based limits only.
-- Password strength enforcement beyond the current `min 8 chars + confirm match` — tracked in [#395](https://github.com/refactor-group/refactor-platform-fe/issues/395) as a cross-cutting improvement across setup, reset, and change-password flows.
+- Strength enforcement beyond length-and-confirm-match (e.g. zxcvbn scoring, common-password rejection, HaveIBeenPwned check) — still tracked in [#395](https://github.com/refactor-group/refactor-platform-fe/issues/395). Length policy itself (`12 ≤ length ≤ 128`, no complexity rules) is now enforced per the `password_policy` decision on the coordination board.
 - Auto-login after successful reset — user is redirected to the login page to sign in fresh with the new password.
 
 ## User Flow
@@ -104,6 +104,19 @@ Aligns with the project's nullable-type discipline (CLAUDE.md memory: prefer dis
 - **Two-column auth shell** — extract from `/setup/[token]/page.tsx` if not already shared; if shared, reuse directly.
 - **Form input + error rendering** — match the inline-red-text pattern from setup page and login form.
 - **`useLogoutUser` hook** — invoked on the `success` state transition to clear the FE auth store + SWR cache before redirecting to `/`. Handles the edge case where a logged-in user completes a reset (theirs or another account's).
+
+### Password Policy
+
+Mirrors the server-side `password_policy` decision exactly:
+
+| Rule | Value | Client-side enforcement |
+|---|---|---|
+| Non-empty after trim | required | "Password cannot be empty or whitespace" |
+| Min length | 12 characters (Unicode scalar values, not bytes) | "Password must be at least 12 characters" |
+| Max length | 128 characters | "Password must be at most 128 characters" |
+| Complexity (uppercase / digit / symbol) | NOT enforced — deliberately | — |
+
+Length is counted via `[...password].length` to match the BE's Unicode-scalar counting (so 12 emoji counts as 12 characters, not ~48 bytes). On a server-side 422 the FE surfaces the BE's `message` verbatim — that way any future policy refinement on the BE is reflected without an FE patch.
 
 ## Security Decisions
 

--- a/docs/architecture/password-reset-flow.md
+++ b/docs/architecture/password-reset-flow.md
@@ -44,10 +44,10 @@ User-initiated password reset for users who have forgotten their password. Cross
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/password-reset/request` | Generate token, email reset link. **Always 200**, regardless of whether the email maps to a real user (enumeration-safe). 429 on rate-limit. |
-| `GET` | `/password-reset/validate?token=<raw>` | Non-destructive token validity check. Returns sanitized `{ first_name, last_name }` only — no email, role, or other PII. |
+| `POST` | `/password-reset/validate` | Non-destructive token validity check. **Token in JSON body** (v1.1 — see Security Decision 2a). Returns sanitized `{ first_name, last_name }` only — no email, role, or other PII. |
 | `POST` | `/password-reset/complete` | Consume token + set new password. Returns updated user. Token is deleted atomically (single-use). |
 
-Full request/response/error schemas live in `PasswordResetEndpoints` v1 on the coordinator board.
+Full request/response/error schemas live in `PasswordResetEndpoints` v1.1 on the coordinator board.
 
 ### Error Discriminators (Specific-Variant Pattern)
 
@@ -92,7 +92,7 @@ The complete-flow state machine follows the existing setup-flow discriminated un
 type PasswordResetPageState =
   | { kind: "validating" }
   | { kind: "ready"; firstName: string; lastName: string }
-  | { kind: "submitting" }
+  | { kind: "submitting"; firstName: string; lastName: string }
   | { kind: "success" }
   | { kind: "error"; message: string };
 ```
@@ -103,7 +103,7 @@ Aligns with the project's nullable-type discipline (CLAUDE.md memory: prefer dis
 
 - **Two-column auth shell** — extract from `/setup/[token]/page.tsx` if not already shared; if shared, reuse directly.
 - **Form input + error rendering** — match the inline-red-text pattern from setup page and login form.
-- **`useLogoutUser` hook** — invoked on the `success` state transition to clear the FE auth store + SWR cache before redirecting to `/`. Handles the edge case where a logged-in user completes a reset (theirs or another account's).
+- **`useLogoutUser` hook** — invoked on the **Sign-In click** from the `success` card (not on state transition) when the user is logged in. Clears the FE auth store + SWR cache and calls `router.replace("/")`. Handles the edge case where a logged-in user completes a reset (theirs or another account's). See Security Decision 9 for why this is click-driven rather than transition-driven.
 
 ### Password Policy
 
@@ -143,6 +143,21 @@ This section is the load-bearing part of the doc. Each decision is recorded with
 - **Matches the existing `/setup/[token]` precedent** — the welcome email already uses path-segment token substitution (verified in backend `domain/src/emails.rs:198`).
 
 **Enforced at:** BE email template (`{token}` placeholder substituted into path segment). FE route at `app/reset-password/[token]/page.tsx`.
+
+### 2a. Token in request body on FE→BE validate, not query string (v1.1)
+
+**Decision:** `POST /password-reset/validate` with `{ "token": "..." }` in the JSON body, **not** `GET ?token=<raw>`. v1 of the contract specified the query-string form; v1.1 (coordinator thread `password_reset_validate_token_transport`, 2026-05-14) corrected this.
+
+**Rationale:** The same argument that drove Decision 2 (path-segment over query-string in the email URL) applies to the FE→BE call. A `GET ?token=<raw>` lands the raw reset token in:
+
+- BE access logs (axum tower-http `TraceLayer` logs query strings by default, as do nginx/Caddy)
+- any reverse-proxy / CDN access log between the FE host and the BE
+- the browser's DevTools network history and `window.history`
+- any error-reporting / APM integration that captures request URLs
+
+JSON body transport bypasses every one of these in a single change. POST-for-a-non-mutating-read is a small REST-semantics tradeoff that's worth it for defense-in-depth and uniformity with `/request` and `/complete` (all three endpoints are now POST-with-body).
+
+**Enforced at:** FE — `axios.post(BASE + "/validate", { token })` in [src/lib/api/password-reset.ts](../../src/lib/api/password-reset.ts). BE — handler takes `Json<ValidateParams>` instead of `Query<ValidateParams>`. Regression-guarded by [__tests__/lib/api/password-reset.test.ts](../../__tests__/lib/api/password-reset.test.ts): the validate spec asserts no `params` config is passed to axios.
 
 ### 3. Strict `Referrer-Policy: no-referrer` on token-bearing pages
 
@@ -200,15 +215,17 @@ The Next.js default policy (`strict-origin-when-cross-origin`) already strips th
 
 **Enforced at:** BE controller projects user model down to the two-field response.
 
-### 9. Force-logout on successful reset
+### 9. Force-logout on successful reset (click-driven, not transition-driven)
 
-**Decision:** When the FE transitions to the `success` state on `/reset-password/[token]`, it calls `useLogoutUser()` to clear the auth store, SWR cache, and BE session cookie before redirecting to `/`.
+**Decision:** When the FE transitions to the `success` state on `/reset-password/[token]`, it shows the "Your password has been updated. Please sign in." card. **If the user was logged in**, clicking the "Go to Sign In" button invokes `useLogoutUser()`, which clears the auth store, SWR cache, and BE session cookie before redirecting to `/`. **If the user was logged out**, the same button is a plain `<Link>` to `/`.
 
 **Rationale:** If a logged-in user (User A) completes a reset for a different account (User B, perhaps because A is helping B on a shared device), simply redirecting to login without clearing A's session would leave A signed in while B is expected to sign in fresh. Force-logout makes the post-reset state unambiguous: nobody is signed in, the user signs in with the new credentials.
 
 This also closes a subtle session-coherence gap when the reset is for the currently-signed-in account: the old session cookie is invalidated alongside the password change, so the user can't accidentally keep using a session that was created under the old password.
 
-**Enforced at:** `success` state transition in `/reset-password/[token]/page.tsx`.
+**Why click-driven, not transition-driven:** An earlier draft invoked `logoutUser()` inside the `complete()` success path, before setting `pageState = "success"`. That had a bug — `useLogoutUser()` calls `router.replace("/")` in its `finally`, so the redirect fired before the success card could render, and the logged-in user never saw the confirmation. Click-driven preserves the success-card UI on both code paths (logged-in and logged-out), and matches the `/setup/[token]` precedent.
+
+**Enforced at:** `handleSignIn` in [src/app/reset-password/[token]/page.tsx](../../src/app/reset-password/[token]/page.tsx). Regression-guarded by the page-state-machine tests in [__tests__/app/reset-password-page.test.tsx](../../__tests__/app/reset-password-page.test.tsx) — one test asserts the success card renders before any logout, another asserts logout fires only after the Sign-In click.
 
 ### 10. BE-side rate limiting (1/60s, 5/24h per email)
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -14,6 +14,22 @@ const nextConfig = {
 			yjs: 'yjs/dist/yjs.mjs',
 		},
 	},
+	// Tokens appear in the URL path on these routes. `no-referrer` prevents
+	// the path (and therefore the token) from being sent in the Referer
+	// header to any outbound request, same-origin or cross-origin.
+	// See docs/architecture/password-reset-flow.md § Security Decision 3.
+	async headers() {
+		return [
+			{
+				source: '/setup/:path*',
+				headers: [{ key: 'Referrer-Policy', value: 'no-referrer' }],
+			},
+			{
+				source: '/reset-password/:path*',
+				headers: [{ key: 'Referrer-Policy', value: 'no-referrer' }],
+			},
+		];
+	},
 };
 
 export default nextConfig;

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useState } from "react"
+import Link from "next/link"
+
+import { cn } from "@/components/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/ui/icons"
+import { ForgotPasswordForm } from "@/components/ui/password-reset/forgot-password-form"
+import { PasswordResetApi } from "@/lib/api/password-reset"
+import { useAuthStore } from "@/lib/providers/auth-store-provider"
+import { siteConfig } from "@/site.config"
+import {
+    isPasswordResetRateLimitedError,
+} from "@/types/password-reset"
+import { EntityApiError } from "@/types/general"
+
+type ForgotPasswordState =
+    | { kind: "idle" }
+    | { kind: "submitting" }
+    | { kind: "sent" }
+
+function getErrorMessage(error: unknown): string {
+    if (isPasswordResetRateLimitedError(error)) {
+        return "Too many password reset requests. Please wait before trying again."
+    }
+    if (error instanceof EntityApiError) {
+        if (error.isServerError()) {
+            return "Something went wrong. Please try again later."
+        }
+        if (error.isNetworkError()) {
+            return "Unable to connect. Please check your connection and try again."
+        }
+    }
+    return "An unexpected error occurred. Please try again."
+}
+
+export default function ForgotPasswordPage() {
+    const initialEmail = useAuthStore((state) => state.userSession.email) ?? ""
+    const [pageState, setPageState] = useState<ForgotPasswordState>({ kind: "idle" })
+    const [formError, setFormError] = useState("")
+
+    const handleSubmit = async (email: string) => {
+        setPageState({ kind: "submitting" })
+        setFormError("")
+        try {
+            await PasswordResetApi.request({ email })
+            setPageState({ kind: "sent" })
+        } catch (error) {
+            setFormError(getErrorMessage(error))
+            setPageState({ kind: "idle" })
+        }
+    }
+
+    return (
+        <main>
+            <div className="container relative h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+                {/* Column 1 — Branding */}
+                <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
+                    <div className="absolute inset-0 bg-zinc-900" />
+                    <div className="relative z-20 flex items-center text-lg font-medium">
+                        <Link
+                            href="https://www.refactorgroup.com"
+                            className="mr-2 flex items-center space-x-2"
+                        >
+                            <div
+                                className={cn(
+                                    buttonVariants({ variant: "ghost" }),
+                                    "w-9 px-0"
+                                )}
+                            >
+                                <Icons.refactor_logo className="h-7 w-7" />
+                                <span className="sr-only">Refactor</span>
+                            </div>
+                        </Link>
+                        {siteConfig.name}
+                    </div>
+                    <div className="relative z-20 mt-auto">
+                        <blockquote className="space-y-2">
+                            <p className="text-lg">{siteConfig.description}</p>
+                        </blockquote>
+                    </div>
+                </div>
+
+                {/* Column 2 — Content */}
+                <div className="mx-auto flex flex-col justify-center mt-16 space-y-8 sm:w-96 lg:mt-0">
+                    <div className="flex flex-col space-y-2 text-center">
+                        <div className="flex items-center justify-center space-x-2">
+                            <Link
+                                href="https://www.refactorgroup.com"
+                                className="flex items-center lg:hidden"
+                            >
+                                <div
+                                    className={cn(
+                                        buttonVariants({ variant: "ghost" }),
+                                        "w-10 px-0"
+                                    )}
+                                >
+                                    <Icons.refactor_logo className="h-7 w-7" />
+                                    <span className="sr-only">Refactor</span>
+                                </div>
+                            </Link>
+                            <h1 className="text-2xl font-semibold tracking-tight">
+                                Reset Your Password
+                            </h1>
+                        </div>
+                    </div>
+
+                    {(pageState.kind === "idle" || pageState.kind === "submitting") && (
+                        <>
+                            <p className="text-center text-sm text-muted-foreground">
+                                Enter your email and we&apos;ll send you a reset link.
+                            </p>
+                            <ForgotPasswordForm
+                                initialEmail={initialEmail}
+                                onSubmit={handleSubmit}
+                                isSubmitting={pageState.kind === "submitting"}
+                                error={formError}
+                            />
+                            <p className="text-center text-sm text-muted-foreground">
+                                <Link href="/" className="underline hover:text-foreground">
+                                    Back to sign in
+                                </Link>
+                            </p>
+                        </>
+                    )}
+
+                    {pageState.kind === "sent" && (
+                        <div className="flex flex-col items-center space-y-4">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900">
+                                <svg className="h-6 w-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                                </svg>
+                            </div>
+                            <p className="text-center text-sm text-muted-foreground">
+                                If an account exists for that email, we&apos;ve sent a reset link to it.
+                                The link expires in 30 minutes. Check your inbox (and your spam folder).
+                            </p>
+                            <Link
+                                href="/"
+                                className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                            >
+                                Back to sign in
+                            </Link>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </main>
+    )
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -36,7 +36,13 @@ function getErrorMessage(error: unknown): string {
 }
 
 export default function ForgotPasswordPage() {
-    const initialEmail = useAuthStore((state) => state.userSession.email) ?? ""
+    // Prefill email only when the user is actually signed in. Reading
+    // userSession.email unconditionally would surface the empty-string
+    // default for logged-out users — a falsy sentinel masquerading as data.
+    const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+    const sessionEmail = useAuthStore((state) => state.userSession.email)
+    const initialEmail = isLoggedIn ? sessionEmail : undefined
+
     const [pageState, setPageState] = useState<ForgotPasswordState>({ kind: "idle" })
     const [formError, setFormError] = useState("")
 

--- a/src/app/reset-password/[token]/page.tsx
+++ b/src/app/reset-password/[token]/page.tsx
@@ -42,7 +42,16 @@ function getCompleteErrorMessage(error: unknown): string {
         return INVALID_OR_EXPIRED_MESSAGE
     }
     if (isPasswordResetValidationError(error)) {
-        return "Passwords do not match. Please try again."
+        // BE returns a specific per-rule message (e.g. "Password must be at
+        // least 12 characters"). Surface it verbatim so the user sees the
+        // exact policy. Falls back to a generic if the body shape is unexpected.
+        if (error instanceof EntityApiError) {
+            const message = (error.data as { message?: unknown })?.message
+            if (typeof message === "string" && message.length > 0) {
+                return message
+            }
+        }
+        return "Your password does not meet requirements. Please try again."
     }
     return getValidateErrorMessage(error)
 }

--- a/src/app/reset-password/[token]/page.tsx
+++ b/src/app/reset-password/[token]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation"
 import Link from "next/link"
 
 import { cn } from "@/components/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
 import { Icons } from "@/components/ui/icons"
 import { ResetPasswordForm } from "@/components/ui/password-reset/reset-password-form"
 import { PasswordResetApi } from "@/lib/api/password-reset"
@@ -42,14 +42,11 @@ function getCompleteErrorMessage(error: unknown): string {
         return INVALID_OR_EXPIRED_MESSAGE
     }
     if (isPasswordResetValidationError(error)) {
-        // BE returns a specific per-rule message (e.g. "Password must be at
-        // least 12 characters"). Surface it verbatim so the user sees the
-        // exact policy. Falls back to a generic if the body shape is unexpected.
-        if (error instanceof EntityApiError) {
-            const message = (error.data as { message?: unknown })?.message
-            if (typeof message === "string" && message.length > 0) {
-                return message
-            }
+        // BE returns a per-rule message (e.g. "Password must be at least 12
+        // characters") — surface it verbatim so the user sees the exact policy.
+        const message = (error.data as { message?: unknown })?.message
+        if (typeof message === "string" && message.length > 0) {
+            return message
         }
         return "Your password does not meet requirements. Please try again."
     }
@@ -58,18 +55,28 @@ function getCompleteErrorMessage(error: unknown): string {
 
 export default function ResetPasswordPage() {
     const params = useParams<{ token: string }>()
-    const token = params.token
+    const token = typeof params.token === "string" ? params.token : ""
     const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
     const logoutUser = useLogoutUser()
 
-    const [pageState, setPageState] = useState<PasswordResetPageState>({
-        kind: "validating",
-    })
+    // Initial state is derived synchronously from the route param — a missing
+    // token short-circuits straight to the error card without ever hitting the
+    // API. (Computing in the effect would trigger a "setState in effect" lint.)
+    const [pageState, setPageState] = useState<PasswordResetPageState>(() =>
+        token
+            ? { kind: "validating" }
+            : { kind: "error", message: INVALID_OR_EXPIRED_MESSAGE }
+    )
     const [formError, setFormError] = useState("")
+    const [isSigningOut, setIsSigningOut] = useState(false)
 
     useEffect(() => {
+        if (!token) return
+
+        let cancelled = false
         PasswordResetApi.validate(token)
             .then((data) => {
+                if (cancelled) return
                 setPageState({
                     kind: "ready",
                     firstName: data.first_name,
@@ -77,11 +84,15 @@ export default function ResetPasswordPage() {
                 })
             })
             .catch((error) => {
+                if (cancelled) return
                 setPageState({
                     kind: "error",
                     message: getValidateErrorMessage(error),
                 })
             })
+        return () => {
+            cancelled = true
+        }
     }, [token])
 
     const handleSubmit = async (password: string, confirmPassword: string) => {
@@ -97,15 +108,6 @@ export default function ResetPasswordPage() {
                 password,
                 confirm_password: confirmPassword,
             })
-
-            // Force-logout: if the user was signed in (e.g. helped someone else
-            // reset their password on a shared device, or reset their own
-            // account while still signed in), clear local state so the post-
-            // reset "Sign in" CTA lands them on a clean login.
-            if (isLoggedIn) {
-                await logoutUser()
-            }
-
             setPageState({ kind: "success" })
         } catch (error) {
             if (isInvalidOrExpiredTokenError(error)) {
@@ -118,6 +120,18 @@ export default function ResetPasswordPage() {
             setFormError(getCompleteErrorMessage(error))
             setPageState({ kind: "ready", firstName, lastName })
         }
+    }
+
+    // Sign-In click on the success card. If the user was logged in (their own
+    // account or a shared device), force-logout to clear local state + BE
+    // session cookie. logoutUser() handles the router.replace("/").
+    const handleSignIn = async () => {
+        if (isLoggedIn) {
+            setIsSigningOut(true)
+            await logoutUser()
+            return
+        }
+        // Logged-out path: plain navigation, handled by the <Link>.
     }
 
     const greeting =
@@ -211,12 +225,29 @@ export default function ResetPasswordPage() {
                             <p className="text-center text-sm text-muted-foreground">
                                 Your password has been updated. Please sign in with your new password.
                             </p>
-                            <Link
-                                href="/"
-                                className={cn(buttonVariants({ variant: "outline" }), "w-full")}
-                            >
-                                Go to Sign In
-                            </Link>
+                            {isLoggedIn ? (
+                                <Button
+                                    className="w-full"
+                                    onClick={handleSignIn}
+                                    disabled={isSigningOut}
+                                >
+                                    {isSigningOut ? (
+                                        <>
+                                            <span className="mr-2">Sign In</span>
+                                            <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                                        </>
+                                    ) : (
+                                        "Go to Sign In"
+                                    )}
+                                </Button>
+                            ) : (
+                                <Link
+                                    href="/"
+                                    className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                                >
+                                    Go to Sign In
+                                </Link>
+                            )}
                         </div>
                     )}
 

--- a/src/app/reset-password/[token]/page.tsx
+++ b/src/app/reset-password/[token]/page.tsx
@@ -1,0 +1,242 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import Link from "next/link"
+
+import { cn } from "@/components/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+import { Icons } from "@/components/ui/icons"
+import { ResetPasswordForm } from "@/components/ui/password-reset/reset-password-form"
+import { PasswordResetApi } from "@/lib/api/password-reset"
+import { useAuthStore } from "@/lib/providers/auth-store-provider"
+import { useLogoutUser } from "@/lib/hooks/use-logout-user"
+import { siteConfig } from "@/site.config"
+import {
+    isInvalidOrExpiredTokenError,
+    isPasswordResetValidationError,
+    type PasswordResetPageState,
+} from "@/types/password-reset"
+import { EntityApiError } from "@/types/general"
+
+const INVALID_OR_EXPIRED_MESSAGE =
+    "This reset link is invalid or has expired. Please request a new one."
+
+function getValidateErrorMessage(error: unknown): string {
+    if (isInvalidOrExpiredTokenError(error)) {
+        return INVALID_OR_EXPIRED_MESSAGE
+    }
+    if (error instanceof EntityApiError) {
+        if (error.isServerError()) {
+            return "Something went wrong. Please try again later."
+        }
+        if (error.isNetworkError()) {
+            return "Unable to connect. Please check your connection and try again."
+        }
+    }
+    return "An unexpected error occurred. Please try again."
+}
+
+function getCompleteErrorMessage(error: unknown): string {
+    if (isInvalidOrExpiredTokenError(error)) {
+        return INVALID_OR_EXPIRED_MESSAGE
+    }
+    if (isPasswordResetValidationError(error)) {
+        return "Passwords do not match. Please try again."
+    }
+    return getValidateErrorMessage(error)
+}
+
+export default function ResetPasswordPage() {
+    const params = useParams<{ token: string }>()
+    const token = params.token
+    const isLoggedIn = useAuthStore((state) => state.isLoggedIn)
+    const logoutUser = useLogoutUser()
+
+    const [pageState, setPageState] = useState<PasswordResetPageState>({
+        kind: "validating",
+    })
+    const [formError, setFormError] = useState("")
+
+    useEffect(() => {
+        PasswordResetApi.validate(token)
+            .then((data) => {
+                setPageState({
+                    kind: "ready",
+                    firstName: data.first_name,
+                    lastName: data.last_name,
+                })
+            })
+            .catch((error) => {
+                setPageState({
+                    kind: "error",
+                    message: getValidateErrorMessage(error),
+                })
+            })
+    }, [token])
+
+    const handleSubmit = async (password: string, confirmPassword: string) => {
+        if (pageState.kind !== "ready") return
+
+        const { firstName, lastName } = pageState
+        setPageState({ kind: "submitting", firstName, lastName })
+        setFormError("")
+
+        try {
+            await PasswordResetApi.complete({
+                token,
+                password,
+                confirm_password: confirmPassword,
+            })
+
+            // Force-logout: if the user was signed in (e.g. helped someone else
+            // reset their password on a shared device, or reset their own
+            // account while still signed in), clear local state so the post-
+            // reset "Sign in" CTA lands them on a clean login.
+            if (isLoggedIn) {
+                await logoutUser()
+            }
+
+            setPageState({ kind: "success" })
+        } catch (error) {
+            if (isInvalidOrExpiredTokenError(error)) {
+                setPageState({
+                    kind: "error",
+                    message: getCompleteErrorMessage(error),
+                })
+                return
+            }
+            setFormError(getCompleteErrorMessage(error))
+            setPageState({ kind: "ready", firstName, lastName })
+        }
+    }
+
+    const greeting =
+        pageState.kind === "ready" || pageState.kind === "submitting"
+            ? `Hi ${pageState.firstName}, set a new password below.`
+            : ""
+
+    return (
+        <main>
+            <div className="container relative h-[800px] flex-col items-center justify-center md:grid lg:max-w-none lg:grid-cols-2 lg:px-0">
+                {/* Column 1 — Branding */}
+                <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
+                    <div className="absolute inset-0 bg-zinc-900" />
+                    <div className="relative z-20 flex items-center text-lg font-medium">
+                        <Link
+                            href="https://www.refactorgroup.com"
+                            className="mr-2 flex items-center space-x-2"
+                        >
+                            <div
+                                className={cn(
+                                    buttonVariants({ variant: "ghost" }),
+                                    "w-9 px-0"
+                                )}
+                            >
+                                <Icons.refactor_logo className="h-7 w-7" />
+                                <span className="sr-only">Refactor</span>
+                            </div>
+                        </Link>
+                        {siteConfig.name}
+                    </div>
+                    <div className="relative z-20 mt-auto">
+                        <blockquote className="space-y-2">
+                            <p className="text-lg">{siteConfig.description}</p>
+                        </blockquote>
+                    </div>
+                </div>
+
+                {/* Column 2 — Content */}
+                <div className="mx-auto flex flex-col justify-center mt-16 space-y-8 sm:w-96 lg:mt-0">
+                    <div className="flex flex-col space-y-2 text-center">
+                        <div className="flex items-center justify-center space-x-2">
+                            <Link
+                                href="https://www.refactorgroup.com"
+                                className="flex items-center lg:hidden"
+                            >
+                                <div
+                                    className={cn(
+                                        buttonVariants({ variant: "ghost" }),
+                                        "w-10 px-0"
+                                    )}
+                                >
+                                    <Icons.refactor_logo className="h-7 w-7" />
+                                    <span className="sr-only">Refactor</span>
+                                </div>
+                            </Link>
+                            <h1 className="text-2xl font-semibold tracking-tight">
+                                Reset Your Password
+                            </h1>
+                        </div>
+                    </div>
+
+                    {pageState.kind === "validating" && (
+                        <div className="flex flex-col items-center space-y-4">
+                            <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+                            <p className="text-sm text-muted-foreground">
+                                Validating your reset link...
+                            </p>
+                        </div>
+                    )}
+
+                    {(pageState.kind === "ready" || pageState.kind === "submitting") && (
+                        <>
+                            <p className="text-center text-sm text-muted-foreground">
+                                {greeting}
+                            </p>
+                            <ResetPasswordForm
+                                onSubmit={handleSubmit}
+                                isSubmitting={pageState.kind === "submitting"}
+                                error={formError}
+                            />
+                        </>
+                    )}
+
+                    {pageState.kind === "success" && (
+                        <div className="flex flex-col items-center space-y-4">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900">
+                                <svg className="h-6 w-6 text-green-600 dark:text-green-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                                </svg>
+                            </div>
+                            <p className="text-center text-sm text-muted-foreground">
+                                Your password has been updated. Please sign in with your new password.
+                            </p>
+                            <Link
+                                href="/"
+                                className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                            >
+                                Go to Sign In
+                            </Link>
+                        </div>
+                    )}
+
+                    {pageState.kind === "error" && (
+                        <div className="flex flex-col items-center space-y-4">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-red-100 dark:bg-red-900">
+                                <svg className="h-6 w-6 text-red-600 dark:text-red-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </div>
+                            <p className="text-center text-sm text-muted-foreground">
+                                {pageState.message}
+                            </p>
+                            <Link
+                                href="/forgot-password"
+                                className={cn(buttonVariants({ variant: "outline" }), "w-full")}
+                            >
+                                Request a new reset link
+                            </Link>
+                            <Link
+                                href="/"
+                                className="text-sm text-muted-foreground underline hover:text-foreground"
+                            >
+                                Back to sign in
+                            </Link>
+                        </div>
+                    )}
+                </div>
+            </div>
+        </main>
+    )
+}

--- a/src/app/setup/[token]/page.tsx
+++ b/src/app/setup/[token]/page.tsx
@@ -24,6 +24,13 @@ function getErrorMessage(error: unknown): string {
             return "This account has already been set up."
         }
         if (status === 422) {
+            // BE returns a specific per-rule message (e.g. "Password must be at
+            // least 12 characters"). Surface it verbatim per the password_policy
+            // decision. Falls back to a generic if the body shape is unexpected.
+            const data = error.response?.data as { message?: unknown } | undefined
+            if (typeof data?.message === "string" && data.message.length > 0) {
+                return data.message
+            }
             return "Password does not meet requirements."
         }
         if (status && status >= 500) {

--- a/src/components/ui/login/user-auth-form.tsx
+++ b/src/components/ui/login/user-auth-form.tsx
@@ -133,7 +133,7 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
           <div className="flex justify-end">
             <Link
               href="/forgot-password"
-              className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              className="text-xs text-muted-foreground/70 underline-offset-4 hover:text-muted-foreground hover:underline"
             >
               Forgot password?
             </Link>

--- a/src/components/ui/login/user-auth-form.tsx
+++ b/src/components/ui/login/user-auth-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import Link from "next/link";
 
 import { cn } from "@/components/lib/utils";
 import { useUserSessionMutation } from "@/lib/api/user-sessions";
@@ -128,6 +129,14 @@ export function UserAuthForm({ className, ...props }: UserAuthFormProps) {
               disabled={isLoading}
               onChange={(e) => updatePassword(e.target.value)}
             />
+          </div>
+          <div className="flex justify-end">
+            <Link
+              href="/forgot-password"
+              className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+            >
+              Forgot password?
+            </Link>
           </div>
           <Button disabled={isLoading}>
             {isLoading && (

--- a/src/components/ui/password-reset/forgot-password-form.tsx
+++ b/src/components/ui/password-reset/forgot-password-form.tsx
@@ -9,16 +9,16 @@ interface ForgotPasswordFormProps {
     initialEmail?: string
     onSubmit: (email: string) => Promise<void>
     isSubmitting: boolean
-    error: string
+    error?: string
 }
 
 export function ForgotPasswordForm({
-    initialEmail = "",
+    initialEmail,
     onSubmit,
     isSubmitting,
     error,
 }: ForgotPasswordFormProps) {
-    const [email, setEmail] = useState(initialEmail)
+    const [email, setEmail] = useState(initialEmail ?? "")
     const [fieldError, setFieldError] = useState("")
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/ui/password-reset/forgot-password-form.tsx
+++ b/src/components/ui/password-reset/forgot-password-form.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { useState, type FormEvent, type ChangeEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface ForgotPasswordFormProps {
+    initialEmail?: string
+    onSubmit: (email: string) => Promise<void>
+    isSubmitting: boolean
+    error: string
+}
+
+export function ForgotPasswordForm({
+    initialEmail = "",
+    onSubmit,
+    isSubmitting,
+    error,
+}: ForgotPasswordFormProps) {
+    const [email, setEmail] = useState(initialEmail)
+    const [fieldError, setFieldError] = useState("")
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setEmail(e.target.value)
+        if (fieldError) setFieldError("")
+    }
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault()
+        if (!email.trim()) {
+            setFieldError("Email is required")
+            return
+        }
+        await onSubmit(email.trim())
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    value={email}
+                    onChange={handleChange}
+                    placeholder="name@example.com"
+                    className={fieldError ? "border-red-500" : ""}
+                    autoComplete="email"
+                    autoCapitalize="none"
+                    autoCorrect="off"
+                    required
+                    disabled={isSubmitting}
+                />
+                {fieldError && <p className="text-sm text-red-500">{fieldError}</p>}
+            </div>
+
+            {error && (
+                <p className="text-center text-sm font-semibold text-red-500">{error}</p>
+            )}
+
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+                {isSubmitting ? (
+                    <>
+                        <span className="mr-2">Sending...</span>
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    </>
+                ) : (
+                    "Send reset link"
+                )}
+            </Button>
+        </form>
+    )
+}

--- a/src/components/ui/password-reset/reset-password-form.tsx
+++ b/src/components/ui/password-reset/reset-password-form.tsx
@@ -8,7 +8,7 @@ import { Label } from "@/components/ui/label"
 interface ResetPasswordFormProps {
     onSubmit: (password: string, confirmPassword: string) => Promise<void>
     isSubmitting: boolean
-    error: string
+    error?: string
 }
 
 export function ResetPasswordForm({ onSubmit, isSubmitting, error }: ResetPasswordFormProps) {

--- a/src/components/ui/password-reset/reset-password-form.tsx
+++ b/src/components/ui/password-reset/reset-password-form.tsx
@@ -1,0 +1,111 @@
+"use client"
+
+import { useState, type FormEvent, type ChangeEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface ResetPasswordFormProps {
+    onSubmit: (password: string, confirmPassword: string) => Promise<void>
+    isSubmitting: boolean
+    error: string
+}
+
+export function ResetPasswordForm({ onSubmit, isSubmitting, error }: ResetPasswordFormProps) {
+    const [formData, setFormData] = useState({
+        password: "",
+        confirm_password: "",
+    })
+    const [errors, setErrors] = useState<Record<string, string>>({})
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = e.target
+        setFormData((prev) => ({ ...prev, [name]: value }))
+
+        if (errors[name]) {
+            setErrors((prev) => {
+                const newErrors = { ...prev }
+                delete newErrors[name]
+                return newErrors
+            })
+        }
+    }
+
+    const validateForm = () => {
+        const newErrors: Record<string, string> = {}
+
+        if (!formData.password.trim()) {
+            newErrors.password = "Password is required"
+        } else if (formData.password.length < 8) {
+            newErrors.password = "Password must be at least 8 characters long"
+        }
+
+        if (!formData.confirm_password.trim()) {
+            newErrors.confirm_password = "Please confirm your password"
+        } else if (formData.password !== formData.confirm_password) {
+            newErrors.confirm_password = "Passwords do not match"
+        }
+
+        setErrors(newErrors)
+        return Object.keys(newErrors).length === 0
+    }
+
+    const handleSubmit = async (e: FormEvent) => {
+        e.preventDefault()
+        if (!validateForm()) return
+        await onSubmit(formData.password, formData.confirm_password)
+    }
+
+    return (
+        <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="space-y-2">
+                <Label htmlFor="password">New password</Label>
+                <Input
+                    id="password"
+                    name="password"
+                    type="password"
+                    value={formData.password}
+                    onChange={handleChange}
+                    placeholder="Enter your new password"
+                    className={errors.password ? "border-red-500" : ""}
+                    autoComplete="new-password"
+                    disabled={isSubmitting}
+                />
+                {errors.password && <p className="text-sm text-red-500">{errors.password}</p>}
+            </div>
+
+            <div className="space-y-2">
+                <Label htmlFor="confirm_password">Confirm new password</Label>
+                <Input
+                    id="confirm_password"
+                    name="confirm_password"
+                    type="password"
+                    value={formData.confirm_password}
+                    onChange={handleChange}
+                    placeholder="Confirm your new password"
+                    className={errors.confirm_password ? "border-red-500" : ""}
+                    autoComplete="new-password"
+                    disabled={isSubmitting}
+                />
+                {errors.confirm_password && (
+                    <p className="text-sm text-red-500">{errors.confirm_password}</p>
+                )}
+            </div>
+
+            {error && (
+                <p className="text-center text-sm font-semibold text-red-500">{error}</p>
+            )}
+
+            <Button type="submit" disabled={isSubmitting} className="w-full">
+                {isSubmitting ? (
+                    <>
+                        <span className="mr-2">Updating...</span>
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                    </>
+                ) : (
+                    "Update password"
+                )}
+            </Button>
+        </form>
+    )
+}

--- a/src/components/ui/password-reset/reset-password-form.tsx
+++ b/src/components/ui/password-reset/reset-password-form.tsx
@@ -34,10 +34,14 @@ export function ResetPasswordForm({ onSubmit, isSubmitting, error }: ResetPasswo
     const validateForm = () => {
         const newErrors: Record<string, string> = {}
 
+        // Mirrors server-side policy: 12 ≤ length ≤ 128, no complexity rules.
+        // See password_policy decision on the coordination board.
         if (!formData.password.trim()) {
-            newErrors.password = "Password is required"
-        } else if (formData.password.length < 8) {
-            newErrors.password = "Password must be at least 8 characters long"
+            newErrors.password = "Password cannot be empty or whitespace"
+        } else if ([...formData.password].length < 12) {
+            newErrors.password = "Password must be at least 12 characters"
+        } else if ([...formData.password].length > 128) {
+            newErrors.password = "Password must be at most 128 characters"
         }
 
         if (!formData.confirm_password.trim()) {

--- a/src/components/ui/setup/account-setup-form.tsx
+++ b/src/components/ui/setup/account-setup-form.tsx
@@ -34,10 +34,14 @@ export function AccountSetupForm({ onSubmit, isSubmitting, error }: AccountSetup
     const validateForm = () => {
         const newErrors: Record<string, string> = {}
 
+        // Mirrors server-side policy: 12 ≤ length ≤ 128, no complexity rules.
+        // See password_policy decision on the coordination board.
         if (!formData.password.trim()) {
-            newErrors.password = "Password is required"
-        } else if (formData.password.length < 8) {
-            newErrors.password = "Password must be at least 8 characters long"
+            newErrors.password = "Password cannot be empty or whitespace"
+        } else if ([...formData.password].length < 12) {
+            newErrors.password = "Password must be at least 12 characters"
+        } else if ([...formData.password].length > 128) {
+            newErrors.password = "Password must be at most 128 characters"
         }
 
         if (!formData.confirm_password.trim()) {

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -70,7 +70,7 @@ export namespace EntityApi {
     } catch (error) {
       // Wrap axios errors in EntityApiError for consistent error handling
       if (axios.isAxiosError(error)) {
-        throw new EntityApiError("get", url, error);
+        throw EntityApiError.from("get", url, error);
       }
 
       // Re-throw non-axios errors as-is
@@ -124,7 +124,7 @@ export namespace EntityApi {
     } catch (error) {
       // Wrap axios errors in EntityApiError for enhanced error handling
       if (axios.isAxiosError(error)) {
-        throw new EntityApiError(method, url, error);
+        throw EntityApiError.from(method, url, error);
       }
 
       // Re-throw non-axios errors as-is

--- a/src/lib/api/goals.ts
+++ b/src/lib/api/goals.ts
@@ -148,9 +148,11 @@ export const GoalApi = {
         { goal_id: goalId }
       ).then(() => undefined),
       (e) =>
-        e instanceof EntityApiError
-          ? e
-          : new EntityApiError("POST", `${COACHING_SESSIONS_BASEURL}/${coachingSessionId}/goals`, e as Error)
+        EntityApiError.from(
+          "POST",
+          `${COACHING_SESSIONS_BASEURL}/${coachingSessionId}/goals`,
+          e
+        )
     ),
 
   /**
@@ -166,9 +168,11 @@ export const GoalApi = {
         `${COACHING_SESSIONS_BASEURL}/${coachingSessionId}/goals/${goalId}`
       ).then(() => undefined),
       (e) =>
-        e instanceof EntityApiError
-          ? e
-          : new EntityApiError("DELETE", `${COACHING_SESSIONS_BASEURL}/${coachingSessionId}/goals/${goalId}`, e as Error)
+        EntityApiError.from(
+          "DELETE",
+          `${COACHING_SESSIONS_BASEURL}/${coachingSessionId}/goals/${goalId}`,
+          e
+        )
     ),
 };
 

--- a/src/lib/api/password-reset.ts
+++ b/src/lib/api/password-reset.ts
@@ -20,13 +20,6 @@ interface ApiResponse<T> {
   data: T;
 }
 
-function wrap(method: string, path: string, error: unknown): EntityApiError {
-  if (error instanceof Error) {
-    return new EntityApiError(method, path, error);
-  }
-  return new EntityApiError(method, path, new Error(String(error)));
-}
-
 export const PasswordResetApi = {
   /**
    * Requests a password-reset email.
@@ -41,7 +34,7 @@ export const PasswordResetApi = {
         axiosConfig
       );
     } catch (error) {
-      throw wrap("POST", "/password-reset/request", error);
+      throw EntityApiError.from("POST", "/password-reset/request", error);
     }
   },
 
@@ -61,7 +54,7 @@ export const PasswordResetApi = {
       );
       return response.data.data;
     } catch (error) {
-      throw wrap("POST", "/password-reset/validate", error);
+      throw EntityApiError.from("POST", "/password-reset/validate", error);
     }
   },
 
@@ -78,7 +71,7 @@ export const PasswordResetApi = {
         axiosConfig
       );
     } catch (error) {
-      throw wrap("POST", "/password-reset/complete", error);
+      throw EntityApiError.from("POST", "/password-reset/complete", error);
     }
   },
 };

--- a/src/lib/api/password-reset.ts
+++ b/src/lib/api/password-reset.ts
@@ -1,0 +1,80 @@
+import axios from "axios";
+import { siteConfig } from "@/site.config";
+import { EntityApiError } from "@/types/general";
+import type {
+  PasswordResetCompleteParams,
+  PasswordResetRequestParams,
+  PasswordResetValidateData,
+} from "@/types/password-reset";
+
+const PASSWORD_RESET_BASEURL = `${siteConfig.env.backendServiceURL}/password-reset`;
+
+const axiosConfig = {
+  headers: { "X-Version": siteConfig.env.backendApiVersion },
+  timeout: 15000,
+};
+
+interface ApiResponse<T> {
+  status_code: number;
+  data: T;
+}
+
+function wrap(method: string, path: string, error: unknown): EntityApiError {
+  if (error instanceof Error) {
+    return new EntityApiError(method, path, error);
+  }
+  return new EntityApiError(method, path, new Error(String(error)));
+}
+
+export const PasswordResetApi = {
+  /**
+   * Requests a password-reset email.
+   * POST /password-reset/request
+   * Always returns 200 if accepted (enumeration-safe). 429 on rate-limit.
+   */
+  request: async (payload: PasswordResetRequestParams): Promise<void> => {
+    try {
+      await axios.post<ApiResponse<null>>(
+        `${PASSWORD_RESET_BASEURL}/request`,
+        payload,
+        axiosConfig
+      );
+    } catch (error) {
+      throw wrap("POST", "/password-reset/request", error);
+    }
+  },
+
+  /**
+   * Validates a password-reset token without consuming it.
+   * GET /password-reset/validate?token={token}
+   * Returns sanitized first/last name only — no email or other PII.
+   */
+  validate: async (token: string): Promise<PasswordResetValidateData> => {
+    try {
+      const response = await axios.get<ApiResponse<PasswordResetValidateData>>(
+        `${PASSWORD_RESET_BASEURL}/validate`,
+        { ...axiosConfig, params: { token } }
+      );
+      return response.data.data;
+    } catch (error) {
+      throw wrap("GET", "/password-reset/validate", error);
+    }
+  },
+
+  /**
+   * Consumes the token and sets the new password.
+   * POST /password-reset/complete
+   * Token is deleted atomically. No auto-login — caller must redirect to sign-in.
+   */
+  complete: async (payload: PasswordResetCompleteParams): Promise<void> => {
+    try {
+      await axios.post<ApiResponse<unknown>>(
+        `${PASSWORD_RESET_BASEURL}/complete`,
+        payload,
+        axiosConfig
+      );
+    } catch (error) {
+      throw wrap("POST", "/password-reset/complete", error);
+    }
+  },
+};

--- a/src/lib/api/password-reset.ts
+++ b/src/lib/api/password-reset.ts
@@ -5,6 +5,7 @@ import type {
   PasswordResetCompleteParams,
   PasswordResetRequestParams,
   PasswordResetValidateData,
+  PasswordResetValidateParams,
 } from "@/types/password-reset";
 
 const PASSWORD_RESET_BASEURL = `${siteConfig.env.backendServiceURL}/password-reset`;
@@ -46,18 +47,21 @@ export const PasswordResetApi = {
 
   /**
    * Validates a password-reset token without consuming it.
-   * GET /password-reset/validate?token={token}
+   * POST /password-reset/validate  (v1.1 — body, not query string, so the
+   * token never lands in BE access logs, proxy logs, or browser history)
    * Returns sanitized first/last name only — no email or other PII.
    */
   validate: async (token: string): Promise<PasswordResetValidateData> => {
     try {
-      const response = await axios.get<ApiResponse<PasswordResetValidateData>>(
+      const payload: PasswordResetValidateParams = { token };
+      const response = await axios.post<ApiResponse<PasswordResetValidateData>>(
         `${PASSWORD_RESET_BASEURL}/validate`,
-        { ...axiosConfig, params: { token } }
+        payload,
+        axiosConfig
       );
       return response.data.data;
     } catch (error) {
-      throw wrap("GET", "/password-reset/validate", error);
+      throw wrap("POST", "/password-reset/validate", error);
     }
   },
 

--- a/src/types/entity-api-error.ts
+++ b/src/types/entity-api-error.ts
@@ -79,6 +79,26 @@ export class EntityApiError extends Error {
   }
 
   /**
+   * Coerces an arbitrary thrown value into an EntityApiError. Passes through
+   * values that are already EntityApiError, wraps Error instances directly,
+   * and stringifies anything else into an Error first.
+   */
+  public static from(
+    method: string,
+    url: string,
+    error: unknown
+  ): EntityApiError {
+    if (error instanceof EntityApiError) {
+      return error;
+    }
+    return new EntityApiError(
+      method,
+      url,
+      error instanceof Error ? error : new Error(String(error))
+    );
+  }
+
+  /**
    * Returns true if this error represents a client error (4xx status codes)
    */
   public isClientError(): boolean {

--- a/src/types/password-reset.ts
+++ b/src/types/password-reset.ts
@@ -1,0 +1,101 @@
+import { EntityApiError } from "@/types/general";
+
+// ─── Password-reset error discriminators ───────────────────────────
+// Top-level `error` string values returned by structured-error
+// responses from password-reset endpoints. Centralized so wire-format
+// strings live in one place. See PasswordResetEndpoints v1 on the
+// coordination board.
+
+export enum PasswordResetErrorCode {
+  /** 400 from /password-reset/validate or /password-reset/complete. */
+  InvalidOrExpiredToken = "invalid_or_expired_token",
+  /** 429 from /password-reset/request when over the per-email cap. */
+  PasswordResetRateLimited = "password_reset_rate_limited",
+  /** 422 from /password-reset/complete when password !== confirm_password. */
+  ValidationError = "validation_error",
+}
+
+/** Payload sent to POST /password-reset/request */
+export interface PasswordResetRequestParams {
+  email: string;
+}
+
+/** Payload sent to POST /password-reset/complete */
+export interface PasswordResetCompleteParams {
+  token: string;
+  password: string;
+  confirm_password: string;
+}
+
+/** Sanitized response from GET /password-reset/validate — first/last name only. */
+export interface PasswordResetValidateData {
+  first_name: string;
+  last_name: string;
+}
+
+/**
+ * Discriminated union for the reset-complete page state machine.
+ * Mirrors the SetupPageState pattern in src/types/magic-link.ts.
+ */
+export type PasswordResetPageState =
+  | { kind: "validating" }
+  | { kind: "ready"; firstName: string; lastName: string }
+  | { kind: "submitting"; firstName: string; lastName: string }
+  | { kind: "success" }
+  | { kind: "error"; message: string };
+
+/**
+ * Returns true when the error is a 400 invalid_or_expired_token response
+ * from /password-reset/validate or /password-reset/complete. Backend
+ * deliberately collapses "doesn't exist", "expired", and "wrong purpose"
+ * into one discriminator to avoid leaking a status oracle.
+ */
+export function isInvalidOrExpiredTokenError(err: unknown): boolean {
+  if (!(err instanceof EntityApiError) || err.status !== 400) {
+    return false;
+  }
+  const data = err.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { error?: unknown }).error ===
+      PasswordResetErrorCode.InvalidOrExpiredToken
+  );
+}
+
+/**
+ * Returns true when the error is a 429 password_reset_rate_limited
+ * response from /password-reset/request. Per-email rate cap enforced by
+ * the BE (1/60s, 5/24h).
+ */
+export function isPasswordResetRateLimitedError(err: unknown): boolean {
+  if (!(err instanceof EntityApiError) || err.status !== 429) {
+    return false;
+  }
+  const data = err.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { error?: unknown }).error ===
+      PasswordResetErrorCode.PasswordResetRateLimited
+  );
+}
+
+/**
+ * Returns true when the error is a 422 validation_error response from
+ * /password-reset/complete. In v1 this is only ever triggered by
+ * password !== confirm_password — the FE blocks this client-side, so
+ * server-side hits indicate a tampered or malformed request.
+ */
+export function isPasswordResetValidationError(err: unknown): boolean {
+  if (!(err instanceof EntityApiError) || err.status !== 422) {
+    return false;
+  }
+  const data = err.data;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { error?: unknown }).error ===
+      PasswordResetErrorCode.ValidationError
+  );
+}

--- a/src/types/password-reset.ts
+++ b/src/types/password-reset.ts
@@ -3,21 +3,33 @@ import { EntityApiError } from "@/types/general";
 // ─── Password-reset error discriminators ───────────────────────────
 // Top-level `error` string values returned by structured-error
 // responses from password-reset endpoints. Centralized so wire-format
-// strings live in one place. See PasswordResetEndpoints v1 on the
+// strings live in one place. See PasswordResetEndpoints v1.1 on the
 // coordination board.
 
 export enum PasswordResetErrorCode {
-  /** 400 from /password-reset/validate or /password-reset/complete. */
+  /** 400 from POST /password-reset/validate or POST /password-reset/complete. */
   InvalidOrExpiredToken = "invalid_or_expired_token",
-  /** 429 from /password-reset/request when over the per-email cap. */
+  /** 429 from POST /password-reset/request when over the per-email cap. */
   PasswordResetRateLimited = "password_reset_rate_limited",
-  /** 422 from /password-reset/complete when password !== confirm_password. */
+  /** 422 from POST /password-reset/complete when password !== confirm_password. */
   ValidationError = "validation_error",
+}
+
+/** Structured error body returned by password-reset endpoints. */
+interface PasswordResetErrorBody {
+  status_code?: number;
+  error?: string;
+  message?: string;
 }
 
 /** Payload sent to POST /password-reset/request */
 export interface PasswordResetRequestParams {
   email: string;
+}
+
+/** Payload sent to POST /password-reset/validate (v1.1 — body, not query). */
+export interface PasswordResetValidateParams {
+  token: string;
 }
 
 /** Payload sent to POST /password-reset/complete */
@@ -27,7 +39,7 @@ export interface PasswordResetCompleteParams {
   confirm_password: string;
 }
 
-/** Sanitized response from GET /password-reset/validate — first/last name only. */
+/** Sanitized response from POST /password-reset/validate — first/last name only. */
 export interface PasswordResetValidateData {
   first_name: string;
   last_name: string;
@@ -44,58 +56,50 @@ export type PasswordResetPageState =
   | { kind: "success" }
   | { kind: "error"; message: string };
 
-/**
- * Returns true when the error is a 400 invalid_or_expired_token response
- * from /password-reset/validate or /password-reset/complete. Backend
- * deliberately collapses "doesn't exist", "expired", and "wrong purpose"
- * into one discriminator to avoid leaking a status oracle.
- */
-export function isInvalidOrExpiredTokenError(err: unknown): boolean {
-  if (!(err instanceof EntityApiError) || err.status !== 400) {
+function hasErrorCode(
+  err: unknown,
+  expectedStatus: number,
+  code: PasswordResetErrorCode
+): err is EntityApiError {
+  if (!(err instanceof EntityApiError) || err.status !== expectedStatus) {
     return false;
   }
-  const data = err.data;
-  return (
-    !!data &&
-    typeof data === "object" &&
-    (data as { error?: unknown }).error ===
-      PasswordResetErrorCode.InvalidOrExpiredToken
+  const data = err.data as PasswordResetErrorBody | null | undefined;
+  return !!data && typeof data === "object" && data.error === code;
+}
+
+/**
+ * Type guard: error is a 400 invalid_or_expired_token from /validate or /complete.
+ * Backend collapses "doesn't exist", "expired", and "wrong purpose" into one
+ * discriminator to avoid leaking a status oracle.
+ */
+export function isInvalidOrExpiredTokenError(
+  err: unknown
+): err is EntityApiError {
+  return hasErrorCode(err, 400, PasswordResetErrorCode.InvalidOrExpiredToken);
+}
+
+/**
+ * Type guard: error is a 429 password_reset_rate_limited from /request.
+ * Per-email rate cap enforced by the BE (1/60s, 5/24h).
+ */
+export function isPasswordResetRateLimitedError(
+  err: unknown
+): err is EntityApiError {
+  return hasErrorCode(
+    err,
+    429,
+    PasswordResetErrorCode.PasswordResetRateLimited
   );
 }
 
 /**
- * Returns true when the error is a 429 password_reset_rate_limited
- * response from /password-reset/request. Per-email rate cap enforced by
- * the BE (1/60s, 5/24h).
+ * Type guard: error is a 422 validation_error from /complete. In v1 only
+ * triggered by password !== confirm_password — FE blocks this client-side,
+ * so server-side hits indicate a tampered or malformed request.
  */
-export function isPasswordResetRateLimitedError(err: unknown): boolean {
-  if (!(err instanceof EntityApiError) || err.status !== 429) {
-    return false;
-  }
-  const data = err.data;
-  return (
-    !!data &&
-    typeof data === "object" &&
-    (data as { error?: unknown }).error ===
-      PasswordResetErrorCode.PasswordResetRateLimited
-  );
-}
-
-/**
- * Returns true when the error is a 422 validation_error response from
- * /password-reset/complete. In v1 this is only ever triggered by
- * password !== confirm_password — the FE blocks this client-side, so
- * server-side hits indicate a tampered or malformed request.
- */
-export function isPasswordResetValidationError(err: unknown): boolean {
-  if (!(err instanceof EntityApiError) || err.status !== 422) {
-    return false;
-  }
-  const data = err.data;
-  return (
-    !!data &&
-    typeof data === "object" &&
-    (data as { error?: unknown }).error ===
-      PasswordResetErrorCode.ValidationError
-  );
+export function isPasswordResetValidationError(
+  err: unknown
+): err is EntityApiError {
+  return hasErrorCode(err, 422, PasswordResetErrorCode.ValidationError);
 }


### PR DESCRIPTION
## Description

Adds a user-initiated password reset feature so users who have forgotten their password can recover access via an email-based reset link. The implementation reuses the existing magic-link token infrastructure on the backend and mirrors the `/setup/[token]` UX pattern for visual and behavioral consistency.

Coordinated with backend in the `password_reset_design_v1` thread and `PasswordResetEndpoints` v1 contract on the cross-repo coordinator board. Full design rationale (including all security decisions) lives in [`docs/architecture/password-reset-flow.md`](docs/architecture/password-reset-flow.md).

#### GitHub Issue: N/A (cross-repo coordinated feature; follow-up tracked in #395 for password strength)

### Changes

* New `/forgot-password` page: enumeration-safe email-request form with generic "if an account exists..." confirmation
* New `/reset-password/[token]` page: 5-state machine (validating → ready → submitting → success → error) mirroring `/setup/[token]`
* New `PasswordResetApi` client (`request`, `validate`, `complete`) wrapping the v1 contract
* New error type guards (`isInvalidOrExpiredTokenError`, `isPasswordResetRateLimitedError`, `isPasswordResetValidationError`) following the goal-error parser convention
* `Referrer-Policy: no-referrer` pinned on both `/setup/*` and `/reset-password/*` via `next.config.mjs` `headers()` — keeps tokens out of the Referer header
* "Forgot password?" link wired into `UserAuthForm` (right-aligned below the password input)
* Email prefill from auth-store on `/forgot-password` for the "logged-in user resets their own password" case
* Force-logout-on-success in `/reset-password/[token]` for the edge case where a logged-in user completes a reset
* 20 new unit tests in `__tests__/types/password-reset.test.ts` (per-parser describes + mutual-exclusion suite, modeled on `goal.test.ts`)
* Architectural design doc at `docs/architecture/password-reset-flow.md` documenting 10 security decisions with rationale

### Screenshots / Videos Showing UI Changes

<img width="1357" height="854" alt="Screenshot 2026-05-21 at 19 47 39" src="https://github.com/user-attachments/assets/00fd71a2-5837-4397-9fc8-e8c246f42ca9" />

<img width="1352" height="849" alt="Screenshot 2026-05-21 at 19 47 26" src="https://github.com/user-attachments/assets/c8be0e23-3f10-4232-a3de-914c4fb6ca48" />


### Testing Strategy

**Automated:**
- `npx vitest run` — full suite (964 tests, including 20 new) passes
- `npx tsc --noEmit` — clean
- `npx eslint` on new files — clean

**Manual (verified locally against running backend):**
- `/` login page renders with "Forgot password?" link
- `/forgot-password` → submit → BE returns 200 → page shows generic "if an account exists..." confirmation
- `/reset-password/<fake-token>` → BE returns 400 `invalid_or_expired_token` → page shows "This reset link is invalid or has expired" + "Request a new reset link" CTA
- `curl -I http://localhost:3000/reset-password/X` and `/setup/X` both return `Referrer-Policy: no-referrer`; `curl -I /` does NOT (site-wide behavior unchanged)

**Still to verify with a real reset token (deferred — requires real email or BE-side fixture):**
- Full happy path: `/validate` 200 → personalized "Hi {first_name}" greeting → submit new password → success state → sign in with new password
- 429 rate-limit copy (requires hitting the per-email cap)

### Concerns & Notes

- **Password strength**: intentionally min 8 chars + confirm-match for v1 (matches existing `/setup/[token]`). Strengthening across setup, reset, and change-password flows is tracked in #395 as a cross-cutting follow-up.
- **Multi-device session invalidation**: deferred per BE Q2; will land with the persistent session store migration. FE's existing `SessionCleanupProvider` handles the post-invalidation 401 gracefully when that lands, so no FE work needed here.
- **Auto-login after reset**: deliberately not implemented. User is redirected to login to sign in fresh, matching the `/setup` flow's security posture.