### PR TITLE
Omit assignee scope for coachee broad view on /actions

### DIFF
--- a/__tests__/e2e/coach-actions-not-regressed.spec.ts
+++ b/__tests__/e2e/coach-actions-not-regressed.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test'
+import {
+  setupAuthentication,
+  mockCommonApiRoutes,
+  MOCK_USER_ID,
+  MOCK_ORGANIZATIONS,
+  SINGLE_RELATIONSHIP,
+} from './helpers'
+
+// Regression guard for the coachee-actions visibility fix: a coach viewing
+// /actions must still send `assignee=coach` for the default "My Actions"
+// view and render the returned actions in the kanban.
+
+const COACH_ID = SINGLE_RELATIONSHIP[0].coach_id
+
+function mockAction(id: string, body: string, assigneeIds: string[]) {
+  return {
+    id,
+    coaching_session_id: 'session-1',
+    body,
+    user_id: COACH_ID,
+    status: 'NotStarted',
+    status_changed_at: '2026-05-01T10:00:00Z',
+    due_by: '2026-05-15T00:00:00Z',
+    created_at: '2026-05-01T10:00:00Z',
+    updated_at: '2026-05-01T10:00:00Z',
+    assignee_ids: assigneeIds,
+  }
+}
+
+const COACH_ASSIGNED_ACTION = mockAction(
+  'action-coach',
+  'Coach-assigned action',
+  [COACH_ID]
+)
+
+test.describe('Coach viewing /actions (regression guard)', () => {
+  test('sends batch request with assignee=coach for default "My Actions" view', async ({
+    page,
+    context,
+  }) => {
+    // Default helper auth has isACoach: true and userId === COACH_ID-adjacent
+    // (MOCK_USER_ID). The wire param we assert on is what the FE *sends*, not
+    // what role the BE would resolve it to — so this still exercises the
+    // coach code path in useActionsFetch.
+    await setupAuthentication(page, context)
+    await mockCommonApiRoutes(page)
+
+    await page.route('**/users/current/organizations', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
+      })
+    })
+
+    const batchUrls: string[] = []
+    await page.route(
+      '**/organizations/*/coaching_relationships/actions**',
+      async (route) => {
+        batchUrls.push(route.request().url())
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              coachee_actions: {
+                [MOCK_USER_ID]: [COACH_ASSIGNED_ACTION],
+              },
+            },
+          }),
+        })
+      }
+    )
+
+    await page.goto('/actions')
+
+    await expect(
+      page.getByText(COACH_ASSIGNED_ACTION.body).first()
+    ).toBeVisible({ timeout: 15_000 })
+
+    // The default coach "My Actions" view sends assignee=coach. Sweep every
+    // batch request — at least one should carry the param.
+    expect(batchUrls.length).toBeGreaterThan(0)
+    const anyCoachScope = batchUrls.some((url) => url.includes('assignee=coach'))
+    expect(anyCoachScope).toBe(true)
+  })
+})

