### PR TITLE
Send tz to user-sessions list for local-day boundaries

### DIFF
--- a/src/components/ui/dashboard/session-buckets/bucket-accordion.tsx
+++ b/src/components/ui/dashboard/session-buckets/bucket-accordion.tsx
@@ -101,7 +101,8 @@ export function BucketAccordion({
     SESSION_INCLUDES,
     "date",
     isPastView ? "desc" : "asc",
-    relationshipId
+    relationshipId,
+    userTimezone
   );
 
   const filteredSessions = (enrichedSessions ?? []).filter((s) =>

--- a/src/components/ui/dashboard/session-buckets/buckets-container.tsx
+++ b/src/components/ui/dashboard/session-buckets/buckets-container.tsx
@@ -256,7 +256,8 @@ export function BucketsContainer({
     WEEK_INCLUDES,
     undefined,
     undefined,
-    relationshipFilter
+    relationshipFilter,
+    userTimezone
   );
   const { thisWeekUpcomingCount, thisWeekPreviousCount } = useMemo(() => {
     const all = weekSessions ?? [];

--- a/src/components/ui/dashboard/session-buckets/this-week-accordion.tsx
+++ b/src/components/ui/dashboard/session-buckets/this-week-accordion.tsx
@@ -73,7 +73,8 @@ export function ThisWeekAccordion({
     SESSION_INCLUDES,
     "date",
     isPastView ? "desc" : "asc",
-    relationshipId
+    relationshipId,
+    userTimezone
   );
 
   const filteredSessions = useMemo(() => {

--- a/src/components/ui/dashboard/session-buckets/today-section.tsx
+++ b/src/components/ui/dashboard/session-buckets/today-section.tsx
@@ -61,6 +61,9 @@ export function TodaySection({
 
   // BE sort: ascending for Upcoming (soonest first), descending for
   // Previous (most recent first). The FE filter below preserves order.
+  // `tz` makes the BE evaluate `from_date`/`to_date` as local-calendar-day
+  // boundaries — load-bearing for the 1-day window so a session whose UTC
+  // date differs from the viewer's local date still lands here.
   const { enrichedSessions } = useEnrichedCoachingSessionsForUser(
     userId,
     range.start,
@@ -68,7 +71,8 @@ export function TodaySection({
     SESSION_INCLUDES,
     "date",
     isPastView ? "desc" : "asc",
-    relationshipId
+    relationshipId,
+    userTimezone
   );
 
   const visibleSessions = useMemo(() => {

--- a/src/components/ui/dashboard/session-buckets/today-section.tsx
+++ b/src/components/ui/dashboard/session-buckets/today-section.tsx
@@ -61,9 +61,7 @@ export function TodaySection({
 
   // BE sort: ascending for Upcoming (soonest first), descending for
   // Previous (most recent first). The FE filter below preserves order.
-  // `tz` makes the BE evaluate `from_date`/`to_date` as local-calendar-day
-  // boundaries — load-bearing for the 1-day window so a session whose UTC
-  // date differs from the viewer's local date still lands here.
+  // `tz` shifts BE date boundaries to the viewer's local day — without it, cross-midnight sessions fall out.
   const { enrichedSessions } = useEnrichedCoachingSessionsForUser(
     userId,
     range.start,

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -195,7 +195,8 @@ export const CoachingSessionApi = {
     include?: CoachingSessionInclude[],
     sortBy?: CoachingSessionSortField,
     sortOrder?: ApiSortOrder,
-    relationshipId?: Id
+    relationshipId?: Id,
+    tz?: string
   ): Promise<EnrichedCoachingSession[]> => {
     const params: Record<string, string> = {
       from_date: fromDate.toISODate() || '',
@@ -215,6 +216,9 @@ export const CoachingSessionApi = {
     }
     if (sortOrder) {
       params.sort_order = sortOrder;
+    }
+    if (tz) {
+      params.tz = tz;
     }
 
     return CoachingSessionApi.listNested(userId, { params });
@@ -384,7 +388,8 @@ export const useEnrichedCoachingSessionsForUser = (
   include?: CoachingSessionInclude[],
   sortBy?: CoachingSessionSortField,
   sortOrder?: ApiSortOrder,
-  relationshipId?: Id
+  relationshipId?: Id,
+  tz?: string
 ) => {
   // Only create params when userId is valid - null params skips the SWR fetch
   const params = userId
@@ -396,6 +401,7 @@ export const useEnrichedCoachingSessionsForUser = (
         ...(relationshipId && { coaching_relationship_id: relationshipId }),
         ...(sortBy && { sort_by: sortBy }),
         ...(sortOrder && { sort_order: sortOrder }),
+        ...(tz && { tz }),
       }
     : null;
 
@@ -410,7 +416,8 @@ export const useEnrichedCoachingSessionsForUser = (
           include,
           sortBy,
           sortOrder,
-          relationshipId
+          relationshipId,
+          tz
         )
       : Promise.resolve([]);
 


### PR DESCRIPTION
## Summary

- Wires an optional `tz` query param through `listForUser` and `useEnrichedCoachingSessionsForUser`, then threads `userTimezone` from the four dashboard callers that already have it (`today-section`, `this-week-accordion`, `bucket-accordion`, and `buckets-container`'s `weekSessions` overlap fetch).
- Fixes the TODAY-section bug where a session whose UTC date differs from the viewer's local date (e.g. 9 PM local Sun May 24 → 01:00Z May 25 in US Eastern) was dropping out of the 1-day query while still appearing in the 7-day THIS WEEK accordion. Symmetric fix to the counts endpoint's existing `tz` handling.
- Backwards-compatible: callers that don't pass `tz` preserve the BE's existing UTC-naive interpretation byte-identically.

## Paired BE change

[`refactor-group/refactor-platform-rs#331`](https://github.com/refactor-group/refactor-platform-rs/pull/331) — adds optional `tz` query param to `GET /users/{user_id}/coaching_sessions`, applies `AT TIME ZONE` boundary shift when present, returns `invalid_timezone` 400 on bad IANA. Either merge order is safe per the [`UserCoachingSessionsListEndpoint` v1](board) contract — until BE ships, FE keeps current behavior; once BE ships, FE auto-corrects.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1269 / 1269 passing
- [ ] Verify against deployed BE: open dashboard with a session whose local date differs from its UTC date (e.g. 9 PM local in a westward TZ) — session appears under TODAY rather than only THIS WEEK
- [ ] Verify request: dashboard fires `GET /users/{id}/coaching_sessions?...&tz=<IANA>` (DevTools Network)
- [ ] Mirror check on the Previous tab: a 1 AM local session whose UTC date is the previous day appears under TODAY (Previous)
- [ ] Regression: when BE has not deployed yet, the request still succeeds (unknown param ignored) and FE behavior matches current main