### PR TITLE
Coachee keeps join button + live recording UI on camera

### DIFF
--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -65,9 +65,9 @@ describe("JoinMeetingButton — disabled (no meeting URL)", () => {
   });
 });
 
-// ── Idle (dropdown) state ────────────────────────────────────────────
+// ── Coach idle (dropdown) state ──────────────────────────────────────
 
-describe("JoinMeetingButton — idle dropdown", () => {
+describe("JoinMeetingButton — coach idle dropdown", () => {
   it("calls window.open synchronously BEFORE startRecording when 'Join with transcription' is clicked", async () => {
     const user = userEvent.setup();
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
@@ -127,40 +127,58 @@ describe("JoinMeetingButton — idle dropdown", () => {
   });
 });
 
-// ── Joining (in-progress, pre-live) state ─────────────────────────────
+// ── Coach joining (pre-live) state ───────────────────────────────────
 
 describe.each([
   MeetingRecordingStatus.Pending,
   MeetingRecordingStatus.Joining,
   MeetingRecordingStatus.WaitingRoom,
-])("JoinMeetingButton — joining (status=%s)", (status) => {
-  it("renders a disabled icon button with the joining-meeting accessible name", () => {
+])("JoinMeetingButton — coach joining (status=%s)", (status) => {
+  it("renders the camera dropdown with 'Open meeting' and no 'Stop transcription' item yet", async () => {
+    const user = userEvent.setup();
     recordingHookState.recording = { status };
+
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
-    const button = screen.getByRole("button", { name: /joining meeting/i });
-    expect(button).toBeDisabled();
+
+    const trigger = screen.getByRole("button", { name: /join meeting/i });
+    expect(trigger).not.toBeDisabled();
+
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    ).toBeInTheDocument();
+    // The bot is still joining — nothing to stop.
+    expect(
+      screen.queryByRole("menuitem", { name: /stop transcription/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("'Open meeting' opens the meeting URL", async () => {
+    const user = userEvent.setup();
+    recordingHookState.recording = { status };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      MEETING_URL,
+      "_blank",
+      "noopener,noreferrer"
+    );
   });
 });
 
-// ── Live state ────────────────────────────────────────────────────────
+// ── Coach live state ─────────────────────────────────────────────────
 
 describe.each([
   MeetingRecordingStatus.InMeeting,
   MeetingRecordingStatus.Recording,
-])("JoinMeetingButton — live (status=%s)", (status) => {
-  it("shows the Transcribing live pill with a duration timer", () => {
-    const startedAt = new Date(Date.now() - 65_000).toISOString();
-    recordingHookState.recording = { status, started_at: startedAt };
-
-    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
-    expect(
-      screen.getByRole("button", { name: /stop transcription/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText(/transcribing/i)).toBeInTheDocument();
-    expect(screen.getByText(/1:05/)).toBeInTheDocument();
-  });
-
-  it("opens the AlertDialog on click; confirming calls stopRecording", async () => {
+])("JoinMeetingButton — coach live (status=%s)", (status) => {
+  it("exposes 'Open meeting' and 'Stop transcription' items under the camera dropdown", async () => {
     const user = userEvent.setup();
     recordingHookState.recording = {
       status,
@@ -168,8 +186,27 @@ describe.each([
     };
 
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /stop transcription/i })
+    ).toBeInTheDocument();
+  });
+
+  it("selecting 'Stop transcription' opens the AlertDialog; confirming calls stopRecording", async () => {
+    const user = userEvent.setup();
+    recordingHookState.recording = {
+      status,
+      started_at: new Date().toISOString(),
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
     await user.click(
-      screen.getByRole("button", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop transcription/i })
     );
 
     const confirm = await screen.findByRole("button", {
@@ -188,8 +225,9 @@ describe.each([
     };
 
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
     await user.click(
-      screen.getByRole("button", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop transcription/i })
     );
 
     const cancel = await screen.findByRole("button", {
@@ -201,18 +239,28 @@ describe.each([
   });
 });
 
-// ── Processing state ─────────────────────────────────────────────────
+// ── Coach processing state ───────────────────────────────────────────
 
-describe("JoinMeetingButton — processing", () => {
-  it("renders a disabled icon button with the processing accessible name", () => {
+describe("JoinMeetingButton — coach processing", () => {
+  it("renders the camera dropdown with only 'Open meeting' (recording is done)", async () => {
+    const user = userEvent.setup();
     recordingHookState.recording = {
       status: MeetingRecordingStatus.Processing,
     };
+
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
-    const button = screen.getByRole("button", {
-      name: /processing transcription/i,
-    });
-    expect(button).toBeDisabled();
+
+    const trigger = screen.getByRole("button", { name: /join meeting/i });
+    expect(trigger).not.toBeDisabled();
+
+    await user.click(trigger);
+
+    expect(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /stop transcription/i })
+    ).not.toBeInTheDocument();
   });
 });
 
@@ -221,7 +269,7 @@ describe("JoinMeetingButton — processing", () => {
 describe.each([
   MeetingRecordingStatus.Completed,
   MeetingRecordingStatus.Failed,
-])("JoinMeetingButton — terminal (status=%s) returns to idle", (status) => {
+])("JoinMeetingButton — coach terminal (status=%s) returns to idle", (status) => {
   it("renders the Join Meeting dropdown trigger", () => {
     recordingHookState.recording = { status };
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
@@ -239,9 +287,13 @@ describe.each([
 //   (1) start a recording (consent ownership)
 //   (2) stop a recording (lifecycle ownership)
 //   (3) silently disable transcription mid-session
+// The coachee must ALWAYS be able to:
+//   (4) open the meeting URL — regardless of recording status (#404)
 //
 // These tests guard those invariants at the component boundary so a
-// future refactor can't accidentally regress consent semantics.
+// future refactor can't accidentally regress consent semantics or
+// re-introduce the bug where the coachee lost their join button once
+// the coach started recording.
 // ─────────────────────────────────────────────────────────────────────
 
 describe("JoinMeetingButton — coachee idle", () => {
@@ -332,96 +384,84 @@ describe("JoinMeetingButton — coachee idle", () => {
   });
 });
 
-describe("JoinMeetingButton — coachee live (transparency, no controls)", () => {
-  it("renders the pulsing Transcribing pill so the coachee sees it's being recorded", () => {
-    recordingHookState.recording = {
-      status: MeetingRecordingStatus.Recording,
-      started_at: new Date(Date.now() - 65_000).toISOString(),
-    };
-    render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-    expect(screen.getByText(/transcribing/i)).toBeInTheDocument();
-    expect(screen.getByText(/1:05/)).toBeInTheDocument();
-  });
-
-  it("the live pill carries a non-interactive accessible name and aria-disabled", () => {
-    recordingHookState.recording = {
-      status: MeetingRecordingStatus.Recording,
-      started_at: new Date().toISOString(),
-    };
-    render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-    const pill = screen.getByRole("button", {
-      name: /transcription in progress/i,
-    });
-    expect(pill).toHaveAttribute("aria-disabled", "true");
-    // The coach's pill is named "Stop transcription"; a coachee with that
-    // accessible name would be a regression we must catch.
-    expect(
-      screen.queryByRole("button", { name: /stop transcription/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it("INVARIANT: clicking the coachee live pill does NOT open the stop-confirm AlertDialog", async () => {
-    const user = userEvent.setup();
-    recordingHookState.recording = {
-      status: MeetingRecordingStatus.Recording,
-      started_at: new Date().toISOString(),
-    };
-    render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-
-    await user.click(
-      screen.getByRole("button", { name: /transcription in progress/i })
-    );
-
-    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/stop transcription\?/i)
-    ).not.toBeInTheDocument();
-  });
-
-  it("INVARIANT: coachee can NEVER call stopRecording, even via repeated clicks", async () => {
-    const user = userEvent.setup();
-    recordingHookState.recording = {
-      status: MeetingRecordingStatus.Recording,
-      started_at: new Date().toISOString(),
-    };
-    render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-    const pill = screen.getByRole("button", {
-      name: /transcription in progress/i,
+// Regression tests for #404 — the coachee must keep their join button
+// across every non-disabled recording status. Pre-fix, statuses other
+// than idle replaced the camera button with a transcription pill.
+describe.each([
+  MeetingRecordingStatus.Pending,
+  MeetingRecordingStatus.Joining,
+  MeetingRecordingStatus.WaitingRoom,
+  MeetingRecordingStatus.InMeeting,
+  MeetingRecordingStatus.Recording,
+  MeetingRecordingStatus.Processing,
+])(
+  "JoinMeetingButton — coachee non-idle (status=%s) — issue #404 regression",
+  (status) => {
+    it("still renders the plain camera join button", () => {
+      recordingHookState.recording = {
+        status,
+        started_at: new Date().toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+      const button = screen.getByRole("button", { name: /join meeting/i });
+      expect(button).not.toBeDisabled();
+      expect(button).not.toHaveAttribute("aria-haspopup", "menu");
     });
 
-    await user.click(pill);
-    await user.click(pill);
-    await user.click(pill);
+    it("does NOT render a 'Transcribing' pill or 'Transcription in progress' affordance", () => {
+      recordingHookState.recording = {
+        status,
+        started_at: new Date().toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+      expect(screen.queryByText(/transcribing/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /transcription in progress/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /stop transcription/i })
+      ).not.toBeInTheDocument();
+    });
 
-    expect(stopRecording).not.toHaveBeenCalled();
-  });
-});
+    it("INVARIANT: clicking the coachee button NEVER calls stopRecording or startRecording", async () => {
+      const user = userEvent.setup();
+      recordingHookState.recording = {
+        status,
+        started_at: new Date().toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+      await user.click(screen.getByRole("button", { name: /join meeting/i }));
 
-describe("JoinMeetingButton — role-agnostic states", () => {
+      expect(stopRecording).not.toHaveBeenCalled();
+      expect(startRecording).not.toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalledWith(
+        MEETING_URL,
+        "_blank",
+        "noopener,noreferrer"
+      );
+    });
+  }
+);
+
+describe("JoinMeetingButton — role-agnostic disabled state", () => {
   it("disabled (no meeting URL) state is identical for coach and coachee", () => {
     const { rerender } = render(
       <JoinMeetingButton
@@ -448,62 +488,77 @@ describe("JoinMeetingButton — role-agnostic states", () => {
       screen.getByRole("button", { name: /join meeting/i })
     ).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: /join meeting/i }).getAttribute(
-        "aria-label"
-      )
+      screen
+        .getByRole("button", { name: /join meeting/i })
+        .getAttribute("aria-label")
     ).toBe(coachLabel);
   });
+});
 
-  it("joining state renders identically regardless of role", () => {
-    recordingHookState.recording = { status: MeetingRecordingStatus.Joining };
-    const { rerender } = render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={true}
-      />
-    );
-    expect(
-      screen.getByRole("button", { name: /joining meeting/i })
-    ).toBeDisabled();
+// Red pulsing dot lives on the camera/join button while the bot is in
+// the meeting (InMeeting or Recording) — matches what the BE actually
+// emits during a live session; bots commonly sit on InMeeting without
+// ever transitioning to a literal Recording status.
+describe("JoinMeetingButton — recording dot on camera icon", () => {
+  const RECORDING_DOT = "join-meeting-recording-dot";
 
-    rerender(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-    expect(
-      screen.getByRole("button", { name: /joining meeting/i })
-    ).toBeDisabled();
+  it.each([
+    MeetingRecordingStatus.InMeeting,
+    MeetingRecordingStatus.Recording,
+  ])("renders a red pulsing dot for the coach during status=%s", (status) => {
+    recordingHookState.recording = {
+      status,
+      started_at: new Date().toISOString(),
+    };
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    const dot = screen.getByTestId(RECORDING_DOT);
+    expect(dot.className).toContain("bg-red-500");
+    expect(dot.className).toContain("motion-safe:animate-pulse");
   });
 
-  it("processing state renders identically regardless of role", () => {
+  it.each([
+    MeetingRecordingStatus.InMeeting,
+    MeetingRecordingStatus.Recording,
+  ])("renders a red pulsing dot for the coachee during status=%s (transparency)", (status) => {
     recordingHookState.recording = {
-      status: MeetingRecordingStatus.Processing,
+      status,
+      started_at: new Date().toISOString(),
     };
-    const { rerender } = render(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={true}
-      />
-    );
-    expect(
-      screen.getByRole("button", { name: /processing transcription/i })
-    ).toBeDisabled();
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={false} />);
+    const dot = screen.getByTestId(RECORDING_DOT);
+    expect(dot.className).toContain("bg-red-500");
+    expect(dot.className).toContain("motion-safe:animate-pulse");
+  });
 
-    rerender(
-      <JoinMeetingButton
-        sessionId="s-1"
-        meetingUrl={MEETING_URL}
-        isCoach={false}
-      />
-    );
-    expect(
-      screen.getByRole("button", { name: /processing transcription/i })
-    ).toBeDisabled();
+  it.each([
+    MeetingRecordingStatus.Pending,
+    MeetingRecordingStatus.Joining,
+    MeetingRecordingStatus.WaitingRoom,
+    MeetingRecordingStatus.Processing,
+    MeetingRecordingStatus.Completed,
+    MeetingRecordingStatus.Failed,
+  ])("does NOT render the dot for status=%s (coach)", (status) => {
+    recordingHookState.recording = { status };
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    expect(screen.queryByTestId(RECORDING_DOT)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    MeetingRecordingStatus.Pending,
+    MeetingRecordingStatus.Joining,
+    MeetingRecordingStatus.WaitingRoom,
+    MeetingRecordingStatus.Processing,
+    MeetingRecordingStatus.Completed,
+    MeetingRecordingStatus.Failed,
+  ])("does NOT render the dot for status=%s (coachee)", (status) => {
+    recordingHookState.recording = { status };
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={false} />);
+    expect(screen.queryByTestId(RECORDING_DOT)).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the dot when idle (no recording)", () => {
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    expect(screen.queryByTestId(RECORDING_DOT)).not.toBeInTheDocument();
   });
 });
 
@@ -522,9 +577,11 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
         isCoach={true}
       />
     );
-    // Coach can stop.
+
+    // Coach: dropdown trigger present; opening it reveals the stop item.
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
     expect(
-      screen.getByRole("button", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop transcription/i })
     ).toBeInTheDocument();
 
     // Role flips to coachee (e.g., role hook re-derives mid-session).
@@ -536,15 +593,12 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
       />
     );
 
-    expect(
-      screen.queryByRole("button", { name: /stop transcription/i })
-    ).not.toBeInTheDocument();
+    // Coachee: plain icon, no menu items, no stop affordance.
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+    const button = screen.getByRole("button", { name: /join meeting/i });
+    expect(button).not.toHaveAttribute("aria-haspopup", "menu");
 
-    // Clicking the now-coachee pill must not trigger stop.
-    const pill = screen.getByRole("button", {
-      name: /transcription in progress/i,
-    });
-    await user.click(pill);
+    await user.click(button);
     expect(stopRecording).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -266,7 +266,7 @@ describe.each([
   MeetingRecordingStatus.Joining,
   MeetingRecordingStatus.WaitingRoom,
 ])("JoinMeetingButton — coach joining (status=%s)", (status) => {
-  it("renders the camera dropdown with 'Open meeting' and no 'Stop transcription' item yet", async () => {
+  it("renders the camera dropdown with 'Open meeting' and no 'stop recording' item yet", async () => {
     const user = userEvent.setup();
     recordingHookState.recording = { status };
 
@@ -282,7 +282,7 @@ describe.each([
     ).toBeInTheDocument();
     // The bot is still joining — nothing to stop.
     expect(
-      screen.queryByRole("menuitem", { name: /stop transcription/i })
+      screen.queryByRole("menuitem", { name: /stop recording/i })
     ).not.toBeInTheDocument();
   });
 
@@ -310,7 +310,7 @@ describe.each([
   MeetingRecordingStatus.InMeeting,
   MeetingRecordingStatus.Recording,
 ])("JoinMeetingButton — coach live (status=%s)", (status) => {
-  it("exposes elapsed-time label, 'Open meeting', and 'Stop transcription' items", async () => {
+  it("exposes elapsed-time label, 'Open meeting', and 'stop recording' items", async () => {
     const user = userEvent.setup();
     recordingHookState.recording = {
       status,
@@ -327,7 +327,7 @@ describe.each([
       await screen.findByRole("menuitem", { name: /open meeting/i })
     ).toBeInTheDocument();
     expect(
-      await screen.findByRole("menuitem", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop recording/i })
     ).toBeInTheDocument();
   });
 
@@ -363,7 +363,7 @@ describe.each([
     ).toBeTruthy();
   });
 
-  it("selecting 'Stop transcription' opens the AlertDialog; confirming calls stopRecording", async () => {
+  it("selecting 'stop recording' opens the AlertDialog; confirming calls stopRecording", async () => {
     const user = userEvent.setup();
     recordingHookState.recording = {
       status,
@@ -373,11 +373,11 @@ describe.each([
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
     await user.click(screen.getByRole("button", { name: /join meeting/i }));
     await user.click(
-      await screen.findByRole("menuitem", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop recording/i })
     );
 
     const confirm = await screen.findByRole("button", {
-      name: /^stop transcription$/i,
+      name: /^stop recording$/i,
     });
     await user.click(confirm);
 
@@ -394,11 +394,11 @@ describe.each([
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
     await user.click(screen.getByRole("button", { name: /join meeting/i }));
     await user.click(
-      await screen.findByRole("menuitem", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop recording/i })
     );
 
     const cancel = await screen.findByRole("button", {
-      name: /keep transcribing/i,
+      name: /keep recording/i,
     });
     await user.click(cancel);
 
@@ -426,7 +426,7 @@ describe("JoinMeetingButton — coach processing", () => {
       await screen.findByRole("menuitem", { name: /open meeting/i })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("menuitem", { name: /stop transcription/i })
+      screen.queryByRole("menuitem", { name: /stop recording/i })
     ).not.toBeInTheDocument();
   });
 });
@@ -436,6 +436,7 @@ describe("JoinMeetingButton — coach processing", () => {
 describe.each([
   MeetingRecordingStatus.Completed,
   MeetingRecordingStatus.Failed,
+  MeetingRecordingStatus.Cancelled,
 ])("JoinMeetingButton — coach terminal (status=%s) returns to idle", (status) => {
   it("renders the Join Meeting dropdown trigger", () => {
     recordingHookState.recording = { status };
@@ -620,7 +621,7 @@ describe.each([
         screen.queryByRole("button", { name: /transcription in progress/i })
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /stop transcription/i })
+        screen.queryByRole("button", { name: /stop recording/i })
       ).not.toBeInTheDocument();
     });
   }
@@ -764,6 +765,7 @@ describe("JoinMeetingButton — recording dot on camera icon", () => {
     MeetingRecordingStatus.Processing,
     MeetingRecordingStatus.Completed,
     MeetingRecordingStatus.Failed,
+    MeetingRecordingStatus.Cancelled,
   ])("does NOT render the dot for status=%s (coach)", (status) => {
     recordingHookState.recording = { status };
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
@@ -777,6 +779,7 @@ describe("JoinMeetingButton — recording dot on camera icon", () => {
     MeetingRecordingStatus.Processing,
     MeetingRecordingStatus.Completed,
     MeetingRecordingStatus.Failed,
+    MeetingRecordingStatus.Cancelled,
   ])("does NOT render the dot for status=%s (coachee)", (status) => {
     recordingHookState.recording = { status };
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={false} />);
@@ -808,7 +811,7 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
     // Coach: dropdown trigger present; opening it reveals the stop item.
     await user.click(screen.getByRole("button", { name: /join meeting/i }));
     expect(
-      await screen.findByRole("menuitem", { name: /stop transcription/i })
+      await screen.findByRole("menuitem", { name: /stop recording/i })
     ).toBeInTheDocument();
     // Close the menu so the rerender swaps a clean closed dropdown in.
     await user.keyboard("{Escape}");

--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -4,10 +4,15 @@ import userEvent from "@testing-library/user-event";
 
 import { JoinMeetingButton } from "@/components/ui/coaching-sessions/join-meeting-button";
 import { MeetingRecordingStatus } from "@/types/meeting-recording";
+import { TranscriptionStatus } from "@/types/transcription";
 
 const recordingHookState: {
   recording: { status: MeetingRecordingStatus; started_at?: string } | null;
 } = { recording: null };
+
+const transcriptionHookState: {
+  transcription: { id: string; status: TranscriptionStatus } | null;
+} = { transcription: null };
 
 const startRecording = vi.fn(() => Promise.resolve({}));
 const stopRecording = vi.fn(() => Promise.resolve({}));
@@ -17,6 +22,12 @@ vi.mock("@/lib/api/meeting-recordings", () => ({
     recording: recordingHookState.recording,
     startRecording,
     stopRecording,
+  }),
+}));
+
+vi.mock("@/lib/api/transcriptions", () => ({
+  useTranscription: () => ({
+    transcription: transcriptionHookState.transcription,
   }),
 }));
 
@@ -34,6 +45,7 @@ let openSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   recordingHookState.recording = null;
+  transcriptionHookState.transcription = null;
   startRecording.mockClear();
   stopRecording.mockClear();
   toastError.mockClear();
@@ -124,6 +136,126 @@ describe("JoinMeetingButton — coach idle dropdown", () => {
 
     expect(toastError).toHaveBeenCalledTimes(1);
     expect(toastError.mock.calls[0][0]).toMatch(/couldn't start transcription/i);
+  });
+});
+
+// ── Coach idle + existing transcription: replacement confirmation ────
+
+describe("JoinMeetingButton — coach idle, existing transcription on the session", () => {
+  it("'Join with transcription' opens a replacement confirmation dialog instead of firing the API", async () => {
+    const user = userEvent.setup();
+    transcriptionHookState.transcription = {
+      id: "t-1",
+      status: TranscriptionStatus.Completed,
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /join with transcription/i })
+    );
+
+    expect(
+      await screen.findByText(/replace existing transcription/i)
+    ).toBeInTheDocument();
+    // Crucially, neither side-effect fires before the user confirms.
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(startRecording).not.toHaveBeenCalled();
+  });
+
+  it("confirming the replacement dialog fires window.open and startRecording (same as the no-transcription path)", async () => {
+    const user = userEvent.setup();
+    transcriptionHookState.transcription = {
+      id: "t-1",
+      status: TranscriptionStatus.Completed,
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /join with transcription/i })
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /replace transcription/i })
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      MEETING_URL,
+      "_blank",
+      "noopener,noreferrer"
+    );
+    expect(startRecording).toHaveBeenCalledWith(MEETING_URL);
+    const openOrder = openSpy.mock.invocationCallOrder[0];
+    const startOrder = startRecording.mock.invocationCallOrder[0];
+    expect(openOrder).toBeLessThan(startOrder);
+  });
+
+  it("cancelling the replacement dialog does NOT call window.open or startRecording", async () => {
+    const user = userEvent.setup();
+    transcriptionHookState.transcription = {
+      id: "t-1",
+      status: TranscriptionStatus.Completed,
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /join with transcription/i })
+    );
+
+    await user.click(
+      await screen.findByRole("button", { name: /keep existing transcript/i })
+    );
+
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(startRecording).not.toHaveBeenCalled();
+  });
+
+  it("'Join WITHOUT transcription' bypasses the confirmation dialog (only the transcribing path is gated)", async () => {
+    const user = userEvent.setup();
+    transcriptionHookState.transcription = {
+      id: "t-1",
+      status: TranscriptionStatus.Completed,
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: /join without transcription/i,
+      })
+    );
+
+    expect(
+      screen.queryByText(/replace existing transcription/i)
+    ).not.toBeInTheDocument();
+    expect(openSpy).toHaveBeenCalledWith(
+      MEETING_URL,
+      "_blank",
+      "noopener,noreferrer"
+    );
+    expect(startRecording).not.toHaveBeenCalled();
+  });
+
+  it("a Failed transcription is NOT treated as an existing transcription — no confirmation prompt", async () => {
+    const user = userEvent.setup();
+    transcriptionHookState.transcription = {
+      id: "t-1",
+      status: TranscriptionStatus.Failed,
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    await user.click(
+      await screen.findByRole("menuitem", { name: /join with transcription/i })
+    );
+
+    expect(
+      screen.queryByText(/replace existing transcription/i)
+    ).not.toBeInTheDocument();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(startRecording).toHaveBeenCalledWith(MEETING_URL);
   });
 });
 

--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -178,7 +178,40 @@ describe.each([
   MeetingRecordingStatus.InMeeting,
   MeetingRecordingStatus.Recording,
 ])("JoinMeetingButton — coach live (status=%s)", (status) => {
-  it("exposes 'Open meeting' and 'Stop transcription' items under the camera dropdown", async () => {
+  it("exposes elapsed-time label, 'Open meeting', and 'Stop transcription' items", async () => {
+    const user = userEvent.setup();
+    recordingHookState.recording = {
+      status,
+      started_at: new Date(Date.now() - 65_000).toISOString(),
+    };
+
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+
+    const label = await screen.findByTestId("join-meeting-elapsed-label");
+    expect(label).toHaveTextContent(/recording/i);
+    expect(label).toHaveTextContent(/1:05/);
+    expect(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitem", { name: /stop transcription/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders the label without a timer when started_at is absent (bot in InMeeting before BE sets started_at)", async () => {
+    const user = userEvent.setup();
+    recordingHookState.recording = { status };
+    render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+
+    const label = await screen.findByTestId("join-meeting-elapsed-label");
+    expect(label).toHaveTextContent(/recording/i);
+    // No m:ss text — only the "Recording" word and the glyph.
+    expect(label.textContent).not.toMatch(/\d+:\d{2}/);
+  });
+
+  it("the elapsed-time label is the FIRST entry in the dropdown (above 'Open meeting')", async () => {
     const user = userEvent.setup();
     recordingHookState.recording = {
       status,
@@ -188,12 +221,14 @@ describe.each([
     render(<JoinMeetingButton sessionId="s-1" meetingUrl={MEETING_URL} isCoach={true} />);
     await user.click(screen.getByRole("button", { name: /join meeting/i }));
 
+    const label = await screen.findByTestId("join-meeting-elapsed-label");
+    const openItem = await screen.findByRole("menuitem", {
+      name: /open meeting/i,
+    });
     expect(
-      await screen.findByRole("menuitem", { name: /open meeting/i })
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByRole("menuitem", { name: /stop transcription/i })
-    ).toBeInTheDocument();
+      label.compareDocumentPosition(openItem) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
   });
 
   it("selecting 'Stop transcription' opens the AlertDialog; confirming calls stopRecording", async () => {
@@ -384,20 +419,18 @@ describe("JoinMeetingButton — coachee idle", () => {
   });
 });
 
-// Regression tests for #404 — the coachee must keep their join button
-// across every non-disabled recording status. Pre-fix, statuses other
-// than idle replaced the camera button with a transcription pill.
+// #404 regression — coachee in non-live, non-idle states (Pending /
+// Joining / WaitingRoom / Processing): plain icon, single click opens
+// the URL. No dropdown (no elapsed time to show yet, no recording).
 describe.each([
   MeetingRecordingStatus.Pending,
   MeetingRecordingStatus.Joining,
   MeetingRecordingStatus.WaitingRoom,
-  MeetingRecordingStatus.InMeeting,
-  MeetingRecordingStatus.Recording,
   MeetingRecordingStatus.Processing,
 ])(
-  "JoinMeetingButton — coachee non-idle (status=%s) — issue #404 regression",
+  "JoinMeetingButton — coachee pre/post-live (status=%s) — issue #404 regression",
   (status) => {
-    it("still renders the plain camera join button", () => {
+    it("renders the plain camera join button (no chevron)", () => {
       recordingHookState.recording = {
         status,
         started_at: new Date().toISOString(),
@@ -414,7 +447,31 @@ describe.each([
       expect(button).not.toHaveAttribute("aria-haspopup", "menu");
     });
 
-    it("does NOT render a 'Transcribing' pill or 'Transcription in progress' affordance", () => {
+    it("single click opens the meeting URL — no startRecording / stopRecording", async () => {
+      const user = userEvent.setup();
+      recordingHookState.recording = {
+        status,
+        started_at: new Date().toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+      await user.click(screen.getByRole("button", { name: /join meeting/i }));
+
+      expect(openSpy).toHaveBeenCalledWith(
+        MEETING_URL,
+        "_blank",
+        "noopener,noreferrer"
+      );
+      expect(startRecording).not.toHaveBeenCalled();
+      expect(stopRecording).not.toHaveBeenCalled();
+    });
+
+    it("does NOT render legacy 'Transcribing' / 'Transcription in progress' affordance", () => {
       recordingHookState.recording = {
         status,
         started_at: new Date().toISOString(),
@@ -434,8 +491,50 @@ describe.each([
         screen.queryByRole("button", { name: /stop transcription/i })
       ).not.toBeInTheDocument();
     });
+  }
+);
 
-    it("INVARIANT: clicking the coachee button NEVER calls stopRecording or startRecording", async () => {
+// #404 regression — coachee in LIVE states (InMeeting / Recording):
+// dropdown surfaces the elapsed-time label + an "Open meeting" item.
+// Coachee still can never start / stop a recording.
+describe.each([
+  MeetingRecordingStatus.InMeeting,
+  MeetingRecordingStatus.Recording,
+])(
+  "JoinMeetingButton — coachee live (status=%s) — elapsed time + open meeting",
+  (status) => {
+    it("exposes the elapsed-time label and 'Open meeting' item; NO 'Stop transcription'", async () => {
+      const user = userEvent.setup();
+      recordingHookState.recording = {
+        status,
+        started_at: new Date(Date.now() - 65_000).toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /join meeting/i }));
+
+      const label = await screen.findByTestId("join-meeting-elapsed-label");
+      expect(label).toHaveTextContent(/recording/i);
+      expect(label).toHaveTextContent(/1:05/);
+
+      expect(
+        await screen.findByRole("menuitem", { name: /open meeting/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("menuitem", { name: /stop transcription/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/join with transcription/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("the elapsed-time label is the FIRST entry in the dropdown", async () => {
       const user = userEvent.setup();
       recordingHookState.recording = {
         status,
@@ -450,13 +549,43 @@ describe.each([
       );
       await user.click(screen.getByRole("button", { name: /join meeting/i }));
 
-      expect(stopRecording).not.toHaveBeenCalled();
-      expect(startRecording).not.toHaveBeenCalled();
+      const label = await screen.findByTestId("join-meeting-elapsed-label");
+      const openItem = await screen.findByRole("menuitem", {
+        name: /open meeting/i,
+      });
+      // Document order: label appears before the menu item.
+      expect(
+        label.compareDocumentPosition(openItem) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it("'Open meeting' menuitem opens the URL — and never calls startRecording / stopRecording", async () => {
+      const user = userEvent.setup();
+      recordingHookState.recording = {
+        status,
+        started_at: new Date().toISOString(),
+      };
+      render(
+        <JoinMeetingButton
+          sessionId="s-1"
+          meetingUrl={MEETING_URL}
+          isCoach={false}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /join meeting/i }));
+      await user.click(
+        await screen.findByRole("menuitem", { name: /open meeting/i })
+      );
+
       expect(openSpy).toHaveBeenCalledWith(
         MEETING_URL,
         "_blank",
         "noopener,noreferrer"
       );
+      expect(startRecording).not.toHaveBeenCalled();
+      expect(stopRecording).not.toHaveBeenCalled();
     });
   }
 );
@@ -583,6 +712,8 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
     expect(
       await screen.findByRole("menuitem", { name: /stop transcription/i })
     ).toBeInTheDocument();
+    // Close the menu so the rerender swaps a clean closed dropdown in.
+    await user.keyboard("{Escape}");
 
     // Role flips to coachee (e.g., role hook re-derives mid-session).
     rerender(
@@ -593,12 +724,16 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
       />
     );
 
-    // Coachee: plain icon, no menu items, no stop affordance.
-    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
-    const button = screen.getByRole("button", { name: /join meeting/i });
-    expect(button).not.toHaveAttribute("aria-haspopup", "menu");
-
-    await user.click(button);
+    // Coachee live: still has a dropdown with the elapsed label and "Open
+    // meeting" — but Stop must be gone, and clicking the trigger cannot
+    // call stopRecording.
+    await user.click(screen.getByRole("button", { name: /join meeting/i }));
+    expect(
+      await screen.findByRole("menuitem", { name: /open meeting/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /stop transcription/i })
+    ).not.toBeInTheDocument();
     expect(stopRecording).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -455,12 +455,12 @@ describe.each([
 //   (2) stop a recording (lifecycle ownership)
 //   (3) silently disable transcription mid-session
 // The coachee must ALWAYS be able to:
-//   (4) open the meeting URL — regardless of recording status (#404)
+//   (4) open the meeting URL — regardless of recording status
 //
 // These tests guard those invariants at the component boundary so a
 // future refactor can't accidentally regress consent semantics or
-// re-introduce the bug where the coachee lost their join button once
-// the coach started recording.
+// re-introduce the regression where the coachee lost their join button
+// once the coach started recording.
 // ─────────────────────────────────────────────────────────────────────
 
 describe("JoinMeetingButton — coachee idle", () => {
@@ -551,16 +551,16 @@ describe("JoinMeetingButton — coachee idle", () => {
   });
 });
 
-// #404 regression — coachee in non-live, non-idle states (Pending /
-// Joining / WaitingRoom / Processing): plain icon, single click opens
-// the URL. No dropdown (no elapsed time to show yet, no recording).
+// Coachee in non-live, non-idle states (Pending / Joining /
+// WaitingRoom / Processing): plain icon, single click opens the URL.
+// No dropdown (no elapsed time to show yet, no recording).
 describe.each([
   MeetingRecordingStatus.Pending,
   MeetingRecordingStatus.Joining,
   MeetingRecordingStatus.WaitingRoom,
   MeetingRecordingStatus.Processing,
 ])(
-  "JoinMeetingButton — coachee pre/post-live (status=%s) — issue #404 regression",
+  "JoinMeetingButton — coachee pre/post-live (status=%s) keeps the plain join icon",
   (status) => {
     it("renders the plain camera join button (no chevron)", () => {
       recordingHookState.recording = {
@@ -626,12 +626,12 @@ describe.each([
   }
 );
 
-// #404 regression — coachee in LIVE states (InMeeting / Recording):
-// still plain single-click camera icon. The red dot conveys "the coach
-// is recording" passively; we do NOT restructure the coachee's join
-// affordance around lifecycle they don't own. No dropdown, no elapsed
-// label — those would imply the coachee is in the meeting when they
-// might not be yet, and add a click to their join flow.
+// Coachee in LIVE states (InMeeting / Recording): still plain
+// single-click camera icon. The red dot conveys "the coach is recording"
+// passively; we do NOT restructure the coachee's join affordance around
+// lifecycle they don't own. No dropdown, no elapsed label — those would
+// imply the coachee is in the meeting when they might not be yet, and
+// add a click to their join flow.
 describe.each([
   MeetingRecordingStatus.InMeeting,
   MeetingRecordingStatus.Recording,

--- a/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
+++ b/__tests__/components/coaching-sessions/join-meeting-button.test.tsx
@@ -495,16 +495,18 @@ describe.each([
 );
 
 // #404 regression — coachee in LIVE states (InMeeting / Recording):
-// dropdown surfaces the elapsed-time label + an "Open meeting" item.
-// Coachee still can never start / stop a recording.
+// still plain single-click camera icon. The red dot conveys "the coach
+// is recording" passively; we do NOT restructure the coachee's join
+// affordance around lifecycle they don't own. No dropdown, no elapsed
+// label — those would imply the coachee is in the meeting when they
+// might not be yet, and add a click to their join flow.
 describe.each([
   MeetingRecordingStatus.InMeeting,
   MeetingRecordingStatus.Recording,
 ])(
-  "JoinMeetingButton — coachee live (status=%s) — elapsed time + open meeting",
+  "JoinMeetingButton — coachee live (status=%s) — passive recording transparency only",
   (status) => {
-    it("exposes the elapsed-time label and 'Open meeting' item; NO 'Stop transcription'", async () => {
-      const user = userEvent.setup();
+    it("renders the plain camera icon with the red recording dot — no chevron, no dropdown", () => {
       recordingHookState.recording = {
         status,
         started_at: new Date(Date.now() - 65_000).toISOString(),
@@ -517,50 +519,16 @@ describe.each([
         />
       );
 
-      await user.click(screen.getByRole("button", { name: /join meeting/i }));
-
-      const label = await screen.findByTestId("join-meeting-elapsed-label");
-      expect(label).toHaveTextContent(/recording/i);
-      expect(label).toHaveTextContent(/1:05/);
-
+      const button = screen.getByRole("button", { name: /join meeting/i });
+      expect(button).not.toBeDisabled();
+      expect(button).not.toHaveAttribute("aria-haspopup", "menu");
+      expect(screen.getByTestId("join-meeting-recording-dot")).toBeInTheDocument();
       expect(
-        await screen.findByRole("menuitem", { name: /open meeting/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("menuitem", { name: /stop transcription/i })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByText(/join with transcription/i)
+        screen.queryByTestId("join-meeting-elapsed-label")
       ).not.toBeInTheDocument();
     });
 
-    it("the elapsed-time label is the FIRST entry in the dropdown", async () => {
-      const user = userEvent.setup();
-      recordingHookState.recording = {
-        status,
-        started_at: new Date().toISOString(),
-      };
-      render(
-        <JoinMeetingButton
-          sessionId="s-1"
-          meetingUrl={MEETING_URL}
-          isCoach={false}
-        />
-      );
-      await user.click(screen.getByRole("button", { name: /join meeting/i }));
-
-      const label = await screen.findByTestId("join-meeting-elapsed-label");
-      const openItem = await screen.findByRole("menuitem", {
-        name: /open meeting/i,
-      });
-      // Document order: label appears before the menu item.
-      expect(
-        label.compareDocumentPosition(openItem) &
-          Node.DOCUMENT_POSITION_FOLLOWING
-      ).toBeTruthy();
-    });
-
-    it("'Open meeting' menuitem opens the URL — and never calls startRecording / stopRecording", async () => {
+    it("single click opens the meeting URL — no startRecording / stopRecording / dropdown", async () => {
       const user = userEvent.setup();
       recordingHookState.recording = {
         status,
@@ -575,9 +543,6 @@ describe.each([
       );
 
       await user.click(screen.getByRole("button", { name: /join meeting/i }));
-      await user.click(
-        await screen.findByRole("menuitem", { name: /open meeting/i })
-      );
 
       expect(openSpy).toHaveBeenCalledWith(
         MEETING_URL,
@@ -586,6 +551,7 @@ describe.each([
       );
       expect(startRecording).not.toHaveBeenCalled();
       expect(stopRecording).not.toHaveBeenCalled();
+      expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
     });
   }
 );
@@ -724,16 +690,12 @@ describe("JoinMeetingButton — role transitions don't leak privileges", () => {
       />
     );
 
-    // Coachee live: still has a dropdown with the elapsed label and "Open
-    // meeting" — but Stop must be gone, and clicking the trigger cannot
-    // call stopRecording.
-    await user.click(screen.getByRole("button", { name: /join meeting/i }));
-    expect(
-      await screen.findByRole("menuitem", { name: /open meeting/i })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("menuitem", { name: /stop transcription/i })
-    ).not.toBeInTheDocument();
+    // Coachee live: plain single-click camera icon — no chevron, no menu
+    // items. Clicking opens the URL and cannot trigger stopRecording.
+    const button = screen.getByRole("button", { name: /join meeting/i });
+    expect(button).not.toHaveAttribute("aria-haspopup", "menu");
+    expect(screen.queryByRole("menuitem")).not.toBeInTheDocument();
+    await user.click(button);
     expect(stopRecording).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/coaching-sessions/transcript-status-indicator.test.tsx
+++ b/__tests__/components/coaching-sessions/transcript-status-indicator.test.tsx
@@ -12,17 +12,6 @@ describe("TranscriptStatusIndicator", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders a red pulsing dot for Recording", () => {
-    const { container } = render(
-      <TranscriptStatusIndicator status={IndicatorStatus.Recording} />
-    );
-    const dot = container.firstChild as HTMLElement;
-    expect(dot).not.toBeNull();
-    expect(dot.className).toContain("bg-red-500");
-    expect(dot.className).toContain("motion-safe:animate-pulse");
-    expect(dot.className).toContain("rounded-full");
-  });
-
   it("renders a solid green dot for TranscriptReady", () => {
     const { container } = render(
       <TranscriptStatusIndicator status={IndicatorStatus.TranscriptReady} />
@@ -45,7 +34,7 @@ describe("TranscriptStatusIndicator", () => {
 
   it("is decorative (aria-hidden) — parent button carries the label", () => {
     const { container } = render(
-      <TranscriptStatusIndicator status={IndicatorStatus.Recording} />
+      <TranscriptStatusIndicator status={IndicatorStatus.TranscriptReady} />
     );
     const dot = container.firstChild as HTMLElement;
     expect(dot.getAttribute("aria-hidden")).toBe("true");

--- a/__tests__/components/coaching-sessions/transcript-toggle-button.test.tsx
+++ b/__tests__/components/coaching-sessions/transcript-toggle-button.test.tsx
@@ -48,7 +48,7 @@ describe("TranscriptToggleButton — status indicator", () => {
     expect(container.querySelector(".bg-emerald-500")).toBeNull();
   });
 
-  it("does NOT render a red pulsing dot — that indicator lives on the camera/join button (issue #404)", () => {
+  it("does NOT render a red pulsing dot — that indicator lives on the camera/join button", () => {
     // The transcript toggle never carries the live-recording dot anymore;
     // even if a caller somehow passed an unrelated status, no red dot
     // should appear here.

--- a/__tests__/components/coaching-sessions/transcript-toggle-button.test.tsx
+++ b/__tests__/components/coaching-sessions/transcript-toggle-button.test.tsx
@@ -48,17 +48,19 @@ describe("TranscriptToggleButton — status indicator", () => {
     expect(container.querySelector(".bg-emerald-500")).toBeNull();
   });
 
-  it("renders the red pulsing dot for Recording", () => {
+  it("does NOT render a red pulsing dot — that indicator lives on the camera/join button (issue #404)", () => {
+    // The transcript toggle never carries the live-recording dot anymore;
+    // even if a caller somehow passed an unrelated status, no red dot
+    // should appear here.
     const { container } = render(
       <TranscriptToggleButton
         isOpen={false}
         onToggle={vi.fn()}
-        indicatorStatus={IndicatorStatus.Recording}
+        indicatorStatus={IndicatorStatus.TranscriptReady}
       />
     );
-    const dot = container.querySelector(".bg-red-500");
-    expect(dot).not.toBeNull();
-    expect(dot?.className).toContain("motion-safe:animate-pulse");
+    expect(container.querySelector(".bg-red-500")).toBeNull();
+    expect(container.querySelector(".animate-pulse")).toBeNull();
   });
 
   it("renders the green solid dot for TranscriptReady", () => {

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -30,12 +30,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useMeetingRecording } from "@/lib/api/meeting-recordings";
+import { useTranscription } from "@/lib/api/transcriptions";
 import { useInterval } from "@/lib/hooks/use-interval";
 import { formatTimestamp } from "@/lib/transcript/format-timestamp";
 import {
   MeetingRecordingStatus,
   isRecordingTerminal,
 } from "@/types/meeting-recording";
+import { TranscriptionStatus } from "@/types/transcription";
 import type { Id } from "@/types/general";
 import { type Option, Some, None } from "@/types/option";
 
@@ -53,6 +55,12 @@ export function JoinMeetingButton({
 }: JoinMeetingButtonProps) {
   const { recording, startRecording, stopRecording } =
     useMeetingRecording(sessionId);
+  const { transcription } = useTranscription(sessionId);
+  // Failed transcriptions hold no content worth confirming over; any
+  // other lifecycle state implies the coach is about to overwrite real
+  // (or in-progress) data and should be prompted.
+  const hasExistingTranscription =
+    !!transcription && transcription.status !== TranscriptionStatus.Failed;
 
   if (!meetingUrl || !sessionId) {
     return <DisabledButton />;
@@ -92,6 +100,7 @@ export function JoinMeetingButton({
       <CoachIdleDropdownButton
         onJoinWithTranscription={handleJoinWithTranscription}
         onJoinWithoutTranscription={openMeeting}
+        hasExistingTranscription={hasExistingTranscription}
       />
     );
   }
@@ -186,54 +195,98 @@ function DisabledButton() {
 interface CoachIdleDropdownButtonProps {
   onJoinWithTranscription: () => void;
   onJoinWithoutTranscription: () => void;
+  /** When true, "Join with transcription" prompts for replacement confirmation. */
+  hasExistingTranscription: boolean;
 }
 
 function CoachIdleDropdownButton({
   onJoinWithTranscription,
   onJoinWithoutTranscription,
+  hasExistingTranscription,
 }: CoachIdleDropdownButtonProps) {
+  const [confirmReplaceOpen, setConfirmReplaceOpen] = useState(false);
+
+  const handleJoinWithTranscriptionSelect = () => {
+    if (hasExistingTranscription) {
+      setConfirmReplaceOpen(true);
+      return;
+    }
+    onJoinWithTranscription();
+  };
+
   return (
-    <DropdownMenu>
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                className="h-10 px-2 gap-0.5"
-                aria-label="Join meeting"
-              >
-                <Video className="!h-6 !w-6" />
-                <ChevronDown className="!h-3 !w-3 opacity-70" />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Join Meeting</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-      <DropdownMenuContent align="end" className="w-64">
-        <DropdownMenuItem
-          onSelect={onJoinWithTranscription}
-          className="flex-col items-start gap-0.5"
-        >
-          <span className="font-medium">Join with transcription</span>
-          <span className="text-xs text-muted-foreground">
-            The meeting will be recorded and transcribed.
-          </span>
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={onJoinWithoutTranscription}
-          className="flex-col items-start gap-0.5"
-        >
-          <span className="font-medium">Join without transcription</span>
-          <span className="text-xs text-muted-foreground">
-            The meeting will not be recorded or transcribed.
-          </span>
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="h-10 px-2 gap-0.5"
+                  aria-label="Join meeting"
+                >
+                  <Video className="!h-6 !w-6" />
+                  <ChevronDown className="!h-3 !w-3 opacity-70" />
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Join Meeting</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <DropdownMenuContent align="end" className="w-64">
+          <DropdownMenuItem
+            onSelect={handleJoinWithTranscriptionSelect}
+            className="flex-col items-start gap-0.5"
+          >
+            <span className="font-medium">Join with transcription</span>
+            <span className="text-xs text-muted-foreground">
+              The meeting will be recorded and transcribed.
+            </span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={onJoinWithoutTranscription}
+            className="flex-col items-start gap-0.5"
+          >
+            <span className="font-medium">Join without transcription</span>
+            <span className="text-xs text-muted-foreground">
+              The meeting will not be recorded or transcribed.
+            </span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog
+        open={confirmReplaceOpen}
+        onOpenChange={setConfirmReplaceOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Replace existing transcription?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This coaching session already has a transcription. Joining with
+              transcription again will start a new recording and replace the
+              existing transcript. This can&apos;t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep existing transcript</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirmReplaceOpen(false);
+                // Synchronous user gesture from this click — window.open
+                // inside onJoinWithTranscription still bypasses pop-up
+                // blockers because we're inside the confirm handler.
+                onJoinWithTranscription();
+              }}
+            >
+              Replace transcription
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -68,18 +68,11 @@ export function JoinMeetingButton({
   const liveStartedAt: Option<string> =
     isLive && recording?.started_at ? Some(recording.started_at) : None;
 
+  // Coachee: plain single-click camera icon in every state. Dot conveys
+  // "the coach started a recording" passively; we don't restructure the
+  // coachee's join affordance around lifecycle they don't own.
   if (!isCoach) {
-    if (isLive) {
-      return (
-        <ActiveDropdownButton
-          onOpenMeeting={openMeeting}
-          showRecordingDot={true}
-          startedAt={liveStartedAt}
-          onStop={undefined}
-        />
-      );
-    }
-    return <CoacheeIdleButton onJoin={openMeeting} />;
+    return <CoacheeIdleButton onJoin={openMeeting} showRecordingDot={isLive} />;
   }
 
   const isIdle = !status || isRecordingTerminal(status);
@@ -342,9 +335,10 @@ function ActiveDropdownButton({
 
 interface CoacheeIdleButtonProps {
   onJoin: () => void;
+  showRecordingDot: boolean;
 }
 
-function CoacheeIdleButton({ onJoin }: CoacheeIdleButtonProps) {
+function CoacheeIdleButton({ onJoin, showRecordingDot }: CoacheeIdleButtonProps) {
   return (
     <TooltipProvider>
       <Tooltip>
@@ -352,11 +346,12 @@ function CoacheeIdleButton({ onJoin }: CoacheeIdleButtonProps) {
           <Button
             variant="ghost"
             size="icon"
-            className="h-10 w-10"
+            className="relative h-10 w-10"
             aria-label="Join meeting"
             onClick={onJoin}
           >
             <Video className="!h-6 !w-6" />
+            {showRecordingDot && <RecordingDot />}
           </Button>
         </TooltipTrigger>
         <TooltipContent>

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -136,12 +136,12 @@ function RecordingDot() {
 }
 
 // Duration recomputed from started_at each tick — never accumulate
-// locally (backgrounded tabs throttle accumulators). When the BE
-// hasn't populated started_at yet (bot in InMeeting before recording
-// actually starts), we render just "Recording" without the timer.
+// locally (backgrounded tabs throttle accumulators).
 function ElapsedTimeLabel({ startedAt }: { startedAt: Option<string> }) {
   const [, setTick] = useState(0);
-  useInterval(() => setTick((t) => t + 1), 1000);
+  // Pause the interval when there's nothing to count — re-renders
+  // wouldn't change the rendered output anyway.
+  useInterval(() => setTick((t) => t + 1), startedAt.some ? 1000 : null);
 
   return (
     <DropdownMenuLabel

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, Video } from "lucide-react";
+import { ChevronDown, Radio, Video } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -28,11 +30,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useMeetingRecording } from "@/lib/api/meeting-recordings";
+import { useInterval } from "@/lib/hooks/use-interval";
+import { formatTimestamp } from "@/lib/transcript/format-timestamp";
 import {
   MeetingRecordingStatus,
   isRecordingTerminal,
 } from "@/types/meeting-recording";
 import type { Id } from "@/types/general";
+import { type Option, Some, None } from "@/types/option";
 
 interface JoinMeetingButtonProps {
   sessionId: Id | null;
@@ -60,11 +65,21 @@ export function JoinMeetingButton({
   const isLive =
     status === MeetingRecordingStatus.InMeeting ||
     status === MeetingRecordingStatus.Recording;
+  const liveStartedAt: Option<string> =
+    isLive && recording?.started_at ? Some(recording.started_at) : None;
 
   if (!isCoach) {
-    return (
-      <CoacheeIdleButton onJoin={openMeeting} showRecordingDot={isLive} />
-    );
+    if (isLive) {
+      return (
+        <ActiveDropdownButton
+          onOpenMeeting={openMeeting}
+          showRecordingDot={true}
+          startedAt={liveStartedAt}
+          onStop={undefined}
+        />
+      );
+    }
+    return <CoacheeIdleButton onJoin={openMeeting} />;
   }
 
   const isIdle = !status || isRecordingTerminal(status);
@@ -89,9 +104,10 @@ export function JoinMeetingButton({
   }
 
   return (
-    <CoachActiveDropdownButton
+    <ActiveDropdownButton
       onOpenMeeting={openMeeting}
       showRecordingDot={isLive}
+      startedAt={liveStartedAt}
       onStop={
         isLive
           ? () =>
@@ -114,6 +130,36 @@ function RecordingDot() {
       data-testid="join-meeting-recording-dot"
       className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500 motion-safe:animate-pulse"
     />
+  );
+}
+
+// Duration recomputed from started_at each tick — never accumulate
+// locally (backgrounded tabs throttle accumulators). When the BE
+// hasn't populated started_at yet (bot in InMeeting before recording
+// actually starts), we render just "Recording" without the timer.
+function ElapsedTimeLabel({ startedAt }: { startedAt: Option<string> }) {
+  const [, setTick] = useState(0);
+  useInterval(() => setTick((t) => t + 1), 1000);
+
+  return (
+    <DropdownMenuLabel
+      data-testid="join-meeting-elapsed-label"
+      className="flex items-center gap-1.5 text-red-700 dark:text-red-300"
+    >
+      <Radio
+        aria-hidden="true"
+        className="h-3.5 w-3.5 motion-safe:animate-pulse"
+        fill="currentColor"
+      />
+      <span>Recording</span>
+      {startedAt.some && (
+        <span className="ml-auto tabular-nums text-xs opacity-80">
+          {formatTimestamp(
+            Math.max(0, Date.now() - new Date(startedAt.val).getTime())
+          )}
+        </span>
+      )}
+    </DropdownMenuLabel>
   );
 }
 
@@ -198,18 +244,21 @@ function CoachIdleDropdownButton({
   );
 }
 
-interface CoachActiveDropdownButtonProps {
+interface ActiveDropdownButtonProps {
   onOpenMeeting: () => void;
   showRecordingDot: boolean;
+  /** When Some, dropdown leads with a live "Recording · m:ss" label. */
+  startedAt: Option<string>;
   /** When set, dropdown exposes "Stop transcription"; otherwise just "Open meeting". */
   onStop: (() => void) | undefined;
 }
 
-function CoachActiveDropdownButton({
+function ActiveDropdownButton({
   onOpenMeeting,
   showRecordingDot,
+  startedAt,
   onStop,
-}: CoachActiveDropdownButtonProps) {
+}: ActiveDropdownButtonProps) {
   const [stopOpen, setStopOpen] = useState(false);
   const canStop = !!onStop;
 
@@ -237,6 +286,12 @@ function CoachActiveDropdownButton({
           </Tooltip>
         </TooltipProvider>
         <DropdownMenuContent align="end" className="w-64">
+          {showRecordingDot && (
+            <>
+              <ElapsedTimeLabel startedAt={startedAt} />
+              <DropdownMenuSeparator />
+            </>
+          )}
           <DropdownMenuItem
             onSelect={onOpenMeeting}
             className="flex-col items-start gap-0.5"
@@ -287,10 +342,9 @@ function CoachActiveDropdownButton({
 
 interface CoacheeIdleButtonProps {
   onJoin: () => void;
-  showRecordingDot: boolean;
 }
 
-function CoacheeIdleButton({ onJoin, showRecordingDot }: CoacheeIdleButtonProps) {
+function CoacheeIdleButton({ onJoin }: CoacheeIdleButtonProps) {
   return (
     <TooltipProvider>
       <Tooltip>
@@ -298,12 +352,11 @@ function CoacheeIdleButton({ onJoin, showRecordingDot }: CoacheeIdleButtonProps)
           <Button
             variant="ghost"
             size="icon"
-            className="relative h-10 w-10"
+            className="h-10 w-10"
             aria-label="Join meeting"
             onClick={onJoin}
           >
             <Video className="!h-6 !w-6" />
-            {showRecordingDot && <RecordingDot />}
           </Button>
         </TooltipTrigger>
         <TooltipContent>

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, Loader2, Radio, Video } from "lucide-react";
+import { ChevronDown, Video } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -27,25 +27,17 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/components/lib/utils";
 import { useMeetingRecording } from "@/lib/api/meeting-recordings";
-import { useInterval } from "@/lib/hooks/use-interval";
 import {
   MeetingRecordingStatus,
   isRecordingTerminal,
 } from "@/types/meeting-recording";
-import { formatTimestamp } from "@/lib/transcript/format-timestamp";
 import type { Id } from "@/types/general";
 
 interface JoinMeetingButtonProps {
   sessionId: Id | null;
   meetingUrl: string | undefined;
-  /**
-   * Whether the current viewer is the coach for this relationship.
-   * Coaches own the recording bot lifecycle (start/stop with the
-   * transcription opt-in choice). Coachees just open the meeting URL —
-   * they see live state for transparency but cannot start/stop.
-   */
+  /** Coach owns the bot lifecycle; coachee only opens the Meet URL. */
   isCoach: boolean;
 }
 
@@ -57,91 +49,70 @@ export function JoinMeetingButton({
   const { recording, startRecording, stopRecording } =
     useMeetingRecording(sessionId);
 
-  // Disable when either the meeting URL or session isn't available — the
-  // recording lifecycle calls (startRecording/stopRecording) both require a
-  // real sessionId, and the SWR fetcher's `sessionId!` non-null assertion
-  // would crash if invoked without one.
   if (!meetingUrl || !sessionId) {
     return <DisabledButton />;
   }
 
+  const openMeeting = () =>
+    window.open(meetingUrl, "_blank", "noopener,noreferrer");
+
   const status = recording?.status;
-
-  if (status === MeetingRecordingStatus.Processing) {
-    return <ProcessingButton />;
-  }
-
-  if (
-    status === MeetingRecordingStatus.Pending ||
-    status === MeetingRecordingStatus.Joining ||
-    status === MeetingRecordingStatus.WaitingRoom
-  ) {
-    return <JoiningButton />;
-  }
-
-  if (
+  const isLive =
     status === MeetingRecordingStatus.InMeeting ||
-    status === MeetingRecordingStatus.Recording
-  ) {
-    return (
-      <LiveButton
-        startedAt={recording?.started_at}
-        onStop={
-          isCoach
-            ? () =>
-                stopRecording().catch((err) =>
-                  toast.error("Couldn't stop transcription.", {
-                    description:
-                      err instanceof Error ? err.message : undefined,
-                  })
-                )
-            : undefined
-        }
-      />
-    );
-  }
+    status === MeetingRecordingStatus.Recording;
 
-  // status is undefined OR terminal (Completed | Failed) — back to idle.
-  // Note: terminal status check is structural — keep `isRecordingTerminal`
-  // import to make the intent explicit even though the conditionals above
-  // already cover the live/processing branches.
-  const isIdle = !status || isRecordingTerminal(status);
-
-  if (!isIdle) return null; // exhaustiveness fallback; should be unreachable
-
-  // Coachee idle path: plain icon button, opens the meeting URL only. The
-  // coach owns the bot lifecycle (consent + 409-on-double-start), so the
-  // coachee never sees a transcription choice.
   if (!isCoach) {
     return (
-      <CoacheeIdleButton
-        onJoin={() =>
-          window.open(meetingUrl, "_blank", "noopener,noreferrer")
-        }
+      <CoacheeIdleButton onJoin={openMeeting} showRecordingDot={isLive} />
+    );
+  }
+
+  const isIdle = !status || isRecordingTerminal(status);
+
+  if (isIdle) {
+    const handleJoinWithTranscription = () => {
+      // Synchronous window.open avoids pop-up blockers; SWR optimistic
+      // mutate transitions the button to the active view.
+      openMeeting();
+      void startRecording(meetingUrl).catch((err) =>
+        toast.error("Couldn't start transcription.", {
+          description: err instanceof Error ? err.message : undefined,
+        })
+      );
+    };
+    return (
+      <CoachIdleDropdownButton
+        onJoinWithTranscription={handleJoinWithTranscription}
+        onJoinWithoutTranscription={openMeeting}
       />
     );
   }
 
-  const handleJoinWithTranscription = () => {
-    // Synchronous window.open to avoid pop-up blockers (Safari/Firefox).
-    // Fire-and-forget the API call; SWR's optimistic mutate transitions
-    // the button into the joining view immediately.
-    window.open(meetingUrl, "_blank", "noopener,noreferrer");
-    void startRecording(meetingUrl).catch((err) =>
-      toast.error("Couldn't start transcription.", {
-        description: err instanceof Error ? err.message : undefined,
-      })
-    );
-  };
-
-  const handleJoinWithoutTranscription = () => {
-    window.open(meetingUrl, "_blank", "noopener,noreferrer");
-  };
-
   return (
-    <IdleDropdownButton
-      onJoinWithTranscription={handleJoinWithTranscription}
-      onJoinWithoutTranscription={handleJoinWithoutTranscription}
+    <CoachActiveDropdownButton
+      onOpenMeeting={openMeeting}
+      showRecordingDot={isLive}
+      onStop={
+        isLive
+          ? () =>
+              stopRecording().catch((err) =>
+                toast.error("Couldn't stop transcription.", {
+                  description:
+                    err instanceof Error ? err.message : undefined,
+                })
+              )
+          : undefined
+      }
+    />
+  );
+}
+
+function RecordingDot() {
+  return (
+    <span
+      aria-hidden="true"
+      data-testid="join-meeting-recording-dot"
+      className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500 motion-safe:animate-pulse"
     />
   );
 }
@@ -173,15 +144,15 @@ function DisabledButton() {
   );
 }
 
-interface IdleDropdownButtonProps {
+interface CoachIdleDropdownButtonProps {
   onJoinWithTranscription: () => void;
   onJoinWithoutTranscription: () => void;
 }
 
-function IdleDropdownButton({
+function CoachIdleDropdownButton({
   onJoinWithTranscription,
   onJoinWithoutTranscription,
-}: IdleDropdownButtonProps) {
+}: CoachIdleDropdownButtonProps) {
   return (
     <DropdownMenu>
       <TooltipProvider>
@@ -227,148 +198,68 @@ function IdleDropdownButton({
   );
 }
 
-interface CoacheeIdleButtonProps {
-  onJoin: () => void;
-}
-
-function CoacheeIdleButton({ onJoin }: CoacheeIdleButtonProps) {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-10 w-10"
-            aria-label="Join meeting"
-            onClick={onJoin}
-          >
-            <Video className="!h-6 !w-6" />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>Join Meeting</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-function JoiningButton() {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span>
-            <Button
-              variant="ghost"
-              size="icon"
-              disabled
-              className="h-10 w-10"
-              aria-label="Joining meeting"
-            >
-              <Loader2 className="!h-6 !w-6 animate-spin text-muted-foreground" />
-            </Button>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>Joining meeting…</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-function ProcessingButton() {
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span>
-            <Button
-              variant="ghost"
-              size="icon"
-              disabled
-              className="h-10 w-10"
-              aria-label="Processing transcription"
-            >
-              <Loader2 className="!h-6 !w-6 animate-spin text-muted-foreground" />
-            </Button>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p>Processing transcription…</p>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
-interface LiveButtonProps {
-  startedAt: string | undefined;
-  /**
-   * When provided (coach), the pill is interactive and clicking opens
-   * the stop-confirmation dialog. When omitted (coachee), the same
-   * pulsing pill renders for transparency but is non-interactive.
-   */
+interface CoachActiveDropdownButtonProps {
+  onOpenMeeting: () => void;
+  showRecordingDot: boolean;
+  /** When set, dropdown exposes "Stop transcription"; otherwise just "Open meeting". */
   onStop: (() => void) | undefined;
 }
 
-function LiveButton({ startedAt, onStop }: LiveButtonProps) {
-  const [open, setOpen] = useState(false);
-
-  // Recompute duration each tick from started_at — never accumulate
-  // locally (tab-throttling skews accumulators on backgrounded tabs).
-  const [, setTick] = useState(0);
-  useInterval(() => setTick((t) => t + 1), 1000);
-
-  const startedMs = startedAt ? new Date(startedAt).getTime() : null;
-  const durationMs =
-    startedMs !== null ? Math.max(0, Date.now() - startedMs) : 0;
-
+function CoachActiveDropdownButton({
+  onOpenMeeting,
+  showRecordingDot,
+  onStop,
+}: CoachActiveDropdownButtonProps) {
+  const [stopOpen, setStopOpen] = useState(false);
   const canStop = !!onStop;
-
-  const pill = (
-    <Button
-      variant="outline"
-      className={cn(
-        "h-10 gap-1.5 border-red-500/40 bg-red-500/5 text-red-700",
-        canStop
-          ? "hover:bg-red-500/10 hover:text-red-800 dark:text-red-300"
-          : "cursor-default hover:bg-red-500/5 hover:text-red-700 dark:text-red-300"
-      )}
-      onClick={canStop ? () => setOpen(true) : undefined}
-      aria-label={canStop ? "Stop transcription" : "Transcription in progress"}
-      aria-disabled={!canStop || undefined}
-    >
-      <Radio
-        className="h-3.5 w-3.5 motion-safe:animate-pulse"
-        fill="currentColor"
-      />
-      Transcribing
-      <span className="tabular-nums text-xs opacity-80">
-        · {formatTimestamp(durationMs)}
-      </span>
-    </Button>
-  );
-
-  if (!canStop) {
-    return (
-      <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>{pill}</TooltipTrigger>
-          <TooltipContent>
-            <p>The coach is recording and transcribing this meeting.</p>
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    );
-  }
 
   return (
     <>
-      {pill}
-      <AlertDialog open={open} onOpenChange={setOpen}>
+      <DropdownMenu>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="relative h-10 px-2 gap-0.5"
+                  aria-label="Join meeting"
+                >
+                  <Video className="!h-6 !w-6" />
+                  <ChevronDown className="!h-3 !w-3 opacity-70" />
+                  {showRecordingDot && <RecordingDot />}
+                </Button>
+              </DropdownMenuTrigger>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Join Meeting</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+        <DropdownMenuContent align="end" className="w-64">
+          <DropdownMenuItem
+            onSelect={onOpenMeeting}
+            className="flex-col items-start gap-0.5"
+          >
+            <span className="font-medium">Open meeting</span>
+            <span className="text-xs text-muted-foreground">
+              Reopen the meeting in a new tab.
+            </span>
+          </DropdownMenuItem>
+          {canStop && (
+            <DropdownMenuItem
+              onSelect={() => setStopOpen(true)}
+              className="flex-col items-start gap-0.5"
+            >
+              <span className="font-medium">Stop transcription</span>
+              <span className="text-xs text-muted-foreground">
+                Stop the recording and finalize the transcript.
+              </span>
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <AlertDialog open={stopOpen} onOpenChange={setStopOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Stop transcription?</AlertDialogTitle>
@@ -381,7 +272,7 @@ function LiveButton({ startedAt, onStop }: LiveButtonProps) {
             <AlertDialogCancel>Keep transcribing</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
-                setOpen(false);
+                setStopOpen(false);
                 onStop?.();
               }}
             >
@@ -391,5 +282,34 @@ function LiveButton({ startedAt, onStop }: LiveButtonProps) {
         </AlertDialogContent>
       </AlertDialog>
     </>
+  );
+}
+
+interface CoacheeIdleButtonProps {
+  onJoin: () => void;
+  showRecordingDot: boolean;
+}
+
+function CoacheeIdleButton({ onJoin, showRecordingDot }: CoacheeIdleButtonProps) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="relative h-10 w-10"
+            aria-label="Join meeting"
+            onClick={onJoin}
+          >
+            <Video className="!h-6 !w-6" />
+            {showRecordingDot && <RecordingDot />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Join Meeting</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/src/components/ui/coaching-sessions/join-meeting-button.tsx
+++ b/src/components/ui/coaching-sessions/join-meeting-button.tsx
@@ -114,7 +114,7 @@ export function JoinMeetingButton({
         isLive
           ? () =>
               stopRecording().catch((err) =>
-                toast.error("Couldn't stop transcription.", {
+                toast.error("Couldn't stop recording.", {
                   description:
                     err instanceof Error ? err.message : undefined,
                 })
@@ -352,9 +352,9 @@ function ActiveDropdownButton({
               onSelect={() => setStopOpen(true)}
               className="flex-col items-start gap-0.5"
             >
-              <span className="font-medium">Stop transcription</span>
+              <span className="font-medium">Stop recording</span>
               <span className="text-xs text-muted-foreground">
-                Stop the recording and finalize the transcript.
+                A transcription of this meeting won&apos;t be generated.
               </span>
             </DropdownMenuItem>
           )}
@@ -363,21 +363,21 @@ function ActiveDropdownButton({
       <AlertDialog open={stopOpen} onOpenChange={setStopOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Stop transcription?</AlertDialogTitle>
+            <AlertDialogTitle>Stop recording?</AlertDialogTitle>
             <AlertDialogDescription>
-              The bot will leave the meeting and finalize the transcript. You
-              can&apos;t resume the same transcription afterward.
+              The bot will leave the meeting. A transcription of this session
+              won&apos;t be generated. This can&apos;t be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Keep transcribing</AlertDialogCancel>
+            <AlertDialogCancel>Keep recording</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 setStopOpen(false);
                 onStop?.();
               }}
             >
-              Stop transcription
+              Stop recording
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/ui/coaching-sessions/transcript-panel.tsx
+++ b/src/components/ui/coaching-sessions/transcript-panel.tsx
@@ -53,6 +53,9 @@ function deriveEmptyState(
     case MeetingRecordingStatus.Failed:
       return { kind: "recording-failed", errorMessage: recording.error_message };
     case MeetingRecordingStatus.Completed:
+    case MeetingRecordingStatus.Cancelled:
+      // Cancelled = user stopped early; bot may have produced a partial
+      // transcript. Downstream pipeline is identical to Completed.
       if (transcription?.status === TranscriptionStatus.Failed) {
         return { kind: "transcription-failed", errorMessage: transcription.error_message };
       }

--- a/src/components/ui/coaching-sessions/transcript-status-indicator.tsx
+++ b/src/components/ui/coaching-sessions/transcript-status-indicator.tsx
@@ -11,7 +11,8 @@ interface TranscriptStatusIndicatorProps {
 }
 
 // Decorative dot/glyph on the transcript-toggle button. Live recording
-// indicator lives on the camera/join button instead (see [[issue 404]]).
+// indicator lives on the camera/join button (meeting-level state, not a
+// transcript-artifact state).
 export function TranscriptStatusIndicator({
   status,
   className,

--- a/src/components/ui/coaching-sessions/transcript-status-indicator.tsx
+++ b/src/components/ui/coaching-sessions/transcript-status-indicator.tsx
@@ -7,23 +7,11 @@ import { IndicatorStatus } from "@/lib/transcript/indicator-status";
 
 interface TranscriptStatusIndicatorProps {
   status: IndicatorStatus;
-  /** Optional extra classes for absolute positioning on a parent icon. */
   className?: string;
 }
 
-/**
- * The dot/glyph rendered on top of the transcript toggle button.
- *
- * Three visible states:
- *   - Recording       → slow-pulsing red dot
- *   - TranscriptReady → solid green dot
- *   - Failed          → small amber ! glyph
- *
- * Renders nothing for `None`.
- *
- * The indicator is decorative (`aria-hidden`); the button's tooltip
- * carries the authoritative text description.
- */
+// Decorative dot/glyph on the transcript-toggle button. Live recording
+// indicator lives on the camera/join button instead (see [[issue 404]]).
 export function TranscriptStatusIndicator({
   status,
   className,
@@ -45,18 +33,7 @@ export function TranscriptStatusIndicator({
   return (
     <span
       aria-hidden="true"
-      className={cn(
-        "h-2 w-2 rounded-full",
-        dotColorClass(status),
-        status === IndicatorStatus.Recording && "motion-safe:animate-pulse",
-        className
-      )}
+      className={cn("h-2 w-2 rounded-full bg-emerald-500", className)}
     />
   );
-}
-
-function dotColorClass(status: IndicatorStatus): string {
-  if (status === IndicatorStatus.Recording) return "bg-red-500";
-  if (status === IndicatorStatus.TranscriptReady) return "bg-emerald-500";
-  return "";
 }

--- a/src/lib/transcript/__tests__/indicator-status.test.ts
+++ b/src/lib/transcript/__tests__/indicator-status.test.ts
@@ -97,4 +97,21 @@ describe("deriveIndicatorStatus — default", () => {
       })
     ).toBe(IndicatorStatus.TranscriptReady);
   });
+
+  it("returns None for a Cancelled recording with no transcription artifact yet", () => {
+    expect(
+      deriveIndicatorStatus({
+        recordingStatus: MeetingRecordingStatus.Cancelled,
+      })
+    ).toBe(IndicatorStatus.None);
+  });
+
+  it("returns TranscriptReady when a Cancelled recording produced a Completed transcript", () => {
+    expect(
+      deriveIndicatorStatus({
+        recordingStatus: MeetingRecordingStatus.Cancelled,
+        transcriptionStatus: TranscriptionStatus.Completed,
+      })
+    ).toBe(IndicatorStatus.TranscriptReady);
+  });
 });

--- a/src/lib/transcript/__tests__/indicator-status.test.ts
+++ b/src/lib/transcript/__tests__/indicator-status.test.ts
@@ -28,7 +28,8 @@ describe("deriveIndicatorStatus — failure takes precedence", () => {
 });
 
 // Live "Recording" state intentionally does NOT surface here — the
-// pulsing red dot lives on the camera/join button (issue #404).
+// pulsing red dot lives on the camera/join button, not on the
+// transcript-toggle indicator.
 describe("deriveIndicatorStatus — live recording is NOT a transcript-toggle state", () => {
   it("returns None across every live/in-progress recording status", () => {
     const liveStates: MeetingRecordingStatus[] = [
@@ -86,9 +87,9 @@ describe("deriveIndicatorStatus — default", () => {
   });
 
   it("returns TranscriptReady when transcript completed even if recording=Recording (re-recording case)", () => {
-    // Pre-#404 this returned Recording (recording took priority). Now the
-    // recording state lives on the camera button, so the transcript-toggle
-    // surfaces the ready-to-view artifact instead.
+    // Recording state lives on the camera button, not here, so a fresh
+    // re-recording with a still-readable prior transcript surfaces the
+    // ready-to-view artifact rather than a (no-op) live indicator.
     expect(
       deriveIndicatorStatus({
         recordingStatus: MeetingRecordingStatus.Recording,

--- a/src/lib/transcript/__tests__/indicator-status.test.ts
+++ b/src/lib/transcript/__tests__/indicator-status.test.ts
@@ -27,23 +27,18 @@ describe("deriveIndicatorStatus — failure takes precedence", () => {
   });
 });
 
-describe("deriveIndicatorStatus — live recording", () => {
-  it("returns Recording when the bot is actively recording", () => {
-    expect(
-      deriveIndicatorStatus({
-        recordingStatus: MeetingRecordingStatus.Recording,
-      })
-    ).toBe(IndicatorStatus.Recording);
-  });
-
-  it("does not pulse during non-Recording live states (joining/in-meeting/processing)", () => {
-    const quietLiveStates: MeetingRecordingStatus[] = [
+// Live "Recording" state intentionally does NOT surface here — the
+// pulsing red dot lives on the camera/join button (issue #404).
+describe("deriveIndicatorStatus — live recording is NOT a transcript-toggle state", () => {
+  it("returns None across every live/in-progress recording status", () => {
+    const liveStates: MeetingRecordingStatus[] = [
       MeetingRecordingStatus.Joining,
       MeetingRecordingStatus.WaitingRoom,
       MeetingRecordingStatus.InMeeting,
+      MeetingRecordingStatus.Recording,
       MeetingRecordingStatus.Processing,
     ];
-    for (const status of quietLiveStates) {
+    for (const status of liveStates) {
       expect(
         deriveIndicatorStatus({ recordingStatus: status })
       ).toBe(IndicatorStatus.None);
@@ -90,12 +85,15 @@ describe("deriveIndicatorStatus — default", () => {
     ).toBe(IndicatorStatus.None);
   });
 
-  it("recording=Recording takes priority over transcript=Completed (e.g. re-recording a session)", () => {
+  it("returns TranscriptReady when transcript completed even if recording=Recording (re-recording case)", () => {
+    // Pre-#404 this returned Recording (recording took priority). Now the
+    // recording state lives on the camera button, so the transcript-toggle
+    // surfaces the ready-to-view artifact instead.
     expect(
       deriveIndicatorStatus({
         recordingStatus: MeetingRecordingStatus.Recording,
         transcriptionStatus: TranscriptionStatus.Completed,
       })
-    ).toBe(IndicatorStatus.Recording);
+    ).toBe(IndicatorStatus.TranscriptReady);
   });
 });

--- a/src/lib/transcript/indicator-status.ts
+++ b/src/lib/transcript/indicator-status.ts
@@ -1,18 +1,10 @@
 import { MeetingRecordingStatus } from "@/types/meeting-recording";
 import { TranscriptionStatus } from "@/types/transcription";
 
-/**
- * The three visual states the transcript toggle button supports, plus
- * `none` for when nothing relevant is happening.
- *
- * See the implementation plan: only red (active recording), green
- * (transcript ready), and ! (failure) are exposed. Intermediate states
- * like "joining the meeting" or "transcript processing" render without
- * an indicator; the tooltip carries the text nuance.
- */
+// Transcript-toggle button states. Live "recording in progress" lives on
+// the camera/join button (see [[issue 404]]), not on the transcript toggle.
 export enum IndicatorStatus {
   None = "none",
-  Recording = "recording",
   TranscriptReady = "transcript-ready",
   Failed = "failed",
 }
@@ -22,20 +14,12 @@ interface DeriveInput {
   transcriptionStatus?: TranscriptionStatus;
 }
 
-/**
- * Collapses the combination of recording and transcription statuses
- * into a single indicator state. Failures take priority over live
- * states, which take priority over ready states.
- */
 export function deriveIndicatorStatus({
   recordingStatus,
   transcriptionStatus,
 }: DeriveInput): IndicatorStatus {
   if (isFailure(recordingStatus, transcriptionStatus)) {
     return IndicatorStatus.Failed;
-  }
-  if (recordingStatus === MeetingRecordingStatus.Recording) {
-    return IndicatorStatus.Recording;
   }
   if (transcriptionStatus === TranscriptionStatus.Completed) {
     return IndicatorStatus.TranscriptReady;

--- a/src/lib/transcript/indicator-status.ts
+++ b/src/lib/transcript/indicator-status.ts
@@ -2,7 +2,8 @@ import { MeetingRecordingStatus } from "@/types/meeting-recording";
 import { TranscriptionStatus } from "@/types/transcription";
 
 // Transcript-toggle button states. Live "recording in progress" lives on
-// the camera/join button (see [[issue 404]]), not on the transcript toggle.
+// the camera/join button (the meeting-level control), not on the transcript
+// toggle (the artifact-level control).
 export enum IndicatorStatus {
   None = "none",
   TranscriptReady = "transcript-ready",

--- a/src/types/meeting-recording.ts
+++ b/src/types/meeting-recording.ts
@@ -18,6 +18,8 @@ export enum MeetingRecordingStatus {
   Processing = "processing",
   Completed = "completed",
   Failed = "failed",
+  /** User cancelled mid-recording; terminal, may have a partial transcript. */
+  Cancelled = "cancelled",
 }
 
 export function isMeetingRecordingStatus(
@@ -31,7 +33,8 @@ export function isMeetingRecordingStatus(
     value === MeetingRecordingStatus.Recording ||
     value === MeetingRecordingStatus.Processing ||
     value === MeetingRecordingStatus.Completed ||
-    value === MeetingRecordingStatus.Failed
+    value === MeetingRecordingStatus.Failed ||
+    value === MeetingRecordingStatus.Cancelled
   );
 }
 
@@ -98,6 +101,7 @@ export function isRecordingInProgress(status: MeetingRecordingStatus): boolean {
 export function isRecordingTerminal(status: MeetingRecordingStatus): boolean {
   return (
     status === MeetingRecordingStatus.Completed ||
-    status === MeetingRecordingStatus.Failed
+    status === MeetingRecordingStatus.Failed ||
+    status === MeetingRecordingStatus.Cancelled
   );
 }


### PR DESCRIPTION
Closes #404.

## Summary

- The join-meeting button was branching on `recording.status` before role, so once the coach started a transcribed session the coachee's camera icon got replaced by a non-interactive transcription pill — leaving them with no way to join. Branch on `isCoach` first; the coachee always gets a clickable camera icon that opens the Meet URL.
- Coach's stop control moves into the camera-button dropdown (`Open meeting` / `Stop transcription`), so the lifecycle controls stay colocated with the join affordance instead of living on a separate live pill.
- Recording indicator (pulsing red dot) moves from the transcript-toggle button to the camera/join button, since recording is a meeting-level state, not a transcript-artifact state. Transcript toggle keeps the green "ready" dot and amber "failed" glyph.
- Dropdown leads with a live `Recording · m:ss` label during `InMeeting`/`Recording`. Coachee sees it too (routing through the same `ActiveDropdownButton`); `Stop transcription` is still coach-only.
- `started_at` is modeled as `Option<string>` from `src/types/option.ts` rather than a nullable union — the label renders just `Recording` until the BE populates `started_at`, then the timer kicks in.

## Pending BE fix

The BE currently never writes `meeting_recordings.started_at` ([coordinator: `meeting_recording_started_at_population`](https://github.com/refactor-group)). Backend has confirmed the bug and is shipping a fix this week to populate `started_at` on first `InMeeting`/`Recording` transition. This FE is already in the right shape to surface the timer the moment the BE field lands — no further FE change needed once the BE PR merges.

## Files changed

- [`src/components/ui/coaching-sessions/join-meeting-button.tsx`](src/components/ui/coaching-sessions/join-meeting-button.tsx) — role-first branching, dropdown lifecycle controls, recording dot + elapsed-time label
- [`src/components/ui/coaching-sessions/transcript-status-indicator.tsx`](src/components/ui/coaching-sessions/transcript-status-indicator.tsx) — drop the `Recording` red-pulse branch
- [`src/lib/transcript/indicator-status.ts`](src/lib/transcript/indicator-status.ts) — drop the `Recording` enum value and derivation branch
- Tests across `__tests__/components/coaching-sessions/` and `src/lib/transcript/__tests__/`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — full suite passing (1335 tests across 119 files)
- [x] Local end-to-end against real backend: coach joins with transcription → coachee in a separate browser sees the camera icon (not the old transcription pill), red dot pulses on the camera button, dropdown shows `Recording` label as first entry
- [ ] Re-verify with timer ticking once BE `started_at` fix ships