--- a/__tests__/e2e/coach-actions-not-regressed.spec.ts
+++ b/__tests__/e2e/coach-actions-not-regressed.spec.ts
@@ -12,11 +12,13 @@ import {
 // view and render the returned actions in the kanban.
 
 const COACH_ID = SINGLE_RELATIONSHIP[0].coach_id
+const SESSION_ID = 'session-1'
+const RELATIONSHIP_ID = SINGLE_RELATIONSHIP[0].id
 
 function mockAction(id: string, body: string, assigneeIds: string[]) {
   return {
     id,
-    coaching_session_id: 'session-1',
+    coaching_session_id: SESSION_ID,
     body,
     user_id: COACH_ID,
     status: 'NotStarted',
@@ -34,6 +36,17 @@ const COACH_ASSIGNED_ACTION = mockAction(
   [COACH_ID]
 )
 
+// addContextToAction drops actions whose coaching_session_id isn't in the
+// session map AND whose enriched session lacks a relationship. Seed both.
+const ENRICHED_SESSION = {
+  id: SESSION_ID,
+  coaching_relationship_id: RELATIONSHIP_ID,
+  date: '2026-05-01T10:00:00Z',
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+  relationship: SINGLE_RELATIONSHIP[0],
+}
+
 test.describe('Coach viewing /actions (regression guard)', () => {
   test('sends batch request with assignee=coach for default "My Actions" view', async ({
     page,
@@ -50,6 +63,19 @@ test.describe('Coach viewing /actions (regression guard)', () => {
         body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
       })
     })
+
+    // Seed the per-user enriched-sessions endpoint so the session map has
+    // an entry for our action's coaching_session_id.
+    await page.route(
+      `**/users/${MOCK_USER_ID}/coaching_sessions**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [ENRICHED_SESSION] }),
+        })
+      }
+    )
 
     const batchUrls: string[] = []
     await page.route(

--- a/__tests__/e2e/coach-actions-not-regressed.spec.ts
+++ b/__tests__/e2e/coach-actions-not-regressed.spec.ts
@@ -39,10 +39,7 @@ test.describe('Coach viewing /actions (regression guard)', () => {
     page,
     context,
   }) => {
-    // Default helper auth has isACoach: true and userId === COACH_ID-adjacent
-    // (MOCK_USER_ID). The wire param we assert on is what the FE *sends*, not
-    // what role the BE would resolve it to — so this still exercises the
-    // coach code path in useActionsFetch.
+    // Helper auth sets isACoach: true → Some(Coach) branch → assignee=coach.
     await setupAuthentication(page, context)
     await mockCommonApiRoutes(page)
 

--- a/__tests__/e2e/coachee-sees-own-actions.spec.ts
+++ b/__tests__/e2e/coachee-sees-own-actions.spec.ts
@@ -4,6 +4,7 @@ import {
   ORGANIZATION_STORE_STATE,
   MOCK_USER_ID,
   MOCK_ORGANIZATIONS,
+  SINGLE_RELATIONSHIP,
   mockCommonApiRoutes,
 } from './helpers'
 
@@ -14,10 +15,13 @@ import {
 // Regression guard for: coachees sending assignee=coachee triggers strict-
 // contains scope on the BE and silently drops unassigned actions.
 
+const SESSION_ID = 'session-1'
+const RELATIONSHIP_ID = SINGLE_RELATIONSHIP[0].id
+
 function mockAction(id: string, body: string, assigneeIds: string[]) {
   return {
     id,
-    coaching_session_id: 'session-1',
+    coaching_session_id: SESSION_ID,
     body,
     user_id: MOCK_USER_ID,
     status: 'NotStarted',
@@ -27,6 +31,17 @@ function mockAction(id: string, body: string, assigneeIds: string[]) {
     updated_at: '2026-05-01T10:00:00Z',
     assignee_ids: assigneeIds,
   }
+}
+
+// addContextToAction drops actions whose coaching_session_id isn't in the
+// session map AND whose enriched session lacks a relationship. Seed both.
+const ENRICHED_SESSION = {
+  id: SESSION_ID,
+  coaching_relationship_id: RELATIONSHIP_ID,
+  date: '2026-05-01T10:00:00Z',
+  created_at: '2026-05-01T10:00:00Z',
+  updated_at: '2026-05-01T10:00:00Z',
+  relationship: SINGLE_RELATIONSHIP[0],
 }
 
 const SELF_ASSIGNED_ACTION = mockAction(
@@ -90,6 +105,19 @@ test.describe('Coachee viewing /actions', () => {
         body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
       })
     })
+
+    // Seed the per-user enriched-sessions endpoint so the session map has
+    // an entry for our action's coaching_session_id.
+    await page.route(
+      `**/users/${MOCK_USER_ID}/coaching_sessions**`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [ENRICHED_SESSION] }),
+        })
+      }
+    )
 
     // Capture every request to the batch endpoint so we can assert on the
     // query string after the page settles.

--- a/__tests__/e2e/coachee-sees-own-actions.spec.ts
+++ b/__tests__/e2e/coachee-sees-own-actions.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect, type Page, type BrowserContext } from '@playwright/test'
+import {
+  AUTH_STORE_STATE,
+  ORGANIZATION_STORE_STATE,
+  MOCK_USER_ID,
+  MOCK_ORGANIZATIONS,
+  mockCommonApiRoutes,
+} from './helpers'
+
+// Canary: a coachee viewing /actions should send the batch request with NO
+// `assignee` query param, and the kanban should render the actions returned
+// by the backend's visibility predicate (self-assigned ∪ unassigned).
+//
+// Regression guard for: coachees sending assignee=coachee triggers strict-
+// contains scope on the BE and silently drops unassigned actions.
+
+function mockAction(id: string, body: string, assigneeIds: string[]) {
+  return {
+    id,
+    coaching_session_id: 'session-1',
+    body,
+    user_id: MOCK_USER_ID,
+    status: 'NotStarted',
+    status_changed_at: '2026-05-01T10:00:00Z',
+    due_by: '2026-05-15T00:00:00Z',
+    created_at: '2026-05-01T10:00:00Z',
+    updated_at: '2026-05-01T10:00:00Z',
+    assignee_ids: assigneeIds,
+  }
+}
+
+const SELF_ASSIGNED_ACTION = mockAction(
+  'action-self',
+  'Coachee self-assigned action',
+  [MOCK_USER_ID]
+)
+
+const UNASSIGNED_ACTION = mockAction(
+  'action-unassigned',
+  'Up-for-grabs unassigned action',
+  []
+)
+
+/**
+ * Set up auth as a coachee (isACoach: false). Mirrors `setupAuthentication`
+ * in helpers.ts but with the role flipped — we can't reuse the helper because
+ * its AUTH_STORE_STATE has isACoach: true.
+ */
+async function setupAsCoachee(page: Page, context: BrowserContext) {
+  const coacheeAuth = {
+    ...AUTH_STORE_STATE,
+    state: { ...AUTH_STORE_STATE.state, isACoach: false },
+  }
+  await page.addInitScript(
+    ({ auth, org }) => {
+      localStorage.setItem('auth-store', auth)
+      localStorage.setItem('organization-state-store', org)
+    },
+    {
+      auth: JSON.stringify(coacheeAuth),
+      org: JSON.stringify(ORGANIZATION_STORE_STATE),
+    }
+  )
+  await context.addCookies([
+    {
+      name: 'id',
+      value: 'mock-session-id-123',
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ])
+}
+
+test.describe('Coachee viewing /actions', () => {
+  test('sends batch request with no `assignee` param and renders returned actions', async ({
+    page,
+    context,
+  }) => {
+    await setupAsCoachee(page, context)
+    await mockCommonApiRoutes(page)
+
+    // Override the catch-all to also serve the user's organization list
+    await page.route('**/users/current/organizations', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
+      })
+    })
+
+    // Capture every request to the batch endpoint so we can assert on the
+    // query string after the page settles.
+    const batchUrls: string[] = []
+    await page.route(
+      '**/organizations/*/coaching_relationships/actions**',
+      async (route) => {
+        batchUrls.push(route.request().url())
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              coachee_actions: {
+                [MOCK_USER_ID]: [SELF_ASSIGNED_ACTION, UNASSIGNED_ACTION],
+              },
+            },
+          }),
+        })
+      }
+    )
+
+    await page.goto('/actions')
+
+    // Wait for at least one action body to be visible — proves the kanban
+    // received and rendered data.
+    await expect(
+      page.getByText(SELF_ASSIGNED_ACTION.body).first()
+    ).toBeVisible({ timeout: 15_000 })
+    await expect(
+      page.getByText(UNASSIGNED_ACTION.body).first()
+    ).toBeVisible()
+
+    // Load-bearing assertion for the bug fix: no request to the batch endpoint
+    // includes `assignee=` (coachee broad view omits scope so the backend's
+    // visibility predicate handles narrowing).
+    expect(batchUrls.length).toBeGreaterThan(0)
+    for (const url of batchUrls) {
+      expect(url).not.toContain('assignee=')
+    }
+  })
+})

--- a/__tests__/lib/hooks/use-actions-fetch.test.ts
+++ b/__tests__/lib/hooks/use-actions-fetch.test.ts
@@ -5,13 +5,14 @@ import {
   AssignmentFilter,
   UserActionsAssigneeFilter,
 } from "@/types/assigned-actions";
+import { Some, None } from "@/types/option";
 
 describe("assignmentFilterToRelationshipActionsParams", () => {
-  describe("with coachee scope", () => {
+  describe("with Some(coachee) scope", () => {
     it("maps Assigned to assignee=coachee with assignee_filter=assigned", () => {
       const result = assignmentFilterToRelationshipActionsParams(
         AssignmentFilter.Assigned,
-        AssigneeScope.Coachee
+        Some(AssigneeScope.Coachee)
       );
       expect(result).toEqual({
         assignee: AssigneeScope.Coachee,
@@ -22,18 +23,18 @@ describe("assignmentFilterToRelationshipActionsParams", () => {
     it("maps All to assignee=coachee with no assignee filter", () => {
       const result = assignmentFilterToRelationshipActionsParams(
         AssignmentFilter.All,
-        AssigneeScope.Coachee
+        Some(AssigneeScope.Coachee)
       );
       expect(result).toEqual({ assignee: AssigneeScope.Coachee });
       expect(result.assigneeFilter).toBeUndefined();
     });
   });
 
-  describe("with coach scope", () => {
+  describe("with Some(coach) scope", () => {
     it("maps Assigned to assignee=coach with assignee_filter=assigned", () => {
       const result = assignmentFilterToRelationshipActionsParams(
         AssignmentFilter.Assigned,
-        AssigneeScope.Coach
+        Some(AssigneeScope.Coach)
       );
       expect(result).toEqual({
         assignee: AssigneeScope.Coach,
@@ -44,9 +45,31 @@ describe("assignmentFilterToRelationshipActionsParams", () => {
     it("maps All to assignee=coach with no assignee filter", () => {
       const result = assignmentFilterToRelationshipActionsParams(
         AssignmentFilter.All,
-        AssigneeScope.Coach
+        Some(AssigneeScope.Coach)
       );
       expect(result).toEqual({ assignee: AssigneeScope.Coach });
+      expect(result.assigneeFilter).toBeUndefined();
+    });
+  });
+
+  describe("with None scope (coachee broad view)", () => {
+    it("maps Assigned to no assignee + assignee_filter=assigned", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.Assigned,
+        None
+      );
+      expect(result).toEqual({
+        assignee: undefined,
+        assigneeFilter: UserActionsAssigneeFilter.Assigned,
+      });
+    });
+
+    it("maps All to no assignee and no assignee filter", () => {
+      const result = assignmentFilterToRelationshipActionsParams(
+        AssignmentFilter.All,
+        None
+      );
+      expect(result.assignee).toBeUndefined();
       expect(result.assigneeFilter).toBeUndefined();
     });
   });
@@ -54,32 +77,37 @@ describe("assignmentFilterToRelationshipActionsParams", () => {
   it("Unassigned ignores scope — returns only assignee_filter=unassigned", () => {
     const coachResult = assignmentFilterToRelationshipActionsParams(
       AssignmentFilter.Unassigned,
-      AssigneeScope.Coach
+      Some(AssigneeScope.Coach)
     );
     const coacheeResult = assignmentFilterToRelationshipActionsParams(
       AssignmentFilter.Unassigned,
-      AssigneeScope.Coachee
+      Some(AssigneeScope.Coachee)
+    );
+    const noneResult = assignmentFilterToRelationshipActionsParams(
+      AssignmentFilter.Unassigned,
+      None
     );
     const expected = {
       assigneeFilter: UserActionsAssigneeFilter.Unassigned,
     };
     expect(coachResult).toEqual(expected);
     expect(coacheeResult).toEqual(expected);
+    expect(noneResult).toEqual(expected);
     expect(coachResult.assignee).toBeUndefined();
   });
 
   it("returns distinct params for each filter value", () => {
     const assigned = assignmentFilterToRelationshipActionsParams(
       AssignmentFilter.Assigned,
-      AssigneeScope.Coachee
+      Some(AssigneeScope.Coachee)
     );
     const unassigned = assignmentFilterToRelationshipActionsParams(
       AssignmentFilter.Unassigned,
-      AssigneeScope.Coachee
+      Some(AssigneeScope.Coachee)
     );
     const all = assignmentFilterToRelationshipActionsParams(
       AssignmentFilter.All,
-      AssigneeScope.Coachee
+      Some(AssigneeScope.Coachee)
     );
 
     expect(assigned).not.toEqual(unassigned);

--- a/src/lib/hooks/use-actions-fetch.ts
+++ b/src/lib/hooks/use-actions-fetch.ts
@@ -8,28 +8,33 @@ import {
   UserActionsAssigneeFilter,
 } from "@/types/assigned-actions";
 import type { Id } from "@/types/general";
+import { type Option, Some, None } from "@/types/option";
 
 /**
  * Maps a UI-level AssignmentFilter to the relationship-actions API params
  * (assignee + assignee_filter).
  *
- * The `assigneeScope` determines whose actions are returned (coach or coachee),
- * while `assignee_filter` controls assigned/unassigned filtering.
+ * `assigneeScope` is the strict-contains scope (Some(coach) / Some(coachee) /
+ * Some(UUID)) or None for "no scope filter." When None, the backend applies
+ * a role-aware visibility predicate to narrow the result instead of
+ * strict-contains; this is the right shape for a coachee asking for their
+ * own broad view (self-assigned ∪ unassigned).
  *
- * Used by both "My Actions" (with coach or coachee scope depending on role)
- * and "Coachee Actions" (always coachee scope).
+ * `assignee_filter` controls assigned/unassigned filtering and is independent
+ * of scope.
  */
 export function assignmentFilterToRelationshipActionsParams(
   filter: AssignmentFilter,
-  assigneeScope: AssigneeScope
+  assigneeScope: Option<AssigneeScope>
 ): {
   assignee?: AssigneeScope;
   assigneeFilter?: UserActionsAssigneeFilter;
 } {
+  const scope = assigneeScope.some ? assigneeScope.val : undefined;
   switch (filter) {
     case AssignmentFilter.Assigned:
       return {
-        assignee: assigneeScope,
+        assignee: scope,
         assigneeFilter: UserActionsAssigneeFilter.Assigned,
       };
     case AssignmentFilter.Unassigned:
@@ -37,7 +42,7 @@ export function assignmentFilterToRelationshipActionsParams(
         assigneeFilter: UserActionsAssigneeFilter.Unassigned,
       };
     case AssignmentFilter.All:
-      return { assignee: assigneeScope };
+      return { assignee: scope };
     default: {
       const _exhaustive: never = filter;
       throw new Error(`Unhandled assignment filter: ${_exhaustive}`);
@@ -48,11 +53,11 @@ export function assignmentFilterToRelationshipActionsParams(
 /**
  * Fetches actions via the batch relationship-actions endpoint.
  *
- * Both "My Actions" and "Coachee Actions" use the same endpoint, differentiated
- * by the `assignee` query param:
- * - My Actions (coach user): assignee=coach
- * - My Actions (coachee-only user): assignee=coachee
- * - Coachee Actions: assignee=coachee
+ * All views hit the same endpoint, differentiated by `assignee`:
+ * - Coach "My Actions" toggle: assignee=coach (strict-contains)
+ * - Coach "Coachee Actions" toggle: assignee=coachee (strict-contains)
+ * - Coachee broad view: assignee omitted (backend visibility predicate returns
+ *   self-assigned ∪ unassigned)
  *
  * @param viewMode - Whether to show the user's own actions or their coachees' actions
  * @param relationshipId - Optional server-side filter to a specific coaching relationship
@@ -70,12 +75,15 @@ export function useActionsFetch(
 
   const isCoacheeMode = viewMode === CoachViewMode.CoacheeActions;
 
-  const assigneeScope: AssigneeScope =
+  // None for the coachee's own broad view: the backend's visibility predicate
+  // returns self-assigned ∪ unassigned. Sending Some(Coachee) instead would
+  // strict-contains-filter and silently drop unassigned actions.
+  const assigneeScope: Option<AssigneeScope> =
     isCoacheeMode
-      ? AssigneeScope.Coachee
+      ? Some(AssigneeScope.Coachee)
       : isACoach
-        ? AssigneeScope.Coach
-        : AssigneeScope.Coachee;
+        ? Some(AssigneeScope.Coach)
+        : None;
 
   const params = assignmentFilterToRelationshipActionsParams(assignmentFilter, assigneeScope);
 

--- a/src/lib/hooks/use-actions-fetch.ts
+++ b/src/lib/hooks/use-actions-fetch.ts
@@ -8,20 +8,11 @@ import {
   UserActionsAssigneeFilter,
 } from "@/types/assigned-actions";
 import type { Id } from "@/types/general";
-import { type Option, Some, None } from "@/types/option";
+import { type Option, Some, None, unwrapOr } from "@/types/option";
 
 /**
- * Maps a UI-level AssignmentFilter to the relationship-actions API params
- * (assignee + assignee_filter).
- *
- * `assigneeScope` is the strict-contains scope (Some(coach) / Some(coachee) /
- * Some(UUID)) or None for "no scope filter." When None, the backend applies
- * a role-aware visibility predicate to narrow the result instead of
- * strict-contains; this is the right shape for a coachee asking for their
- * own broad view (self-assigned ∪ unassigned).
- *
- * `assignee_filter` controls assigned/unassigned filtering and is independent
- * of scope.
+ * Maps UI AssignmentFilter + Option<AssigneeScope> to wire params. None scope
+ * omits `assignee` so the backend's visibility predicate handles narrowing.
  */
 export function assignmentFilterToRelationshipActionsParams(
   filter: AssignmentFilter,
@@ -30,7 +21,7 @@ export function assignmentFilterToRelationshipActionsParams(
   assignee?: AssigneeScope;
   assigneeFilter?: UserActionsAssigneeFilter;
 } {
-  const scope = assigneeScope.some ? assigneeScope.val : undefined;
+  const scope = unwrapOr(assigneeScope, undefined);
   switch (filter) {
     case AssignmentFilter.Assigned:
       return {
@@ -48,6 +39,16 @@ export function assignmentFilterToRelationshipActionsParams(
       throw new Error(`Unhandled assignment filter: ${_exhaustive}`);
     }
   }
+}
+
+/** None = coachee broad view; lets the backend's visibility predicate narrow. */
+function selectAssigneeScope(
+  isACoach: boolean,
+  isCoacheeMode: boolean
+): Option<AssigneeScope> {
+  if (isCoacheeMode) return Some(AssigneeScope.Coachee);
+  if (isACoach) return Some(AssigneeScope.Coach);
+  return None;
 }
 
 /**
@@ -74,16 +75,7 @@ export function useActionsFetch(
   const { currentOrganizationId } = useCurrentOrganization();
 
   const isCoacheeMode = viewMode === CoachViewMode.CoacheeActions;
-
-  // None for the coachee's own broad view: the backend's visibility predicate
-  // returns self-assigned ∪ unassigned. Sending Some(Coachee) instead would
-  // strict-contains-filter and silently drop unassigned actions.
-  const assigneeScope: Option<AssigneeScope> =
-    isCoacheeMode
-      ? Some(AssigneeScope.Coachee)
-      : isACoach
-        ? Some(AssigneeScope.Coach)
-        : None;
+  const assigneeScope = selectAssigneeScope(isACoach, isCoacheeMode);
 
   const params = assignmentFilterToRelationshipActionsParams(assignmentFilter, assigneeScope);
 

--- a/src/types/option.ts
+++ b/src/types/option.ts
@@ -26,3 +26,8 @@ export function isOption(value: unknown): value is Option<unknown> {
   const obj = value as Record<string, unknown>;
   return typeof obj.some === "boolean" && typeof obj.none === "boolean";
 }
+
+/** Unwrap an Option, returning the contained value when Some or the fallback when None. */
+export function unwrapOr<T, U>(opt: Option<T>, fallback: U): T | U {
+  return opt.some ? opt.val : fallback;
+}


### PR DESCRIPTION
## Summary

Coachees viewing `/actions` previously saw an empty kanban because the FE sent `assignee=coachee` (strict-contains scope) and the backend's relationship lookup was coach-only. With the BE change in [refactor-platform-rs#314](https://github.com/refactor-group/refactor-platform-rs/pull/314) (broadens auth to coach OR coachee + adds a role-aware visibility predicate), the wire-level convention is now: omit `assignee` for the broad view, include it only when explicitly scoping to a role.

This PR makes the FE side of that convention:

- `useActionsFetch` switches the role-aware decision to `Option<AssigneeScope>` — `Some(Coach)` / `Some(Coachee)` for the coach's two toggles, `None` for the coachee's broad view (no toggle exists).
- `assignmentFilterToRelationshipActionsParams` takes the `Option` and unwraps to `undefined` only at the wire-construction boundary where URL `URLSearchParams` requires it.

Adds 2 canary Playwright specs and updates the existing 5 unit-test cases (+3 new cases for `None` scope).

Verified end-to-end against the BE PR #314 branch as Caleb Bourg through every filter combination — `assignee=` is never sent for the coachee on any of: Assigned / Unassigned / All / Status / per-relationship / time-range.

**Coordinated merge**: BE PR #314 merges first by ≤15 min, then this PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run __tests__/lib/hooks/ __tests__/lib/api/relationship-actions.test.ts` — 59/59 pass
- [x] `npx eslint` on changed files — clean
- [x] Live verification as Caleb against BE PR #314 branch:
  - Default Assigned view: 3 actions render, wire is `?assignee_filter=assigned`
  - Assignment=All: 3 actions render, wire is `?` (no params)
  - Assignment=Unassigned: empty board, wire is `?assignee_filter=unassigned`
  - Status=Open/All/Closed: client-side column filtering works, no new network requests
  - Relationship filter → single-rel endpoint, still no `assignee=`
  - Time Range=All time: client-side, no network request
- [ ] BE PR #314 merges, FE PR merges within 15 min