### PR TITLE
fix(dashboard): make coaching session dialog responsive

### DIFF
--- a/src/components/ui/dashboard/coaching-session-dialog.tsx
+++ b/src/components/ui/dashboard/coaching-session-dialog.tsx
@@ -6,6 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { cn } from "@/components/lib/utils";
 import CoachingSessionForm, { CoachingSessionFormMode } from "./coaching-session-form";
 import type { CoachingSession } from "@/types/coaching-session";
 
@@ -24,7 +25,12 @@ export function CoachingSessionDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent
+        className={cn(
+          "max-h-[90dvh] overflow-y-auto",
+          mode === "create" ? "sm:max-w-3xl" : "sm:max-w-lg"
+        )}
+      >
         <DialogHeader>
           <DialogTitle>
             {mode === "create" ? "Create New Coaching Session" : "Update Coaching Session"}

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -406,196 +406,196 @@ export default function CoachingSessionForm({
           is a different operation that isn't supported by this dialog. */}
       {mode === "create" && (
         <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="recurring-switch" className="cursor-pointer">
-                Repeats
-              </Label>
-              <Switch
-                id="recurring-switch"
-                checked={isRecurring}
-                onCheckedChange={setIsRecurring}
-                disabled={isSubmitting}
-              />
-            </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="recurring-switch" className="cursor-pointer">
+              Repeats
+            </Label>
+            <Switch
+              id="recurring-switch"
+              checked={isRecurring}
+              onCheckedChange={setIsRecurring}
+              disabled={isSubmitting}
+            />
+          </div>
 
-            {isRecurring && (
-              <div className="space-y-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <div className="space-y-2">
-                    <Label htmlFor="recurrence-frequency">Frequency</Label>
-                    <Select
-                      value={frequency}
-                      onValueChange={(v) => setFrequency(v as Frequency)}
-                      disabled={isSubmitting}
-                    >
-                      <SelectTrigger id="recurrence-frequency">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Object.values(Frequency).map((f) => (
-                          <SelectItem key={f} value={f}>
-                            {frequencyLabel(f)}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="recurrence-interval">Every</Label>
-                    <Input
-                      id="recurrence-interval"
-                      type="number"
-                      min={1}
-                      max={MAX_INTERVAL}
-                      value={interval}
-                      onChange={(e) => {
-                        const next = parseInt(e.target.value, 10);
-                        setInterval(Number.isFinite(next) && next >= 1 ? next : 1);
-                      }}
-                      disabled={isSubmitting}
-                    />
-                  </div>
-                </div>
-
-                {frequencySupportsWeekdays(frequency) && (
-                  <div className="space-y-2">
-                    <Label>On these days</Label>
-                    <ToggleGroup
-                      type="multiple"
-                      value={byWeekdays}
-                      onValueChange={(v) => setByWeekdays(v as Weekday[])}
-                      disabled={isSubmitting}
-                      className="justify-start flex-wrap"
-                    >
-                      {WEEKDAYS_ORDERED.map((d) => (
-                        <ToggleGroupItem
-                          key={d}
-                          value={d}
-                          aria-label={weekdayLabel(d)}
-                          className="w-10"
-                        >
-                          {weekdayLabel(d).slice(0, 1)}
-                        </ToggleGroupItem>
-                      ))}
-                    </ToggleGroup>
-                    {startWeekday && (
-                      <p className="text-xs text-muted-foreground">
-                        Your first session is on a {weekdayLabel(startWeekday)}, which must stay selected.
-                      </p>
-                    )}
-                  </div>
-                )}
-
+          {isRecurring && (
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
                 <div className="space-y-2">
-                  <Label>Ends</Label>
-                  <RadioGroup
-                    value={end.kind}
-                    onValueChange={(v) =>
-                      setEnd(
-                        v === "count"
-                          ? { kind: "count", count: end.kind === "count" ? end.count : 4 }
-                          : {
-                              kind: "until",
-                              until:
-                                end.kind === "until" && end.until
-                                  ? end.until
-                                  : defaultUntilDate(),
-                            }
-                      )
-                    }
+                  <Label htmlFor="recurrence-frequency">Frequency</Label>
+                  <Select
+                    value={frequency}
+                    onValueChange={(v) => setFrequency(v as Frequency)}
                     disabled={isSubmitting}
                   >
-                    <div className="flex items-center gap-3">
-                      <RadioGroupItem id="end-count" value="count" />
-                      <Label htmlFor="end-count" className="cursor-pointer">
-                        After
-                      </Label>
-                      <Input
-                        type="number"
-                        min={1}
-                        max={MAX_OCCURRENCES}
-                        value={end.kind === "count" ? end.count : ""}
-                        onChange={(e) => {
-                          const next = parseInt(e.target.value, 10);
-                          setEnd({
-                            kind: "count",
-                            count: Number.isFinite(next) && next >= 1 ? next : 1,
-                          });
-                        }}
-                        disabled={isSubmitting || end.kind !== "count"}
-                        className="w-20"
-                      />
-                      <span className="text-sm text-muted-foreground">
-                        occurrences
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <RadioGroupItem id="end-until" value="until" />
-                      <Label htmlFor="end-until" className="cursor-pointer">
-                        On
-                      </Label>
-                      <Popover>
-                        <PopoverTrigger asChild>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            disabled={isSubmitting || end.kind !== "until"}
-                            className={cn(
-                              "h-9 gap-2 font-normal",
-                              end.kind === "until" && end.until
-                                ? ""
-                                : "text-muted-foreground"
-                            )}
-                          >
-                            <CalendarIcon className="h-4 w-4" />
-                            {end.kind === "until" && end.until
-                              ? DateTime.fromISO(end.until).toLocaleString(
-                                  DateTime.DATE_MED
-                                )
-                              : "Pick a date"}
-                          </Button>
-                        </PopoverTrigger>
-                        <PopoverContent
-                          className="w-auto p-0"
-                          align="start"
-                        >
-                          <Calendar
-                            mode="single"
-                            selected={
-                              end.kind === "until" && end.until
-                                ? new Date(`${end.until}T00:00:00`)
-                                : undefined
-                            }
-                            onSelect={(date) =>
-                              setEnd({
-                                kind: "until",
-                                until: date
-                                  ? DateTime.fromJSDate(date).toFormat(
-                                      "yyyy-MM-dd"
-                                    )
-                                  : "",
-                              })
-                            }
-                          />
-                        </PopoverContent>
-                      </Popover>
-                    </div>
-                  </RadioGroup>
+                    <SelectTrigger id="recurrence-frequency">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.values(Frequency).map((f) => (
+                        <SelectItem key={f} value={f}>
+                          {frequencyLabel(f)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
-
-                {recurrenceError && (
-                  <p className="text-sm text-destructive">{recurrenceError}</p>
-                )}
+                <div className="space-y-2">
+                  <Label htmlFor="recurrence-interval">Every</Label>
+                  <Input
+                    id="recurrence-interval"
+                    type="number"
+                    min={1}
+                    max={MAX_INTERVAL}
+                    value={interval}
+                    onChange={(e) => {
+                      const next = parseInt(e.target.value, 10);
+                      setInterval(Number.isFinite(next) && next >= 1 ? next : 1);
+                    }}
+                    disabled={isSubmitting}
+                  />
+                </div>
               </div>
-            )}
-          </div>
-        )}
+
+              {frequencySupportsWeekdays(frequency) && (
+                <div className="space-y-2">
+                  <Label>On these days</Label>
+                  <ToggleGroup
+                    type="multiple"
+                    value={byWeekdays}
+                    onValueChange={(v) => setByWeekdays(v as Weekday[])}
+                    disabled={isSubmitting}
+                    className="justify-start flex-wrap"
+                  >
+                    {WEEKDAYS_ORDERED.map((d) => (
+                      <ToggleGroupItem
+                        key={d}
+                        value={d}
+                        aria-label={weekdayLabel(d)}
+                        className="w-10"
+                      >
+                        {weekdayLabel(d).slice(0, 1)}
+                      </ToggleGroupItem>
+                    ))}
+                  </ToggleGroup>
+                  {startWeekday && (
+                    <p className="text-xs text-muted-foreground">
+                      Your first session is on a {weekdayLabel(startWeekday)}, which must stay selected.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label>Ends</Label>
+                <RadioGroup
+                  value={end.kind}
+                  onValueChange={(v) =>
+                    setEnd(
+                      v === "count"
+                        ? { kind: "count", count: end.kind === "count" ? end.count : 4 }
+                        : {
+                            kind: "until",
+                            until:
+                              end.kind === "until" && end.until
+                                ? end.until
+                                : defaultUntilDate(),
+                          }
+                    )
+                  }
+                  disabled={isSubmitting}
+                >
+                  <div className="flex items-center gap-3">
+                    <RadioGroupItem id="end-count" value="count" />
+                    <Label htmlFor="end-count" className="cursor-pointer">
+                      After
+                    </Label>
+                    <Input
+                      type="number"
+                      min={1}
+                      max={MAX_OCCURRENCES}
+                      value={end.kind === "count" ? end.count : ""}
+                      onChange={(e) => {
+                        const next = parseInt(e.target.value, 10);
+                        setEnd({
+                          kind: "count",
+                          count: Number.isFinite(next) && next >= 1 ? next : 1,
+                        });
+                      }}
+                      disabled={isSubmitting || end.kind !== "count"}
+                      className="w-20"
+                    />
+                    <span className="text-sm text-muted-foreground">
+                      occurrences
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <RadioGroupItem id="end-until" value="until" />
+                    <Label htmlFor="end-until" className="cursor-pointer">
+                      On
+                    </Label>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={isSubmitting || end.kind !== "until"}
+                          className={cn(
+                            "h-9 gap-2 font-normal",
+                            end.kind === "until" && end.until
+                              ? ""
+                              : "text-muted-foreground"
+                          )}
+                        >
+                          <CalendarIcon className="h-4 w-4" />
+                          {end.kind === "until" && end.until
+                            ? DateTime.fromISO(end.until).toLocaleString(
+                                DateTime.DATE_MED
+                              )
+                            : "Pick a date"}
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent
+                        className="w-auto p-0"
+                        align="start"
+                      >
+                        <Calendar
+                          mode="single"
+                          selected={
+                            end.kind === "until" && end.until
+                              ? new Date(`${end.until}T00:00:00`)
+                              : undefined
+                          }
+                          onSelect={(date) =>
+                            setEnd({
+                              kind: "until",
+                              until: date
+                                ? DateTime.fromJSDate(date).toFormat(
+                                    "yyyy-MM-dd"
+                                  )
+                                : "",
+                            })
+                          }
+                        />
+                      </PopoverContent>
+                    </Popover>
+                  </div>
+                </RadioGroup>
+              </div>
+
+              {recurrenceError && (
+                <p className="text-sm text-destructive">{recurrenceError}</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       <Button
         type="submit"
         disabled={!canSubmit}
-        className={cn(showTwoCol && "sm:col-span-2 sm:justify-self-start")}
+        className={cn("justify-self-start", showTwoCol && "sm:col-span-2")}
       >
         {isSubmitting && <Spinner className="mr-2" />}
         {buttonText}

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -137,6 +137,8 @@ export default function CoachingSessionForm({
   const [byWeekdays, setByWeekdays] = useState<Weekday[]>([]);
   const [end, setEnd] = useState<RecurrenceEnd>({ kind: "count", count: 4 });
 
+  const showTwoCol = mode === "create";
+
   // Computes a default end date for the "On" option so the user never sees
   // an empty-state "Pick an end date" error before they've had a chance to
   // act. Anchored to sessionDate when set, otherwise today; both fall back
@@ -345,36 +347,39 @@ export default function CoachingSessionForm({
         : "Create Session";
 
   return (
-    <div>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {/* Coachee selector - only shown in create mode */}
-        {mode === "create" && (
-          <div className="space-y-2">
-            <Label htmlFor="coachee-select">Select Coachee</Label>
-            <Select
-              value={selectedRelationshipId}
-              onValueChange={setSelectedRelationshipId}
-              disabled={isLoadingRelationships || isSubmitting}
-            >
-              <SelectTrigger id="coachee-select">
-                <SelectValue placeholder="Select a coachee" />
-              </SelectTrigger>
-              <SelectContent>
-                {coacheeRelationships.length === 0 ? (
-                  <SelectItem value="_no_coachees" disabled>
-                    No coachees available
+    <form
+      onSubmit={handleSubmit}
+      className={cn("grid gap-6", showTwoCol && "sm:grid-cols-2 sm:items-start")}
+    >
+      {/* Coachee selector - only shown in create mode */}
+      {mode === "create" && (
+        <div className={cn("space-y-2", showTwoCol && "sm:col-span-2")}>
+          <Label htmlFor="coachee-select">Select Coachee</Label>
+          <Select
+            value={selectedRelationshipId}
+            onValueChange={setSelectedRelationshipId}
+            disabled={isLoadingRelationships || isSubmitting}
+          >
+            <SelectTrigger id="coachee-select">
+              <SelectValue placeholder="Select a coachee" />
+            </SelectTrigger>
+            <SelectContent>
+              {coacheeRelationships.length === 0 ? (
+                <SelectItem value="_no_coachees" disabled>
+                  No coachees available
+                </SelectItem>
+              ) : (
+                coacheeRelationships.map((rel) => (
+                  <SelectItem key={rel.id} value={rel.id}>
+                    {rel.coachee_first_name} {rel.coachee_last_name}
                   </SelectItem>
-                ) : (
-                  coacheeRelationships.map((rel) => (
-                    <SelectItem key={rel.id} value={rel.id}>
-                      {rel.coachee_first_name} {rel.coachee_last_name}
-                    </SelectItem>
-                  ))
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-        )}
+                ))
+              )}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+      <div className="space-y-4">
         <div className="space-y-2">
           <Label htmlFor="session-date">Session Date</Label>
           <Calendar
@@ -395,11 +400,12 @@ export default function CoachingSessionForm({
             disabled={isSubmitting}
           />
         </div>
+      </div>
 
-        {/* Recurring section — create mode only. Editing a recurrence rule
-            is a different operation that isn't supported by this dialog. */}
-        {mode === "create" && (
-          <div className="space-y-3 rounded-md border p-3">
+      {/* Recurring section — create mode only. Editing a recurrence rule
+          is a different operation that isn't supported by this dialog. */}
+      {mode === "create" && (
+        <div className="space-y-3">
             <div className="flex items-center justify-between">
               <Label htmlFor="recurring-switch" className="cursor-pointer">
                 Repeats
@@ -586,11 +592,14 @@ export default function CoachingSessionForm({
           </div>
         )}
 
-        <Button type="submit" disabled={!canSubmit}>
-          {isSubmitting && <Spinner className="mr-2" />}
-          {buttonText}
-        </Button>
-      </form>
-    </div>
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className={cn(showTwoCol && "sm:col-span-2 sm:justify-self-start")}
+      >
+        {isSubmitting && <Spinner className="mr-2" />}
+        {buttonText}
+      </Button>
+    </form>
   );
 }


### PR DESCRIPTION
## Description
The Schedule Coaching Session dialog grew vertically when the Repeats section was toggled on, pushing content past the bottom of the viewport. On wide screens it now uses a two-column layout (Date/Time on the left, Repeats on the right), so toggling expands the panel in place instead of vertically. On narrow viewports the form stacks as before, with `max-h-[90dvh]` + internal scroll as a safety net.

#### GitHub Issue: N/A

### Changes
- `coaching-session-dialog.tsx`: in create mode, widen `DialogContent` to `sm:max-w-3xl`; cap height at `90dvh` with internal scroll.
- `coaching-session-form.tsx`: switch root form to `grid gap-6` with `sm:grid-cols-2 sm:items-start` in create mode. Coachee selector and submit button span both columns.
- Remove the bordered/padded wrapper around the Repeats section so it visually matches the other field groups.

### Screenshots / Videos Showing UI Changes (if applicable)

> Drag-and-drop these from \`./.playwright-mcp/\` in the PR description editor:
> - **Wide, Repeats collapsed:** \`wide-collapsed.png\`
> - **Wide, Repeats expanded:** \`wide-no-box.png\` (final layout, no border around Repeats)
> - **Wide, with extra label spacing:** \`wide-gap6.png\`
> - **Narrow viewport (mobile portrait):** \`narrow-viewport.png\`

### Testing Strategy
1. Open the dashboard, click "Schedule a coaching session".
2. On a wide screen, confirm Repeats sits in the right column; toggle it on and verify the recurrence form expands in place without the dialog growing vertically.
3. Resize to a narrow viewport (~390px wide) and confirm the form stacks vertically with internal scroll if content overflows.
4. Update mode: open an existing session's edit dialog and confirm it stays single-column at `sm:max-w-lg`.

### Concerns
Narrow viewports still rely on internal dialog scrolling — that's the acknowledged mobile-portrait fallback. A dedicated mobile layout could be a follow-up.