### PR TITLE
Add per-session duration with coach default

### DIFF
--- a/__tests__/coaching-session.test.ts
+++ b/__tests__/coaching-session.test.ts
@@ -25,6 +25,15 @@ describe("isPastSession", () => {
     expect(isPastSession(session)).toBe(false);
   });
 
+  it("uses the session's own duration_minutes (30-min session is past at minute 31)", () => {
+    // Phase 2 rewire: this would have returned false under the old constant
+    // (60-min default) because 31 min < 60. The session's own duration drives
+    // the calculation now.
+    const session = createSessionAt(-31);
+    session.duration_minutes = 30;
+    expect(isPastSession(session)).toBe(true);
+  });
+
   it("returns true when now is past the custom cutoff", () => {
     const session = createSessionAt(-30); // 30 min ago, normally still active
     const cutoff = DateTime.now().minus({ minutes: 5 }); // cutoff was 5 min ago
@@ -126,6 +135,15 @@ describe("isUnderwaySession", () => {
 
   it("returns false when session has not started yet", () => {
     const session = createSessionAt(30);
+    expect(isUnderwaySession(session)).toBe(false);
+  });
+
+  it("uses the session's own duration_minutes (90-min session is not underway at minute 91)", () => {
+    // Phase 2 rewire: with a longer custom duration, the underway window
+    // extends to match. Boundary check confirms isUnderwaySession reads
+    // session.duration_minutes (not the constant).
+    const session = createSessionAt(-91);
+    session.duration_minutes = 90;
     expect(isUnderwaySession(session)).toBe(false);
   });
 });

--- a/__tests__/coaching-session.test.ts
+++ b/__tests__/coaching-session.test.ts
@@ -5,8 +5,8 @@ import {
   isFutureSession,
   isUnderwaySession,
   isSessionToday,
-  DEFAULT_SESSION_DURATION_MINUTES,
 } from "@/types/coaching-session";
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 import { createSessionAt, createMockSession } from "./test-utils";
 
 describe("isPastSession", () => {
@@ -124,7 +124,7 @@ describe("isUnderwaySession", () => {
   });
 
   it("returns true near the end of the session duration", () => {
-    const session = createSessionAt(-(DEFAULT_SESSION_DURATION_MINUTES - 1)); // 1 min before end
+    const session = createSessionAt(-(FALLBACK_DURATION_MINUTES - 1)); // 1 min before end
     expect(isUnderwaySession(session)).toBe(true);
   });
 

--- a/__tests__/components/coaching-sessions/coaching-session-duration-input.test.tsx
+++ b/__tests__/components/coaching-sessions/coaching-session-duration-input.test.tsx
@@ -1,39 +1,33 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
 
 describe("CoachingSessionDurationInput", () => {
-  it("renders a single number input with the current value", () => {
+  it("renders a single combobox input with the current value", () => {
     render(<CoachingSessionDurationInput value={45} onChange={vi.fn()} />);
-    const input = screen.getByRole("spinbutton");
-    expect(input).toHaveValue(45);
+    const input = screen.getByRole("combobox", {
+      name: /duration in minutes/i,
+    });
+    expect(input).toHaveValue("45");
   });
 
-  it("links the input to a datalist of presets so the dropdown surfaces 15/30/45/60/90/120", () => {
-    render(<CoachingSessionDurationInput value={60} onChange={vi.fn()} />);
-    const input = screen.getByRole("spinbutton");
-    const listId = input.getAttribute("list");
-    expect(listId).toBeTruthy();
-    const datalist = document.getElementById(listId!);
-    expect(datalist).toBeInTheDocument();
-    const optionValues = Array.from(
-      datalist!.querySelectorAll("option")
-    ).map((o) => Number(o.getAttribute("value")));
-    expect(optionValues).toEqual([15, 30, 45, 60, 90, 120]);
-  });
-
-  it("emits onChange with the parsed integer when the value changes", () => {
+  it("emits onChange with the parsed integer when the user types", () => {
     const onChange = vi.fn();
     render(<CoachingSessionDurationInput value={60} onChange={onChange} />);
-    const input = screen.getByRole("spinbutton");
+    const input = screen.getByRole("combobox", {
+      name: /duration in minutes/i,
+    });
     fireEvent.change(input, { target: { value: "75" } });
     expect(onChange).toHaveBeenLastCalledWith(75);
   });
 
-  it("does not emit onChange with NaN when the value is cleared", () => {
+  it("does not emit onChange with NaN when the input is cleared", () => {
     const onChange = vi.fn();
     render(<CoachingSessionDurationInput value={60} onChange={onChange} />);
-    const input = screen.getByRole("spinbutton");
+    const input = screen.getByRole("combobox", {
+      name: /duration in minutes/i,
+    });
     fireEvent.change(input, { target: { value: "" } });
     const nanCalls = onChange.mock.calls.filter((call) =>
       Number.isNaN(call[0])
@@ -41,10 +35,35 @@ describe("CoachingSessionDurationInput", () => {
     expect(nanCalls).toEqual([]);
   });
 
-  it("enforces the 1..=480 range via min/max attributes on the input", () => {
-    render(<CoachingSessionDurationInput value={60} onChange={vi.fn()} />);
-    const input = screen.getByRole("spinbutton");
-    expect(input).toHaveAttribute("min", "1");
-    expect(input).toHaveAttribute("max", "480");
+  it("opens a presets popover with all six common durations when the chevron is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CoachingSessionDurationInput value={75} onChange={vi.fn()} />);
+    const trigger = screen.getByRole("button", {
+      name: /show duration presets/i,
+    });
+    await user.click(trigger);
+
+    const options = screen
+      .getAllByRole("option")
+      .map((o) => o.textContent?.trim());
+    expect(options).toEqual([
+      "15 minutes",
+      "30 minutes",
+      "45 minutes",
+      "60 minutes",
+      "90 minutes",
+      "120 minutes",
+    ]);
+  });
+
+  it("emits onChange with the preset value when a preset is clicked", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CoachingSessionDurationInput value={75} onChange={onChange} />);
+    await user.click(
+      screen.getByRole("button", { name: /show duration presets/i })
+    );
+    await user.click(screen.getByRole("option", { name: "30 minutes" }));
+    expect(onChange).toHaveBeenLastCalledWith(30);
   });
 });

--- a/__tests__/components/coaching-sessions/coaching-session-duration-input.test.tsx
+++ b/__tests__/components/coaching-sessions/coaching-session-duration-input.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
+
+describe("CoachingSessionDurationInput", () => {
+  it("renders a single number input with the current value", () => {
+    render(<CoachingSessionDurationInput value={45} onChange={vi.fn()} />);
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveValue(45);
+  });
+
+  it("links the input to a datalist of presets so the dropdown surfaces 15/30/45/60/90/120", () => {
+    render(<CoachingSessionDurationInput value={60} onChange={vi.fn()} />);
+    const input = screen.getByRole("spinbutton");
+    const listId = input.getAttribute("list");
+    expect(listId).toBeTruthy();
+    const datalist = document.getElementById(listId!);
+    expect(datalist).toBeInTheDocument();
+    const optionValues = Array.from(
+      datalist!.querySelectorAll("option")
+    ).map((o) => Number(o.getAttribute("value")));
+    expect(optionValues).toEqual([15, 30, 45, 60, 90, 120]);
+  });
+
+  it("emits onChange with the parsed integer when the value changes", () => {
+    const onChange = vi.fn();
+    render(<CoachingSessionDurationInput value={60} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "75" } });
+    expect(onChange).toHaveBeenLastCalledWith(75);
+  });
+
+  it("does not emit onChange with NaN when the value is cleared", () => {
+    const onChange = vi.fn();
+    render(<CoachingSessionDurationInput value={60} onChange={onChange} />);
+    const input = screen.getByRole("spinbutton");
+    fireEvent.change(input, { target: { value: "" } });
+    const nanCalls = onChange.mock.calls.filter((call) =>
+      Number.isNaN(call[0])
+    );
+    expect(nanCalls).toEqual([]);
+  });
+
+  it("enforces the 1..=480 range via min/max attributes on the input", () => {
+    render(<CoachingSessionDurationInput value={60} onChange={vi.fn()} />);
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("min", "1");
+    expect(input).toHaveAttribute("max", "480");
+  });
+});

--- a/__tests__/components/settings/coaching-preferences-section.test.tsx
+++ b/__tests__/components/settings/coaching-preferences-section.test.tsx
@@ -82,7 +82,7 @@ describe("CoachingPreferencesSection", () => {
       mockUpdate.mockResolvedValue(undefined);
       render(<CoachingPreferencesSection />);
 
-      const numericInput = screen.getByRole("spinbutton");
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
       fireEvent.change(numericInput, { target: { value: "45" } });
 
       // Before the debounce elapses, no save has fired.
@@ -102,7 +102,7 @@ describe("CoachingPreferencesSection", () => {
       mockUpdate.mockResolvedValue(undefined);
       render(<CoachingPreferencesSection />);
 
-      const numericInput = screen.getByRole("spinbutton");
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
       fireEvent.change(numericInput, { target: { value: "30" } });
       fireEvent.change(numericInput, { target: { value: "45" } });
       fireEvent.change(numericInput, { target: { value: "60" } });
@@ -123,7 +123,7 @@ describe("CoachingPreferencesSection", () => {
       mockUpdate.mockResolvedValue(undefined);
       render(<CoachingPreferencesSection />);
 
-      const numericInput = screen.getByRole("spinbutton");
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
       fireEvent.change(numericInput, { target: { value: "999" } });
 
       await act(async () => {
@@ -144,7 +144,7 @@ describe("CoachingPreferencesSection", () => {
       );
       render(<CoachingPreferencesSection />);
 
-      const numericInput = screen.getByRole("spinbutton");
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
       fireEvent.change(numericInput, { target: { value: "45" } });
 
       await act(async () => {
@@ -163,7 +163,7 @@ describe("CoachingPreferencesSection", () => {
       );
       render(<CoachingPreferencesSection />);
 
-      const numericInput = screen.getByRole("spinbutton");
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
       fireEvent.change(numericInput, { target: { value: "45" } });
 
       await act(async () => {

--- a/__tests__/components/settings/coaching-preferences-section.test.tsx
+++ b/__tests__/components/settings/coaching-preferences-section.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CoachingPreferencesSection } from "@/components/ui/settings/coaching-preferences-section";
+import { EntityApiError } from "@/types/general";
+import { createMockUser } from "../../test-utils";
+
+const AUTOSAVE_DEBOUNCE_MS = 400;
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  }),
+}));
+
+const mockAuthStore = vi.fn();
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector(mockAuthStore()),
+}));
+
+const mockUpdate = vi.fn();
+const mockRefresh = vi.fn();
+let mockUserState = {
+  user: createMockUser(),
+  isLoading: false,
+  isError: undefined,
+  refresh: mockRefresh,
+};
+
+vi.mock("@/lib/api/users", () => ({
+  useUser: () => mockUserState,
+  useUserMutation: () => ({
+    update: mockUpdate,
+    isLoading: false,
+  }),
+}));
+
+function makeApiError(status: number, data: unknown): EntityApiError {
+  const axiosLikeError = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Error", data },
+  });
+  return new EntityApiError("PUT", "/users/user-1", axiosLikeError);
+}
+
+describe("CoachingPreferencesSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockUserState = {
+      user: createMockUser({
+        id: "user-1",
+        default_coaching_session_duration_minutes: 75,
+      }),
+      isLoading: false,
+      isError: undefined,
+      refresh: mockRefresh,
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("auth gating", () => {
+    it("does not render the section for non-coaches", () => {
+      mockAuthStore.mockReturnValue({ isACoach: false, userId: "user-1" });
+      const { container } = render(<CoachingPreferencesSection />);
+      expect(container.innerHTML).toBe("");
+    });
+  });
+
+  describe("auto-save behavior", () => {
+    beforeEach(() => {
+      mockAuthStore.mockReturnValue({ isACoach: true, userId: "user-1" });
+    });
+
+    it("calls useUserMutation().update with the new value after the debounce window", async () => {
+      mockUpdate.mockResolvedValue(undefined);
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("spinbutton");
+      fireEvent.change(numericInput, { target: { value: "45" } });
+
+      // Before the debounce elapses, no save has fired.
+      expect(mockUpdate).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+      });
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      const [calledId, calledPayload] = mockUpdate.mock.calls[0];
+      expect(calledId).toBe("user-1");
+      expect(calledPayload.default_coaching_session_duration_minutes).toBe(45);
+    });
+
+    it("coalesces rapid changes into a single PUT (debounce)", async () => {
+      mockUpdate.mockResolvedValue(undefined);
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("spinbutton");
+      fireEvent.change(numericInput, { target: { value: "30" } });
+      fireEvent.change(numericInput, { target: { value: "45" } });
+      fireEvent.change(numericInput, { target: { value: "60" } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+      });
+
+      // Only the last value should be saved — the earlier timers are
+      // canceled by the useEffect cleanup.
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(
+        mockUpdate.mock.calls[0][1].default_coaching_session_duration_minutes
+      ).toBe(60);
+    });
+
+    it("does not save when the value is invalid (validation gate)", async () => {
+      mockUpdate.mockResolvedValue(undefined);
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("spinbutton");
+      fireEvent.change(numericInput, { target: { value: "999" } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+      });
+
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the BE's validation_error message verbatim on 422", async () => {
+      mockUpdate.mockRejectedValue(
+        makeApiError(422, {
+          status_code: 422,
+          error: "validation_error",
+          message:
+            "default_coaching_session_duration_minutes must be between 1 and 480 (got 999)",
+        })
+      );
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("spinbutton");
+      fireEvent.change(numericInput, { target: { value: "45" } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+        await Promise.resolve();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "default_coaching_session_duration_minutes must be between 1 and 480 (got 999)"
+      );
+    });
+
+    it("shows a generic fallback toast on non-422 errors", async () => {
+      mockUpdate.mockRejectedValue(
+        makeApiError(503, { status_code: 503, error: "service_unavailable" })
+      );
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("spinbutton");
+      fireEvent.change(numericInput, { target: { value: "45" } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+        await Promise.resolve();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Couldn't save preferences. Please try again."
+      );
+    });
+  });
+});

--- a/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
@@ -109,7 +109,7 @@ describe("CoachingSessionForm – coachee dropdown ordering", () => {
   function renderCreateForm() {
     render(
       <Wrapper>
-        <CoachingSessionForm mode="create" onOpenChange={vi.fn()} />
+        <CoachingSessionForm mode="create" onOpenChange={vi.fn()} defaultDurationMinutes={60} />
       </Wrapper>
     );
   }
@@ -143,7 +143,7 @@ describe("CoachingSessionForm – coachee dropdown ordering", () => {
 
     renderCreateForm();
 
-    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByLabelText("Select Coachee"));
 
     const optionNames = screen
       .getAllByRole("option")
@@ -169,6 +169,7 @@ describe("CoachingSessionForm – handleSubmit error handling", () => {
           mode="update"
           existingSession={existingSession}
           onOpenChange={vi.fn()}
+          defaultDurationMinutes={60}
         />
       </Wrapper>
     );

--- a/__tests__/factories/coaching-session.factory.ts
+++ b/__tests__/factories/coaching-session.factory.ts
@@ -21,6 +21,7 @@ export function createMockCoachingSession(
     id: 'session-123',
     coaching_relationship_id: 'rel-123',
     date: now,
+    duration_minutes: 60,
     created_at: now,
     updated_at: now,
     ...overrides,

--- a/__tests__/integration/coaching-session-duration.integration.test.tsx
+++ b/__tests__/integration/coaching-session-duration.integration.test.tsx
@@ -122,10 +122,10 @@ describe("Coaching session duration integration", () => {
   describe("create mode: pre-populates from coach default and sends duration_minutes", () => {
     it("opens with coach's stored default (50) in the duration input", async () => {
       render(<CoachingSessionDialog open onOpenChange={vi.fn()} />);
-      const durationInput = await screen.findByRole("spinbutton", {
+      const durationInput = await screen.findByRole("combobox", {
         name: /duration in minutes/i,
       });
-      expect(durationInput).toHaveValue(50);
+      expect(durationInput).toHaveValue("50");
     });
 
     it("includes duration_minutes in the POST /coaching_sessions payload", async () => {
@@ -143,7 +143,7 @@ describe("Coaching session duration integration", () => {
       ) as HTMLInputElement;
       fireEvent.change(timeInput, { target: { value: "10:00" } });
 
-      const durationInput = screen.getByRole("spinbutton", {
+      const durationInput = screen.getByRole("combobox", {
         name: /duration in minutes/i,
       });
       fireEvent.change(durationInput, { target: { value: "30" } });
@@ -174,11 +174,11 @@ describe("Coaching session duration integration", () => {
           coachingSessionToEdit={existing}
         />
       );
-      const durationInput = await screen.findByRole("spinbutton", {
+      const durationInput = await screen.findByRole("combobox", {
         name: /duration in minutes/i,
       });
       // 90 != coach default 50 — proves the existing session's value wins.
-      expect(durationInput).toHaveValue(90);
+      expect(durationInput).toHaveValue("90");
     });
 
     it("sends the new duration_minutes in PUT /coaching_sessions/{id} payload", async () => {
@@ -196,7 +196,7 @@ describe("Coaching session duration integration", () => {
         />
       );
 
-      const durationInput = screen.getByRole("spinbutton", {
+      const durationInput = screen.getByRole("combobox", {
         name: /duration in minutes/i,
       });
       fireEvent.change(durationInput, { target: { value: "100" } });

--- a/__tests__/integration/coaching-session-duration.integration.test.tsx
+++ b/__tests__/integration/coaching-session-duration.integration.test.tsx
@@ -1,0 +1,252 @@
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRouter } from "next/navigation";
+import { CoachingSessionDialog } from "@/components/ui/dashboard/coaching-session-dialog";
+import { EntityApiError } from "@/types/general";
+import { createMockUser, createMockSession } from "../test-utils";
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  }),
+}));
+
+const mockAuthStore = vi.fn();
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector(mockAuthStore()),
+}));
+
+const mockCoachingRelationshipState = vi.fn();
+vi.mock("@/lib/providers/coaching-relationship-state-store-provider", () => ({
+  useCoachingRelationshipStateStore: (selector: (state: unknown) => unknown) =>
+    selector(mockCoachingRelationshipState()),
+}));
+
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+}));
+
+const mockUserFetch = vi.fn();
+vi.mock("@/lib/api/users", () => ({
+  useUser: (id: string) => mockUserFetch(id),
+  useUserMutation: () => ({
+    update: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockCreateRecurring = vi.fn();
+vi.mock("@/lib/api/coaching-sessions", () => ({
+  useCoachingSessionList: () => ({ refresh: vi.fn() }),
+  useCoachingSessionMutation: () => ({
+    create: mockCreate,
+    update: mockUpdate,
+  }),
+  CoachingSessionApi: {
+    createRecurring: (...args: unknown[]) => mockCreateRecurring(...args),
+  },
+}));
+
+vi.mock("@/lib/api/coaching-relationships", () => ({
+  useCoachingRelationshipList: () => ({
+    relationships: [
+      {
+        id: "rel-1",
+        coach_id: "user-1",
+        coachee_id: "user-2",
+        organization_id: "org-1",
+        coach_first_name: "Jim",
+        coach_last_name: "Hodapp",
+        coachee_first_name: "Alex",
+        coachee_last_name: "Chen",
+      },
+    ],
+    isLoading: false,
+    isError: undefined,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api/oauth-connection", () => ({
+  useOAuthConnections: () => ({ connections: [] }),
+}));
+
+function makeApiError(status: number, data: unknown): EntityApiError {
+  const axiosLikeError = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Error", data },
+  });
+  return new EntityApiError("POST", "/coaching_sessions", axiosLikeError);
+}
+
+describe("Coaching session duration integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthStore.mockReturnValue({
+      userSession: {
+        id: "user-1",
+        timezone: "America/Los_Angeles",
+      },
+      userId: "user-1",
+      isACoach: true,
+    });
+    mockCoachingRelationshipState.mockReturnValue({
+      currentCoachingRelationshipId: "rel-1",
+    });
+    mockUserFetch.mockReturnValue({
+      user: createMockUser({
+        id: "user-1",
+        default_coaching_session_duration_minutes: 50,
+      }),
+      isLoading: false,
+      isError: undefined,
+      refresh: vi.fn(),
+    });
+    vi.mocked(useRouter).mockReturnValue({
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    });
+  });
+
+  describe("create mode: pre-populates from coach default and sends duration_minutes", () => {
+    it("opens with coach's stored default (50) in the duration input", async () => {
+      render(<CoachingSessionDialog open onOpenChange={vi.fn()} />);
+      const durationInput = await screen.findByRole("spinbutton", {
+        name: /duration in minutes/i,
+      });
+      expect(durationInput).toHaveValue(50);
+    });
+
+    it("includes duration_minutes in the POST /coaching_sessions payload", async () => {
+      mockCreate.mockResolvedValue(undefined);
+      const user = userEvent.setup();
+      render(<CoachingSessionDialog open onOpenChange={vi.fn()} />);
+
+      const today = new Date();
+      const dayLabel = String(today.getDate());
+      const dayButtons = screen.getAllByRole("gridcell", { name: dayLabel });
+      await user.click(dayButtons[0]);
+
+      const timeInput = document.getElementById(
+        "session-time"
+      ) as HTMLInputElement;
+      fireEvent.change(timeInput, { target: { value: "10:00" } });
+
+      const durationInput = screen.getByRole("spinbutton", {
+        name: /duration in minutes/i,
+      });
+      fireEvent.change(durationInput, { target: { value: "30" } });
+
+      const submitButton = screen.getByRole("button", { name: /create session/i });
+      await act(async () => {
+        await user.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(mockCreate).toHaveBeenCalled();
+      });
+      const payload = mockCreate.mock.calls[0][0];
+      expect(payload.duration_minutes).toBe(30);
+    });
+  });
+
+  describe("update mode: pre-populates from existing session", () => {
+    it("renders the input with existingSession.duration_minutes (not the coach default)", async () => {
+      const existing = createMockSession({
+        id: "sess-1",
+        duration_minutes: 90,
+      });
+      render(
+        <CoachingSessionDialog
+          open
+          onOpenChange={vi.fn()}
+          coachingSessionToEdit={existing}
+        />
+      );
+      const durationInput = await screen.findByRole("spinbutton", {
+        name: /duration in minutes/i,
+      });
+      // 90 != coach default 50 — proves the existing session's value wins.
+      expect(durationInput).toHaveValue(90);
+    });
+
+    it("sends the new duration_minutes in PUT /coaching_sessions/{id} payload", async () => {
+      mockUpdate.mockResolvedValue(undefined);
+      const existing = createMockSession({
+        id: "sess-1",
+        duration_minutes: 75,
+      });
+      const user = userEvent.setup();
+      render(
+        <CoachingSessionDialog
+          open
+          onOpenChange={vi.fn()}
+          coachingSessionToEdit={existing}
+        />
+      );
+
+      const durationInput = screen.getByRole("spinbutton", {
+        name: /duration in minutes/i,
+      });
+      fireEvent.change(durationInput, { target: { value: "100" } });
+
+      const submitButton = screen.getByRole("button", { name: /update session/i });
+      await act(async () => {
+        await user.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalled();
+      });
+      const [calledId, payload] = mockUpdate.mock.calls[0];
+      expect(calledId).toBe("sess-1");
+      expect(payload.duration_minutes).toBe(100);
+    });
+  });
+
+  describe("422 validation_error surfaces BE message verbatim", () => {
+    it("toasts error.data.message instead of the generic 422 fallback", async () => {
+      mockUpdate.mockRejectedValue(
+        makeApiError(422, {
+          status_code: 422,
+          error: "validation_error",
+          message: "duration_minutes must be between 1 and 480 (got 999)",
+        })
+      );
+      const existing = createMockSession({
+        id: "sess-1",
+        duration_minutes: 60,
+      });
+      const user = userEvent.setup();
+      render(
+        <CoachingSessionDialog
+          open
+          onOpenChange={vi.fn()}
+          coachingSessionToEdit={existing}
+        />
+      );
+
+      const submitButton = screen.getByRole("button", { name: /update session/i });
+      await act(async () => {
+        await user.click(submitButton);
+      });
+
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith(
+          "duration_minutes must be between 1 and 480 (got 999)"
+        );
+      });
+    });
+  });
+});

--- a/__tests__/test-utils.ts
+++ b/__tests__/test-utils.ts
@@ -24,6 +24,7 @@ export function createMockUser(overrides?: Partial<User>): User {
     last_name: "Hodapp",
     display_name: "Jim Hodapp",
     timezone: "America/Los_Angeles",
+    default_coaching_session_duration_minutes: 60,
     role: "coach",
     roles: [],
     invite_status: null,
@@ -74,6 +75,7 @@ export function createMockSession(
     id: "session-1",
     coaching_relationship_id: "rel-1",
     date: now.plus({ hours: 2 }).toISO() ?? '', // Date is ISO string
+    duration_minutes: 60,
     created_at: now, // CoachingSession expects DateTime object
     updated_at: now,
     ...overrides,
@@ -103,6 +105,7 @@ export function createMockEnrichedSession(
     id: "session-1",
     coaching_relationship_id: "rel-1",
     date: now.plus({ hours: 2 }).toISO() ?? "",
+    duration_minutes: 60,
     created_at: now,
     updated_at: now,
     relationship: {
@@ -120,6 +123,7 @@ export function createMockEnrichedSession(
       last_name: "Hodapp",
       display_name: "Jim Hodapp",
       timezone: "America/Los_Angeles",
+      default_coaching_session_duration_minutes: 60,
       role: "coach",
       roles: [],
       created_at: now.toISO() ?? "",
@@ -132,6 +136,7 @@ export function createMockEnrichedSession(
       last_name: "Chen",
       display_name: "Alex Chen",
       timezone: "America/Los_Angeles",
+      default_coaching_session_duration_minutes: 60,
       role: "user",
       roles: [],
       created_at: now.toISO() ?? "",

--- a/__tests__/types/coaching-session-duration.test.ts
+++ b/__tests__/types/coaching-session-duration.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { EntityApiError } from "@/types/general";
+import {
+  DurationErrorCode,
+  isDurationValidationError,
+  validateDurationMinutes,
+} from "@/types/coaching-session-duration";
+
+function makeEntityApiError(status: number, data: unknown): EntityApiError {
+  const axiosLikeError = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Error", data },
+  });
+  return new EntityApiError("PUT", "/coaching_sessions/1", axiosLikeError);
+}
+
+describe("validateDurationMinutes", () => {
+  it("rejects zero (below MIN_DURATION_MINUTES)", () => {
+    expect(validateDurationMinutes(0)).not.toBeNull();
+  });
+
+  it("accepts 1 (the minimum)", () => {
+    expect(validateDurationMinutes(1)).toBeNull();
+  });
+
+  it("accepts 60 (typical default)", () => {
+    expect(validateDurationMinutes(60)).toBeNull();
+  });
+
+  it("accepts 480 (the maximum)", () => {
+    expect(validateDurationMinutes(480)).toBeNull();
+  });
+
+  it("rejects 481 (above MAX_DURATION_MINUTES)", () => {
+    expect(validateDurationMinutes(481)).not.toBeNull();
+  });
+
+  it("rejects negative values", () => {
+    expect(validateDurationMinutes(-30)).not.toBeNull();
+  });
+
+  it("rejects non-integer values", () => {
+    expect(validateDurationMinutes(1.5)).not.toBeNull();
+  });
+
+  it("rejects NaN", () => {
+    expect(validateDurationMinutes(NaN)).not.toBeNull();
+  });
+});
+
+describe("isDurationValidationError", () => {
+  it("returns false for a non-EntityApiError value", () => {
+    expect(isDurationValidationError(new Error("plain"))).toBe(false);
+    expect(isDurationValidationError(null)).toBe(false);
+    expect(isDurationValidationError(undefined)).toBe(false);
+  });
+
+  it("returns false for an EntityApiError with non-422 status", () => {
+    const err = makeEntityApiError(500, {
+      status_code: 500,
+      error: "validation_error",
+      message: "should not match",
+    });
+    expect(isDurationValidationError(err)).toBe(false);
+  });
+
+  it("returns false for a 422 with a different error discriminator", () => {
+    const err = makeEntityApiError(422, {
+      status_code: 422,
+      error: "cannot_link_completed_goal",
+      message: "wrong discriminator",
+    });
+    expect(isDurationValidationError(err)).toBe(false);
+  });
+
+  it("returns true for a 422 with the validation_error discriminator", () => {
+    const err = makeEntityApiError(422, {
+      status_code: 422,
+      error: DurationErrorCode.ValidationError,
+      message: "duration_minutes must be between 1 and 480 (got 481)",
+    });
+    expect(isDurationValidationError(err)).toBe(true);
+  });
+
+  it("returns false for a 422 with no body", () => {
+    const err = makeEntityApiError(422, null);
+    expect(isDurationValidationError(err)).toBe(false);
+  });
+});

--- a/__tests__/types/coaching-session-duration.test.ts
+++ b/__tests__/types/coaching-session-duration.test.ts
@@ -16,35 +16,39 @@ function makeEntityApiError(status: number, data: unknown): EntityApiError {
 
 describe("validateDurationMinutes", () => {
   it("rejects zero (below MIN_DURATION_MINUTES)", () => {
-    expect(validateDurationMinutes(0)).not.toBeNull();
+    expect(validateDurationMinutes(0).isErr()).toBe(true);
   });
 
   it("accepts 1 (the minimum)", () => {
-    expect(validateDurationMinutes(1)).toBeNull();
+    const result = validateDurationMinutes(1);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(1);
   });
 
   it("accepts 60 (typical default)", () => {
-    expect(validateDurationMinutes(60)).toBeNull();
+    const result = validateDurationMinutes(60);
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(60);
   });
 
   it("accepts 480 (the maximum)", () => {
-    expect(validateDurationMinutes(480)).toBeNull();
+    expect(validateDurationMinutes(480).isOk()).toBe(true);
   });
 
   it("rejects 481 (above MAX_DURATION_MINUTES)", () => {
-    expect(validateDurationMinutes(481)).not.toBeNull();
+    expect(validateDurationMinutes(481).isErr()).toBe(true);
   });
 
   it("rejects negative values", () => {
-    expect(validateDurationMinutes(-30)).not.toBeNull();
+    expect(validateDurationMinutes(-30).isErr()).toBe(true);
   });
 
   it("rejects non-integer values", () => {
-    expect(validateDurationMinutes(1.5)).not.toBeNull();
+    expect(validateDurationMinutes(1.5).isErr()).toBe(true);
   });
 
   it("rejects NaN", () => {
-    expect(validateDurationMinutes(NaN)).not.toBeNull();
+    expect(validateDurationMinutes(NaN).isErr()).toBe(true);
   });
 });
 

--- a/__tests__/types/user.test.ts
+++ b/__tests__/types/user.test.ts
@@ -1,6 +1,27 @@
 import { describe, it, expect } from 'vitest';
-import { getUserRoleForOrganization, Role } from '@/types/user';
+import { getUserRoleForOrganization, parseUser, Role } from '@/types/user';
 import type { UserRole } from '@/types/user';
+
+describe('parseUser', () => {
+  it('falls back to 60 for default_coaching_session_duration_minutes when the upstream payload omits it', () => {
+    // Defense-in-depth: BE guarantees the field per CoachingSessionDurationFeature v2,
+    // but a stale cache or test fixture might omit it; the parser shouldn't crash.
+    const payload = {
+      id: 'user-1',
+      email: 'jim@example.com',
+      password: 'irrelevant',
+      first_name: 'Jim',
+      last_name: 'Hodapp',
+      display_name: 'Jim Hodapp',
+      timezone: 'America/Los_Angeles',
+      role: Role.User,
+      roles: [],
+      invite_status: null,
+    };
+    const user = parseUser(payload);
+    expect(user.default_coaching_session_duration_minutes).toBe(60);
+  });
+});
 
 describe('getUserRoleForOrganization', () => {
   it('should prioritize SuperAdmin role', () => {

--- a/src/app/settings/preferences/page.tsx
+++ b/src/app/settings/preferences/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { CoachingPreferencesSection } from "@/components/ui/settings/coaching-preferences-section";
+
+export default function PreferencesPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold tracking-tight">Coaching Sessions</h2>
+        <p className="text-sm text-muted-foreground">
+          Set defaults that pre-fill when you schedule coaching sessions.
+        </p>
+      </div>
+      <CoachingPreferencesSection />
+    </div>
+  );
+}

--- a/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
@@ -17,7 +17,7 @@ export interface CoachingSessionDurationInputProps {
   onChange: (minutes: number) => void;
   disabled?: boolean;
   id?: string;
-  error?: string | null;
+  error?: string;
 }
 
 export function CoachingSessionDurationInput({

--- a/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import * as React from "react";
+import { ChevronDown } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
-  DURATION_PRESETS,
-  MAX_DURATION_MINUTES,
-  MIN_DURATION_MINUTES,
-} from "@/types/coaching-session-duration";
-
-const PRESETS_DATALIST_ID = "coaching-session-duration-presets";
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/components/lib/utils";
+import { DURATION_PRESETS } from "@/types/coaching-session-duration";
 
 export interface CoachingSessionDurationInputProps {
   value: number;
@@ -25,33 +26,72 @@ export function CoachingSessionDurationInput({
   id,
   error,
 }: CoachingSessionDurationInputProps) {
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const [open, setOpen] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const next = parseInt(e.target.value, 10);
     if (Number.isFinite(next)) {
       onChange(next);
     }
   };
 
+  const handlePresetSelect = (minutes: number) => {
+    onChange(minutes);
+    setOpen(false);
+    inputRef.current?.focus();
+  };
+
   return (
     <>
-      <Input
-        id={id}
-        type="number"
-        list={PRESETS_DATALIST_ID}
-        min={MIN_DURATION_MINUTES}
-        max={MAX_DURATION_MINUTES}
-        value={value}
-        onChange={handleChange}
-        disabled={disabled}
-        aria-label="Duration in minutes"
-      />
-      <datalist id={PRESETS_DATALIST_ID}>
-        {DURATION_PRESETS.map((m) => (
-          <option key={m} value={m}>
-            {m} minutes
-          </option>
-        ))}
-      </datalist>
+      <div className="relative">
+        <Input
+          ref={inputRef}
+          id={id}
+          type="text"
+          inputMode="numeric"
+          role="combobox"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          aria-label="Duration in minutes"
+          value={value}
+          onChange={handleInputChange}
+          disabled={disabled}
+          className="pr-9"
+        />
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={disabled}
+              aria-label="Show duration presets"
+              className="absolute inset-y-0 right-0 flex items-center justify-center w-9 text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <ChevronDown className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-40 p-1">
+            <ul role="listbox" aria-label="Duration presets">
+              {DURATION_PRESETS.map((m) => (
+                <li key={m}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={value === m}
+                    onClick={() => handlePresetSelect(m)}
+                    className={cn(
+                      "w-full text-left px-2 py-1.5 text-sm rounded hover:bg-accent",
+                      value === m && "bg-accent/50 font-medium"
+                    )}
+                  >
+                    {m} minutes
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      </div>
       {error && <p className="text-sm text-destructive">{error}</p>}
     </>
   );

--- a/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import * as React from "react";
+import { Input } from "@/components/ui/input";
+import {
+  DURATION_PRESETS,
+  MAX_DURATION_MINUTES,
+  MIN_DURATION_MINUTES,
+} from "@/types/coaching-session-duration";
+
+const PRESETS_DATALIST_ID = "coaching-session-duration-presets";
+
+export interface CoachingSessionDurationInputProps {
+  value: number;
+  onChange: (minutes: number) => void;
+  disabled?: boolean;
+  id?: string;
+  error?: string | null;
+}
+
+export function CoachingSessionDurationInput({
+  value,
+  onChange,
+  disabled,
+  id,
+  error,
+}: CoachingSessionDurationInputProps) {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const next = parseInt(e.target.value, 10);
+    if (Number.isFinite(next)) {
+      onChange(next);
+    }
+  };
+
+  return (
+    <>
+      <Input
+        id={id}
+        type="number"
+        list={PRESETS_DATALIST_ID}
+        min={MIN_DURATION_MINUTES}
+        max={MAX_DURATION_MINUTES}
+        value={value}
+        onChange={handleChange}
+        disabled={disabled}
+        aria-label="Duration in minutes"
+      />
+      <datalist id={PRESETS_DATALIST_ID}>
+        {DURATION_PRESETS.map((m) => (
+          <option key={m} value={m}>
+            {m} minutes
+          </option>
+        ))}
+      </datalist>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </>
+  );
+}

--- a/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-duration-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import * as React from "react";
+import { useRef, useState } from "react";
+import type { ChangeEvent } from "react";
 import { ChevronDown } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -26,10 +27,10 @@ export function CoachingSessionDurationInput({
   id,
   error,
 }: CoachingSessionDurationInputProps) {
-  const [open, setOpen] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
     const next = parseInt(e.target.value, 10);
     if (Number.isFinite(next)) {
       onChange(next);

--- a/src/components/ui/dashboard/coaching-session-dialog.tsx
+++ b/src/components/ui/dashboard/coaching-session-dialog.tsx
@@ -9,6 +9,9 @@ import {
 import { cn } from "@/components/lib/utils";
 import CoachingSessionForm, { CoachingSessionFormMode } from "./coaching-session-form";
 import type { CoachingSession } from "@/types/coaching-session";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useUser } from "@/lib/api/users";
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 
 interface CoachingSessionDialogProps {
   open: boolean;
@@ -22,6 +25,10 @@ export function CoachingSessionDialog({
   coachingSessionToEdit,
 }: CoachingSessionDialogProps) {
   const mode: CoachingSessionFormMode = coachingSessionToEdit ? "update" : "create";
+  const { userId } = useAuthStore((state) => state);
+  const { user } = useUser(userId);
+  const defaultDurationMinutes =
+    user?.default_coaching_session_duration_minutes ?? FALLBACK_DURATION_MINUTES;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -40,6 +47,7 @@ export function CoachingSessionDialog({
           mode={mode}
           existingSession={coachingSessionToEdit}
           onOpenChange={onOpenChange}
+          defaultDurationMinutes={defaultDurationMinutes}
         />
       </DialogContent>
     </Dialog>

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -59,6 +59,11 @@ import {
   weekdayFromLuxon,
   weekdayLabel,
 } from "@/types/recurrence";
+import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
+import {
+  DurationErrorCode,
+  validateDurationMinutes,
+} from "@/types/coaching-session-duration";
 
 export type CoachingSessionFormMode = "create" | "update";
 
@@ -66,6 +71,7 @@ interface CoachingSessionFormProps {
   existingSession?: CoachingSession;
   mode: CoachingSessionFormMode;
   onOpenChange: (open: boolean) => void;
+  defaultDurationMinutes: number;
 }
 
 
@@ -73,6 +79,7 @@ export default function CoachingSessionForm({
   existingSession,
   mode,
   onOpenChange,
+  defaultDurationMinutes,
 }: CoachingSessionFormProps) {
   const { currentCoachingRelationshipId } = useCoachingRelationshipStateStore(
     (state) => state
@@ -130,6 +137,10 @@ export default function CoachingSessionForm({
     return localDateTime.toFormat("HH:mm");
   });
 
+  const [durationMinutes, setDurationMinutes] = useState<number>(
+    () => existingSession?.duration_minutes ?? defaultDurationMinutes
+  );
+
   // ── Recurrence state (create mode only) ─────────────────────────────
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<Frequency>(Frequency.Weekly);
@@ -186,6 +197,9 @@ export default function CoachingSessionForm({
   const resetForm = () => {
     setSessionDate(undefined);
     setSessionTime("");
+    setDurationMinutes(
+      existingSession?.duration_minutes ?? defaultDurationMinutes
+    );
     setSelectedRelationshipId(currentCoachingRelationshipId ?? "");
     setIsRecurring(false);
     setFrequency(Frequency.Weekly);
@@ -205,6 +219,7 @@ export default function CoachingSessionForm({
       ...defaultCoachingSession(),
       coaching_relationship_id: relationshipId,
       date: dateTime,
+      duration_minutes: durationMinutes,
       provider: activeProvider ? activeProvider as Provider : undefined
     };
     await createCoachingSession(newCoachingSession);
@@ -224,6 +239,7 @@ export default function CoachingSessionForm({
       coaching_relationship_id: relationshipId,
       start_at: dateTime,
       recurrence,
+      duration_minutes: durationMinutes,
     };
     const created = await CoachingSessionApi.createRecurring(payload);
     toast.success(
@@ -236,6 +252,7 @@ export default function CoachingSessionForm({
     await update(existingSession.id, {
       ...existingSession,
       date: dateTime,
+      duration_minutes: durationMinutes,
       updated_at: DateTime.now().toUTC(),
     });
   };
@@ -285,13 +302,21 @@ export default function CoachingSessionForm({
         toast.error("Your Google Meet integration has been disconnected. Please reconnect in Settings.");
         router.push("/settings/integrations");
       } else {
-        const message = error.isNetworkError()
-          ? "Could not connect to server. Please check your internet connection."
-          : error.status === 502
-            ? "Could not create Google Meet link due to a connection error. Please try again."
-            : error.status === 422
-              ? `Couldn't ${mode === "update" ? "update" : "create"} ${isRecurring ? "the recurring sessions" : "the session"}. Please review the form and try again.`
-              : `Failed to ${mode} coaching session. Please try again.`;
+        const errorData = error.data as { error?: string; message?: string } | null | undefined;
+        const isDurationValidationError =
+          error.status === 422 && errorData?.error === DurationErrorCode.ValidationError;
+        let message: string;
+        if (isDurationValidationError) {
+          message = errorData?.message ?? "Invalid duration.";
+        } else if (error.isNetworkError()) {
+          message = "Could not connect to server. Please check your internet connection.";
+        } else if (error.status === 502) {
+          message = "Could not create Google Meet link due to a connection error. Please try again.";
+        } else if (error.status === 422) {
+          message = `Couldn't ${mode === "update" ? "update" : "create"} ${isRecurring ? "the recurring sessions" : "the session"}. Please review the form and try again.`;
+        } else {
+          message = `Failed to ${mode} coaching session. Please try again.`;
+        }
         toast.error(message);
         console.error(`Failed to ${mode} coaching session:`, error);
       }
@@ -328,6 +353,8 @@ export default function CoachingSessionForm({
     userSession?.timezone,
   ]);
 
+  const durationError = validateDurationMinutes(durationMinutes);
+
   // Determine if form can be submitted
   const canSubmit = (() => {
     if (!sessionDate || !sessionTime || isSubmitting) return false;
@@ -336,6 +363,7 @@ export default function CoachingSessionForm({
       if (!relationshipId) return false;
     }
     if (recurrenceError) return false;
+    if (durationError) return false;
     return true;
   })();
 
@@ -388,17 +416,29 @@ export default function CoachingSessionForm({
             onSelect={(date) => setSessionDate(date)}
           />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="session-time">Session Time</Label>
-          <input
-            type="time"
-            id="session-time"
-            value={sessionTime}
-            onChange={(e) => setSessionTime(e.target.value)}
-            className="w-full border rounded p-2"
-            required
-            disabled={isSubmitting}
-          />
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="session-time">Session Time</Label>
+            <input
+              type="time"
+              id="session-time"
+              value={sessionTime}
+              onChange={(e) => setSessionTime(e.target.value)}
+              className="w-full border rounded p-2"
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="session-duration">Duration</Label>
+            <CoachingSessionDurationInput
+              id="session-duration"
+              value={durationMinutes}
+              onChange={setDurationMinutes}
+              disabled={isSubmitting}
+              error={durationError}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -141,6 +141,17 @@ export default function CoachingSessionForm({
     () => existingSession?.duration_minutes ?? defaultDurationMinutes
   );
 
+  // Sync with the coach's stored default once user data loads. Only in create
+  // mode — update mode pre-fills from the existing session, which doesn't
+  // change after mount. Without this, a cold-load dialog seeds the duration
+  // from FALLBACK_DURATION_MINUTES (60) before useUser resolves, and the
+  // coach's real default (e.g. 45) never makes it into the form state.
+  useEffect(() => {
+    if (mode === "create") {
+      setDurationMinutes(defaultDurationMinutes);
+    }
+  }, [defaultDurationMinutes, mode]);
+
   // ── Recurrence state (create mode only) ─────────────────────────────
   const [isRecurring, setIsRecurring] = useState(false);
   const [frequency, setFrequency] = useState<Frequency>(Frequency.Weekly);

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/types/recurrence";
 import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
 import {
-  DurationErrorCode,
+  isDurationValidationError,
   validateDurationMinutes,
 } from "@/types/coaching-session-duration";
 
@@ -302,12 +302,9 @@ export default function CoachingSessionForm({
         toast.error("Your Google Meet integration has been disconnected. Please reconnect in Settings.");
         router.push("/settings/integrations");
       } else {
-        const errorData = error.data as { error?: string; message?: string } | null | undefined;
-        const isDurationValidationError =
-          error.status === 422 && errorData?.error === DurationErrorCode.ValidationError;
         let message: string;
-        if (isDurationValidationError) {
-          message = errorData?.message ?? "Invalid duration.";
+        if (isDurationValidationError(error)) {
+          message = error.data.message;
         } else if (error.isNetworkError()) {
           message = "Could not connect to server. Please check your internet connection.";
         } else if (error.status === 502) {
@@ -353,7 +350,7 @@ export default function CoachingSessionForm({
     userSession?.timezone,
   ]);
 
-  const durationError = validateDurationMinutes(durationMinutes);
+  const durationValidation = validateDurationMinutes(durationMinutes);
 
   // Determine if form can be submitted
   const canSubmit = (() => {
@@ -363,7 +360,7 @@ export default function CoachingSessionForm({
       if (!relationshipId) return false;
     }
     if (recurrenceError) return false;
-    if (durationError) return false;
+    if (durationValidation.isErr()) return false;
     return true;
   })();
 
@@ -436,7 +433,7 @@ export default function CoachingSessionForm({
               value={durationMinutes}
               onChange={setDurationMinutes}
               disabled={isSubmitting}
-              error={durationError}
+              error={durationValidation.match(() => undefined, (msg) => msg)}
             />
           </div>
         </div>

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -36,7 +36,7 @@ import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { DateTime } from "ts-luxon";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
-import { useState, useMemo, useEffect, type FormEvent } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback, type FormEvent } from "react";
 import { useRouter } from "next/navigation";
 import { defaultCoachingSession } from "@/types/coaching-session";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
@@ -141,15 +141,24 @@ export default function CoachingSessionForm({
     () => existingSession?.duration_minutes ?? defaultDurationMinutes
   );
 
+  // Tracks whether the coach has manually edited the duration field this
+  // session. Set on any user-driven change; checked by the sync effect so
+  // that the cold-load default-load doesn't clobber deliberate edits.
+  const hasUserEditedDurationRef = useRef(false);
+
+  const handleDurationChange = useCallback((next: number) => {
+    hasUserEditedDurationRef.current = true;
+    setDurationMinutes(next);
+  }, []);
+
   // Sync with the coach's stored default once user data loads. Only in create
-  // mode — update mode pre-fills from the existing session, which doesn't
-  // change after mount. Without this, a cold-load dialog seeds the duration
-  // from FALLBACK_DURATION_MINUTES (60) before useUser resolves, and the
-  // coach's real default (e.g. 45) never makes it into the form state.
+  // mode (update mode pre-fills from the existing session), and only while the
+  // coach hasn't manually edited the field yet — otherwise a cold-load fetch
+  // resolving mid-edit would silently overwrite a deliberate value.
   useEffect(() => {
-    if (mode === "create") {
-      setDurationMinutes(defaultDurationMinutes);
-    }
+    if (mode !== "create") return;
+    if (hasUserEditedDurationRef.current) return;
+    setDurationMinutes(defaultDurationMinutes);
   }, [defaultDurationMinutes, mode]);
 
   // ── Recurrence state (create mode only) ─────────────────────────────
@@ -211,6 +220,7 @@ export default function CoachingSessionForm({
     setDurationMinutes(
       existingSession?.duration_minutes ?? defaultDurationMinutes
     );
+    hasUserEditedDurationRef.current = false;
     setSelectedRelationshipId(currentCoachingRelationshipId ?? "");
     setIsRecurring(false);
     setFrequency(Frequency.Weekly);
@@ -442,7 +452,7 @@ export default function CoachingSessionForm({
             <CoachingSessionDurationInput
               id="session-duration"
               value={durationMinutes}
-              onChange={setDurationMinutes}
+              onChange={handleDurationChange}
               disabled={isSubmitting}
               error={durationValidation.match(() => undefined, (msg) => msg)}
             />

--- a/src/components/ui/dashboard/coaching-sessions-hover-detail.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-hover-detail.tsx
@@ -45,7 +45,7 @@ export function SessionHoverDetail({
     zone: "utc",
   }).setZone(userTimezone);
   const scheduledPrefix = isPastSession(session) ? "Held" : "Scheduled for";
-  const scheduledLabel = `${scheduledPrefix} ${formatDateWithTime(scheduledDateTime, "·", true)}`;
+  const scheduledLabel = `${scheduledPrefix} ${formatDateWithTime(scheduledDateTime, "·", true)} · ${session.duration_minutes} min`;
 
   // Sections are siblings under the parent's `gap-4` (set by the wrapper in
   // `coaching-sessions-list-view.tsx`), matching the rhythm of

--- a/src/components/ui/dashboard/upcoming-session-card.tsx
+++ b/src/components/ui/dashboard/upcoming-session-card.tsx
@@ -25,7 +25,6 @@ import {
 import { getBrowserTimezone } from "@/lib/timezone-utils";
 import { userSessionFirstLastLettersToString } from "@/types/user-session";
 import {
-  DEFAULT_SESSION_DURATION_MINUTES,
   type EnrichedCoachingSession,
 } from "@/types/coaching-session";
 import { SessionUrgency } from "@/types/session-display";
@@ -223,6 +222,7 @@ function PopulatedBody({
       <HeaderRow
         participantName={participant.participantName}
         timeStr={timeStr}
+        durationMinutes={session.duration_minutes}
       />
 
       <ParticipantRow initials={initials} actionsDueCount={actionsDueCount} />
@@ -245,9 +245,11 @@ function PopulatedBody({
 function HeaderRow({
   participantName,
   timeStr,
+  durationMinutes,
 }: {
   participantName: string;
   timeStr: string;
+  durationMinutes: number;
 }) {
   return (
     <div className="flex items-start justify-between gap-4">
@@ -264,7 +266,7 @@ function HeaderRow({
           {timeStr}
         </span>
         <span className="text-[11px] text-muted-foreground/60 tabular-nums whitespace-nowrap">
-          {DEFAULT_SESSION_DURATION_MINUTES} min
+          {durationMinutes} min
         </span>
       </div>
     </div>

--- a/src/components/ui/members/profile-info-update-form.tsx
+++ b/src/components/ui/members/profile-info-update-form.tsx
@@ -32,6 +32,8 @@ export function ProfileInfoUpdateForm({
     last_name: user.last_name,
     display_name: user.display_name,
     timezone: user.timezone || getBrowserTimezone(),
+    default_coaching_session_duration_minutes:
+      user.default_coaching_session_duration_minutes,
     role: user.role,
     roles: user.roles,
     invite_status: user.invite_status,

--- a/src/components/ui/settings/coaching-preferences-section.tsx
+++ b/src/components/ui/settings/coaching-preferences-section.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+import type { FC } from "react";
+import { toast } from "sonner";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useUser, useUserMutation } from "@/lib/api/users";
+import {
+  FieldSet,
+  FieldGroup,
+  FieldLegend,
+  FieldDescription,
+  Field,
+  FieldLabel,
+  FieldContent,
+} from "@/components/kibo/ui/field";
+import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
+import {
+  FALLBACK_DURATION_MINUTES,
+  isDurationValidationError,
+  validateDurationMinutes,
+} from "@/types/coaching-session-duration";
+
+const AUTOSAVE_DEBOUNCE_MS = 400;
+
+export const CoachingPreferencesSection: FC = () => {
+  const { isACoach, userId } = useAuthStore((state) => state);
+  const { user, isLoading, refresh } = useUser(userId);
+  const { update } = useUserMutation();
+
+  const savedValue =
+    user?.default_coaching_session_duration_minutes ?? FALLBACK_DURATION_MINUTES;
+  const [durationMinutes, setDurationMinutes] =
+    React.useState<number>(savedValue);
+
+  React.useEffect(() => {
+    setDurationMinutes(savedValue);
+  }, [savedValue]);
+
+  const validationError = validateDurationMinutes(durationMinutes);
+  const isDirty = durationMinutes !== savedValue;
+
+  // Auto-save on value change, debounced so rapid edits (e.g. per-keystroke
+  // onChange from the custom numeric input) coalesce into a single PUT.
+  React.useEffect(() => {
+    if (!user || !isDirty || validationError !== null) return;
+    const timer = setTimeout(() => {
+      void (async () => {
+        try {
+          await update(userId, {
+            ...user,
+            default_coaching_session_duration_minutes: durationMinutes,
+          });
+          refresh();
+        } catch (error) {
+          if (isDurationValidationError(error)) {
+            toast.error(
+              (error.data as { message?: string }).message ??
+                "Invalid duration."
+            );
+          } else {
+            toast.error("Couldn't save preferences. Please try again.");
+          }
+        }
+      })();
+    }, AUTOSAVE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [
+    durationMinutes,
+    isDirty,
+    validationError,
+    user,
+    userId,
+    update,
+    refresh,
+  ]);
+
+  if (!isACoach) {
+    return null;
+  }
+
+  return (
+    <FieldSet>
+      <FieldGroup>
+        <FieldLegend>Default Coaching Session Duration</FieldLegend>
+        <FieldDescription>
+          Pre-fills the duration when you schedule a new coaching session.
+          You can override the duration for any individual session.
+        </FieldDescription>
+
+        <Field orientation="horizontal">
+          <FieldLabel htmlFor="default-duration">Default duration</FieldLabel>
+          <FieldContent>
+            <CoachingSessionDurationInput
+              id="default-duration"
+              value={durationMinutes}
+              onChange={setDurationMinutes}
+              disabled={isLoading}
+              error={isDirty ? validationError : null}
+            />
+          </FieldContent>
+        </Field>
+      </FieldGroup>
+    </FieldSet>
+  );
+};

--- a/src/components/ui/settings/coaching-preferences-section.tsx
+++ b/src/components/ui/settings/coaching-preferences-section.tsx
@@ -26,7 +26,7 @@ const AUTOSAVE_DEBOUNCE_MS = 400;
 export const CoachingPreferencesSection: FC = () => {
   const { isACoach, userId } = useAuthStore((state) => state);
   const { user, isLoading, refresh } = useUser(userId);
-  const { update } = useUserMutation();
+  const { update, isLoading: isSaving } = useUserMutation();
 
   const savedValue =
     user?.default_coaching_session_duration_minutes ?? FALLBACK_DURATION_MINUTES;
@@ -43,8 +43,10 @@ export const CoachingPreferencesSection: FC = () => {
 
   // Auto-save on value change, debounced so rapid edits (e.g. per-keystroke
   // onChange from the custom numeric input) coalesce into a single PUT.
+  // `isSaving` gates re-entry so an in-flight save doesn't trigger a second
+  // PUT when `update`'s identity changes mid-request and reruns the effect.
   useEffect(() => {
-    if (!user || !isDirty || !isValid) return;
+    if (!user || !isDirty || !isValid || isSaving) return;
     const timer = setTimeout(() => {
       void (async () => {
         try {
@@ -67,6 +69,7 @@ export const CoachingPreferencesSection: FC = () => {
     durationMinutes,
     isDirty,
     isValid,
+    isSaving,
     user,
     userId,
     update,

--- a/src/components/ui/settings/coaching-preferences-section.tsx
+++ b/src/components/ui/settings/coaching-preferences-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import * as React from "react";
+import { useEffect, useState } from "react";
 import type { FC } from "react";
 import { toast } from "sonner";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
@@ -31,9 +31,9 @@ export const CoachingPreferencesSection: FC = () => {
   const savedValue =
     user?.default_coaching_session_duration_minutes ?? FALLBACK_DURATION_MINUTES;
   const [durationMinutes, setDurationMinutes] =
-    React.useState<number>(savedValue);
+    useState<number>(savedValue);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setDurationMinutes(savedValue);
   }, [savedValue]);
 
@@ -42,7 +42,7 @@ export const CoachingPreferencesSection: FC = () => {
 
   // Auto-save on value change, debounced so rapid edits (e.g. per-keystroke
   // onChange from the custom numeric input) coalesce into a single PUT.
-  React.useEffect(() => {
+  useEffect(() => {
     if (!user || !isDirty || validationError !== null) return;
     const timer = setTimeout(() => {
       void (async () => {

--- a/src/components/ui/settings/coaching-preferences-section.tsx
+++ b/src/components/ui/settings/coaching-preferences-section.tsx
@@ -37,13 +37,14 @@ export const CoachingPreferencesSection: FC = () => {
     setDurationMinutes(savedValue);
   }, [savedValue]);
 
-  const validationError = validateDurationMinutes(durationMinutes);
+  const durationValidation = validateDurationMinutes(durationMinutes);
   const isDirty = durationMinutes !== savedValue;
+  const isValid = durationValidation.isOk();
 
   // Auto-save on value change, debounced so rapid edits (e.g. per-keystroke
   // onChange from the custom numeric input) coalesce into a single PUT.
   useEffect(() => {
-    if (!user || !isDirty || validationError !== null) return;
+    if (!user || !isDirty || !isValid) return;
     const timer = setTimeout(() => {
       void (async () => {
         try {
@@ -54,10 +55,7 @@ export const CoachingPreferencesSection: FC = () => {
           refresh();
         } catch (error) {
           if (isDurationValidationError(error)) {
-            toast.error(
-              (error.data as { message?: string }).message ??
-                "Invalid duration."
-            );
+            toast.error(error.data.message);
           } else {
             toast.error("Couldn't save preferences. Please try again.");
           }
@@ -68,7 +66,7 @@ export const CoachingPreferencesSection: FC = () => {
   }, [
     durationMinutes,
     isDirty,
-    validationError,
+    isValid,
     user,
     userId,
     update,
@@ -96,7 +94,11 @@ export const CoachingPreferencesSection: FC = () => {
               value={durationMinutes}
               onChange={setDurationMinutes}
               disabled={isLoading}
-              error={isDirty ? validationError : null}
+              error={
+                isDirty
+                  ? durationValidation.match(() => undefined, (msg) => msg)
+                  : undefined
+              }
             />
           </FieldContent>
         </Field>

--- a/src/components/ui/settings/settings-nav.tsx
+++ b/src/components/ui/settings/settings-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Puzzle, Video } from "lucide-react";
+import { Clock, Puzzle, Settings, Video } from "lucide-react";
 import { cn } from "@/components/lib/utils";
 
 import type { FC, ComponentType } from "react";
@@ -20,6 +20,13 @@ interface NavGroup {
 }
 
 const NAV_GROUPS: NavGroup[] = [
+  {
+    title: "Preferences",
+    icon: Settings,
+    children: [
+      { title: "Coaching Sessions", href: "/settings/preferences", icon: Clock },
+    ],
+  },
   {
     title: "Integrations",
     icon: Puzzle,

--- a/src/lib/utils/session.ts
+++ b/src/lib/utils/session.ts
@@ -4,7 +4,7 @@ import {
   CoachingSessionBucketDescriptor,
   CoachingSessionBucketKind,
 } from "@/types/coaching-session-bucket";
-import { CoachingSession, DEFAULT_SESSION_DURATION_MINUTES, EnrichedCoachingSession } from "@/types/coaching-session";
+import { CoachingSession, EnrichedCoachingSession } from "@/types/coaching-session";
 import { CoachingRelationshipWithUserNames } from "@/types/coaching-relationship";
 import { User } from "@/types/user";
 import { Id } from "@/types/general";
@@ -57,7 +57,7 @@ export function calculateSessionUrgency(
   const now = DateTime.now();
   // Parse session date as UTC (backend stores in UTC)
   const sessionTime = DateTime.fromISO(session.date, { zone: 'utc' });
-  const sessionEndTime = sessionTime.plus({ minutes: DEFAULT_SESSION_DURATION_MINUTES });
+  const sessionEndTime = sessionTime.plus({ minutes: session.duration_minutes });
   const minutesUntilSession = sessionTime.diff(now, "minutes").minutes;
   const minutesUntilEnd = sessionEndTime.diff(now, "minutes").minutes;
 
@@ -100,7 +100,7 @@ export function getUrgencyMessage(
 
   switch (urgency) {
     case SessionUrgency.Past: {
-      const sessionEndTimeUTC = sessionTimeUTC.plus({ minutes: DEFAULT_SESSION_DURATION_MINUTES });
+      const sessionEndTimeUTC = sessionTimeUTC.plus({ minutes: session.duration_minutes });
       const minutesSinceEnd = Math.abs(
         sessionEndTimeUTC.diff(now, "minutes").minutes
       );

--- a/src/types/coaching-session-duration.ts
+++ b/src/types/coaching-session-duration.ts
@@ -1,3 +1,4 @@
+import { Result, ok, err } from "neverthrow";
 import { EntityApiError } from "@/types/general";
 
 export const MIN_DURATION_MINUTES = 1;
@@ -10,38 +11,39 @@ export enum DurationErrorCode {
   ValidationError = "validation_error",
 }
 
-interface DurationErrorBody {
+export interface DurationErrorBody {
   status_code?: number;
-  error?: string;
-  message?: string;
+  error: DurationErrorCode.ValidationError;
+  message: string;
 }
 
-export function validateDurationMinutes(value: number): string | null {
+export function validateDurationMinutes(value: number): Result<number, string> {
   if (!Number.isFinite(value)) {
-    return "Duration must be a number.";
+    return err("Duration must be a number.");
   }
   if (!Number.isInteger(value)) {
-    return "Duration must be a whole number of minutes.";
+    return err("Duration must be a whole number of minutes.");
   }
   if (value < MIN_DURATION_MINUTES) {
-    return `Duration must be at least ${MIN_DURATION_MINUTES} minute.`;
+    return err(`Duration must be at least ${MIN_DURATION_MINUTES} minute.`);
   }
   if (value > MAX_DURATION_MINUTES) {
-    return `Duration must be at most ${MAX_DURATION_MINUTES} minutes.`;
+    return err(`Duration must be at most ${MAX_DURATION_MINUTES} minutes.`);
   }
-  return null;
+  return ok(value);
 }
 
 export function isDurationValidationError(
-  err: unknown
-): err is EntityApiError {
-  if (!(err instanceof EntityApiError) || err.status !== 422) {
+  error: unknown
+): error is EntityApiError & { data: DurationErrorBody } {
+  if (!(error instanceof EntityApiError) || error.status !== 422) {
     return false;
   }
-  const data = err.data as DurationErrorBody | null | undefined;
+  const data = error.data as Partial<DurationErrorBody> | null | undefined;
   return (
     !!data &&
     typeof data === "object" &&
-    data.error === DurationErrorCode.ValidationError
+    data.error === DurationErrorCode.ValidationError &&
+    typeof data.message === "string"
   );
 }

--- a/src/types/coaching-session-duration.ts
+++ b/src/types/coaching-session-duration.ts
@@ -1,0 +1,47 @@
+import { EntityApiError } from "@/types/general";
+
+export const MIN_DURATION_MINUTES = 1;
+export const MAX_DURATION_MINUTES = 480;
+export const FALLBACK_DURATION_MINUTES = 60;
+
+export const DURATION_PRESETS = [15, 30, 45, 60, 90, 120] as const;
+
+export enum DurationErrorCode {
+  ValidationError = "validation_error",
+}
+
+interface DurationErrorBody {
+  status_code?: number;
+  error?: string;
+  message?: string;
+}
+
+export function validateDurationMinutes(value: number): string | null {
+  if (!Number.isFinite(value)) {
+    return "Duration must be a number.";
+  }
+  if (!Number.isInteger(value)) {
+    return "Duration must be a whole number of minutes.";
+  }
+  if (value < MIN_DURATION_MINUTES) {
+    return `Duration must be at least ${MIN_DURATION_MINUTES} minute.`;
+  }
+  if (value > MAX_DURATION_MINUTES) {
+    return `Duration must be at most ${MAX_DURATION_MINUTES} minutes.`;
+  }
+  return null;
+}
+
+export function isDurationValidationError(
+  err: unknown
+): err is EntityApiError {
+  if (!(err instanceof EntityApiError) || err.status !== 422) {
+    return false;
+  }
+  const data = err.data as DurationErrorBody | null | undefined;
+  return (
+    !!data &&
+    typeof data === "object" &&
+    data.error === DurationErrorCode.ValidationError
+  );
+}

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -8,8 +8,9 @@ import { Goal } from "@/types/goal";
 import { Agreement } from "@/types/agreement";
 import { Provider } from "@/types/provider";
 /**
- * Default session duration in minutes (used until backend provides per-session duration).
- * TODO: replace this constant once full session duration has been implemented in the entire system.
+ * Fallback session duration in minutes, used when a CoachingSession is not
+ * available in the calling context. Concrete sessions carry their own
+ * `duration_minutes` and should be preferred.
  */
 export const DEFAULT_SESSION_DURATION_MINUTES = 60;
 
@@ -19,6 +20,7 @@ export interface CoachingSession {
   id: Id;
   coaching_relationship_id: Id;
   date: string;
+  duration_minutes: number;
   meeting_url?: string;
   provider?: Provider;
   created_at: DateTime;
@@ -79,6 +81,7 @@ export function isCoachingSession(value: unknown): value is CoachingSession {
     typeof object.id === "string" &&
     typeof object.coaching_relationship_id === "string" &&
     typeof object.date === "string" &&
+    typeof object.duration_minutes === "number" &&
     typeof object.created_at === "string" &&
     typeof object.updated_at === "string"
   );
@@ -141,6 +144,7 @@ export function defaultCoachingSession(): CoachingSession {
     id: "",
     coaching_relationship_id: "",
     date: "",
+    duration_minutes: DEFAULT_SESSION_DURATION_MINUTES,
     created_at: now,
     updated_at: now,
   };
@@ -166,7 +170,7 @@ export function coachingSessionsToString(
  * Returns true when the coaching session is considered "past."
  *
  * By default a session is past once the current time exceeds the session
- * start plus {@link DEFAULT_SESSION_DURATION_MINUTES}. Callers that need a
+ * start plus the session's own `duration_minutes`. Callers that need a
  * different boundary — for example end-of-day in the user's timezone — can
  * supply a custom `cutoff` DateTime that overrides the default calculation.
  *
@@ -183,7 +187,7 @@ export function isPastSession(
     return now > options.cutoff;
   }
   const sessionDate = DateTime.fromISO(session.date, { zone: 'utc' });
-  const sessionEnd = sessionDate.plus({ minutes: DEFAULT_SESSION_DURATION_MINUTES });
+  const sessionEnd = sessionDate.plus({ minutes: session.duration_minutes });
   return sessionEnd < now;
 }
 
@@ -201,7 +205,7 @@ export function isFutureSession(session: CoachingSession): boolean {
 
 export function isUnderwaySession(session: CoachingSession): boolean {
   const sessionStart = DateTime.fromISO(session.date, { zone: 'utc' });
-  const sessionEnd = sessionStart.plus({ minutes: DEFAULT_SESSION_DURATION_MINUTES });
+  const sessionEnd = sessionStart.plus({ minutes: session.duration_minutes });
   const now = DateTime.now();
   return now >= sessionStart && now < sessionEnd;
 }

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -7,12 +7,7 @@ import { Organization } from "@/types/organization";
 import { Goal } from "@/types/goal";
 import { Agreement } from "@/types/agreement";
 import { Provider } from "@/types/provider";
-/**
- * Fallback session duration in minutes, used when a CoachingSession is not
- * available in the calling context. Concrete sessions carry their own
- * `duration_minutes` and should be preferred.
- */
-export const DEFAULT_SESSION_DURATION_MINUTES = 60;
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 
 // This must always reflect the Rust struct on the backend
 // entity::coaching_sessions::Model
@@ -144,7 +139,7 @@ export function defaultCoachingSession(): CoachingSession {
     id: "",
     coaching_relationship_id: "",
     date: "",
-    duration_minutes: DEFAULT_SESSION_DURATION_MINUTES,
+    duration_minutes: FALLBACK_DURATION_MINUTES,
     created_at: now,
     updated_at: now,
   };

--- a/src/types/recurrence.ts
+++ b/src/types/recurrence.ts
@@ -112,6 +112,7 @@ export interface CreateRecurringSessionRequest {
   coaching_relationship_id: Id;
   start_at: string;
   recurrence: Recurrence;
+  duration_minutes?: number;
 }
 
 export function recurrenceToPayload(

--- a/src/types/user-session.ts
+++ b/src/types/user-session.ts
@@ -1,4 +1,5 @@
 import { User, Role } from "@/types/user";
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 
 /**
  * This is an intersection type that combines the User type with additional properties.
@@ -28,7 +29,7 @@ export function defaultUserSession(): UserSession {
     last_name: "",
     display_name: "",
     timezone: "UTC",
-    default_coaching_session_duration_minutes: 60,
+    default_coaching_session_duration_minutes: FALLBACK_DURATION_MINUTES,
     role: Role.User,
     roles: [],
     invite_status: null,

--- a/src/types/user-session.ts
+++ b/src/types/user-session.ts
@@ -28,6 +28,7 @@ export function defaultUserSession(): UserSession {
     last_name: "",
     display_name: "",
     timezone: "UTC",
+    default_coaching_session_duration_minutes: 60,
     role: Role.User,
     roles: [],
     invite_status: null,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,4 +1,5 @@
 import { Id } from "@/types/general";
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 
 /**
  * Represents a user role assignment within an organization or at the system level.
@@ -76,7 +77,7 @@ export function parseUser(data: unknown): User {
     display_name: data.display_name,
     timezone: data.timezone || "UTC",
     default_coaching_session_duration_minutes:
-      data.default_coaching_session_duration_minutes ?? 60,
+      data.default_coaching_session_duration_minutes ?? FALLBACK_DURATION_MINUTES,
     role: data.role,
     roles: data.roles,
     invite_status: data.invite_status,
@@ -108,7 +109,7 @@ export function defaultUser(): User {
     last_name: "",
     display_name: "",
     timezone: "UTC",
-    default_coaching_session_duration_minutes: 60,
+    default_coaching_session_duration_minutes: FALLBACK_DURATION_MINUTES,
     role: Role.User,
     roles: [],
     invite_status: null,

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -33,6 +33,7 @@ export interface User {
   last_name: string;
   display_name: string;
   timezone: string;
+  default_coaching_session_duration_minutes: number;
   /**
    * @deprecated Use roles array with getUserRoleForOrganization() instead
    */
@@ -74,6 +75,8 @@ export function parseUser(data: unknown): User {
     last_name: data.last_name,
     display_name: data.display_name,
     timezone: data.timezone || "UTC",
+    default_coaching_session_duration_minutes:
+      data.default_coaching_session_duration_minutes ?? 60,
     role: data.role,
     roles: data.roles,
     invite_status: data.invite_status,
@@ -105,6 +108,7 @@ export function defaultUser(): User {
     last_name: "",
     display_name: "",
     timezone: "UTC",
+    default_coaching_session_duration_minutes: 60,
     role: Role.User,
     roles: [],
     invite_status: null,


### PR DESCRIPTION
Closes #402. Pairs with backend `refactor-platform-rs#332` (`feat/coaching-session-duration`). Typed against `CoachingSessionDurationFeature` v2 on the coordination board.

## What this does

- New `/settings/preferences` page — coach-gated section to set the default coaching session duration. Debounced auto-save (400 ms), no Save button (BE supports partial updates).
- Duration input added to the schedule / reschedule / recurring coaching session dialogs, sitting next to Session Time. Single `<input type="number" list="presets">` backed by a `<datalist>` (15/30/45/60/90/120 min) — pick a preset or type any 1–480 value directly in the same field.
- Sends `duration_minutes` in `POST /coaching_sessions`, `POST /coaching_sessions/recurring`, and `PUT /coaching_sessions/{id}`. Pre-populated from `existingSession.duration_minutes` in update mode, otherwise from the coach's stored default (fallback 60).
- `422 validation_error` responses are surfaced verbatim via `error.data.message`.
- Cleanup: `DEFAULT_SESSION_DURATION_MINUTES` readers (`calculateSessionUrgency`, `getUrgencyMessage`, `upcoming-session-card`'s "X min" badge, `isPastSession`, `isUnderwaySession`) now read `session.duration_minutes`.

## Acceptance criteria (from #402) — all verified end-to-end against live BE

| # | AC | Evidence |
|---|---|---|
| 1 | Coach settings reads/writes `default_coaching_session_duration_minutes` | `PUT /users/{id}` 200, value persists |
| 2 | Schedule dialog → `POST /coaching_sessions` with `duration_minutes` | POST 201 with `45` (preset) and `75` (custom) |
| 3 | Reschedule pre-populated from existing value, sends `PUT` with new value | Pre-fills `60`, PUT 204 with `90` |
| 4 | Recurring sends one duration applied to entire series | POST 201 with 4 sessions, each `duration_minutes: 30` |
| 5 | Client-side 1–480 validation | `min="1"` `max="480"` on input; `validateDurationMinutes` unit-tested |
| 6 | `CoachingSession` and `User` types updated | Both gained the field; BE responses confirm on the wire |

## Test plan

- [ ] `npx tsc --noEmit` clean
- [ ] `npm test` — 1301 passing locally
- [ ] Coach: change duration in settings → debounced `PUT /users/{id}` after ~400 ms
- [ ] Coachee: settings section hidden
- [ ] Schedule dialog pre-fills from coach default; POST payload has `duration_minutes`
- [ ] Reschedule pre-fills from existing session; PUT payload has new value
- [ ] Recurring POST returns N sessions each with the same `duration_minutes`