### PR TITLE
Seed selected notes text into the Add Action form

### DIFF
--- a/__tests__/app/coaching-sessions/coaching-session-page.test.tsx
+++ b/__tests__/app/coaching-sessions/coaching-session-page.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { useRouter, useParams, useSearchParams, usePathname } from 'next/navigation'
 import CoachingSessionsPage from '@/app/coaching-sessions/[id]/page'
@@ -79,14 +80,27 @@ vi.mock('@/lib/hooks/use-sidebar', () => ({
 }))
 
 vi.mock('@/components/ui/coaching-sessions/coaching-session-panel', () => ({
-  CoachingSessionPanel: ({ readOnly }: { readOnly?: boolean }) => (
-    <div data-testid="coaching-session-panel" data-readonly={String(!!readOnly)}>Goals</div>
+  CoachingSessionPanel: ({ readOnly, actionDraft }: any) => (
+    <div
+      data-testid="coaching-session-panel"
+      data-readonly={String(!!readOnly)}
+      data-draft-body={actionDraft?.some ? actionDraft.val.body : ''}
+    >Goals</div>
   )
 }))
 
 vi.mock('@/components/ui/coaching-sessions/coaching-tabs-container', () => ({
-  CoachingTabsContainer: () => (
-    <div data-testid="coaching-tabs-container">Notes</div>
+  CoachingTabsContainer: ({ onAddActionFromNote }: any) => (
+    <div data-testid="coaching-tabs-container">
+      <button
+        data-testid="trigger-add-from-note"
+        onClick={() => onAddActionFromNote('  Hello from the notes  ')}
+      >Add from note</button>
+      <button
+        data-testid="trigger-add-from-note-blank"
+        onClick={() => onAddActionFromNote('   ')}
+      >Add from blank note</button>
+    </div>
   )
 }))
 
@@ -673,5 +687,91 @@ describe('CoachingSessionsPage - Panel visibility across URL states', () => {
     expect(screen.queryByRole('heading', { name: 'Transcript' })).not.toBeInTheDocument()
     expect(screen.getByTestId('coaching-tabs-container')).toBeInTheDocument()
     expect(screen.getByTestId('coaching-session-panel')).toBeInTheDocument()
+  })
+})
+
+/**
+ * Test Suite: Add action from notes selection
+ *
+ * Validates the page-level bridge from the notes "Add as Action" affordance:
+ * the selected text is trimmed and handed to the panel as the action draft,
+ * and (when the panel is already expanded) the URL is pinned to panel=actions.
+ */
+describe('CoachingSessionsPage - Add action from notes selection', () => {
+  const mockReplace = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(useRouter as any).mockReturnValue({ push: vi.fn(), replace: mockReplace })
+    ;(useParams as any).mockReturnValue({ id: 'session-123' })
+    ;(useSearchParams as any).mockReturnValue(new URLSearchParams())
+    ;(usePathname as any).mockReturnValue('/coaching-sessions/session-123')
+    mockRoleAsCoach()
+
+    vi.mocked(useCurrentCoachingSession).mockReturnValue({
+      currentCoachingSessionId: 'session-123',
+      currentCoachingSession: createMockCoachingSession({
+        id: 'session-123',
+        coaching_relationship_id: 'rel-123',
+      }),
+      isError: false,
+      isLoading: false,
+      refresh: vi.fn(),
+    })
+
+    vi.mocked(useCurrentCoachingRelationship).mockReturnValue({
+      currentCoachingRelationshipId: 'rel-123',
+      setCurrentCoachingRelationshipId: vi.fn(),
+      currentCoachingRelationship: null,
+      isLoading: false,
+      isError: false,
+      currentOrganizationId: 'org-123',
+      resetCoachingRelationshipState: vi.fn(),
+      refresh: vi.fn(),
+    })
+  })
+
+  it('passes the trimmed selection to the panel and pins panel=actions in the URL', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestProviders>
+        <CoachingSessionsPage />
+      </TestProviders>
+    )
+
+    await user.click(screen.getByTestId('trigger-add-from-note'))
+
+    // Trim guard: surrounding whitespace from the selection is stripped.
+    expect(
+      screen.getByTestId('coaching-session-panel').getAttribute('data-draft-body')
+    ).toBe('Hello from the notes')
+
+    // Panel is expanded by default, so the deferred URL sync fires.
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith(
+        expect.stringContaining('panel=actions'),
+        expect.objectContaining({ scroll: false })
+      )
+    })
+  })
+
+  it('ignores a whitespace-only selection (no draft, no URL change)', async () => {
+    const user = userEvent.setup()
+    render(
+      <TestProviders>
+        <CoachingSessionsPage />
+      </TestProviders>
+    )
+
+    await user.click(screen.getByTestId('trigger-add-from-note-blank'))
+
+    // Guard bails before setting a draft or touching the URL.
+    expect(
+      screen.getByTestId('coaching-session-panel').getAttribute('data-draft-body')
+    ).toBe('')
+    expect(mockReplace).not.toHaveBeenCalledWith(
+      expect.stringContaining('panel=actions'),
+      expect.anything()
+    )
   })
 })

--- a/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
@@ -6,6 +6,7 @@ import { DateTime } from "ts-luxon";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ActionSectionContent } from "@/components/ui/coaching-sessions/action-section-content";
 import { ItemStatus } from "@/types/general";
+import { Some } from "@/types/option";
 import { createMockAction } from "../../../test-utils";
 
 // Same DueDatePicker mock as in the action-card test — exposes a stable
@@ -284,6 +285,38 @@ describe("ActionSectionContent", () => {
 
       // After save, parent is notified that adding is done.
       expect(onAddingActionChange).toHaveBeenCalledWith(false);
+    });
+
+    it("seeds the add-form body from a notes selection, then appends on a new nonce", async () => {
+      const { rerender } = render(
+        <Wrapper>
+          <ActionSectionContent
+            {...baseProps({
+              isAddingAction: true,
+              actionBodyAppend: Some({ text: "First selection", nonce: 1 }),
+            })}
+          />
+        </Wrapper>
+      );
+
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+      await waitFor(() => expect(textarea.value).toBe("First selection"));
+
+      // A new nonce appends as a new paragraph rather than replacing.
+      rerender(
+        <Wrapper>
+          <ActionSectionContent
+            {...baseProps({
+              isAddingAction: true,
+              actionBodyAppend: Some({ text: "Second selection", nonce: 2 }),
+            })}
+          />
+        </Wrapper>
+      );
+
+      await waitFor(() =>
+        expect(textarea.value).toBe("First selection\n\nSecond selection")
+      );
     });
   });
 });

--- a/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
@@ -2,11 +2,12 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { CoachingSessionPanel } from "@/components/ui/coaching-sessions/coaching-session-panel"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector"
 import { createMockGoal, createMockAgreement } from "../../../test-utils"
 import { ItemStatus } from "@/types/general"
 import { GoalProgress } from "@/types/goal-progress"
-import { None } from "@/types/option"
+import { Some, None } from "@/types/option"
 import { DateTime } from "ts-luxon"
 
 // Mock matchMedia to simulate desktop viewport (md+ breakpoint)
@@ -33,6 +34,12 @@ const mockUpdateGoal = vi.fn()
 vi.mock("@/lib/api/goals", () => ({
   useGoalsBySession: vi.fn(),
   useGoalList: vi.fn(),
+  useGoal: vi.fn(() => ({
+    goal: undefined,
+    isLoading: false,
+    isError: false,
+    refresh: vi.fn(),
+  })),
   useGoalMutation: vi.fn(() => ({
     create: mockCreateGoal,
     update: mockUpdateGoal,
@@ -332,6 +339,58 @@ describe("CoachingSessionPanel", () => {
           action: expect.objectContaining({ label: "Undo" }),
         })
       )
+    })
+  })
+
+  it("opens the Actions add-form seeded with a notes selection", async () => {
+    setupMocks()
+    render(
+      <TooltipProvider>
+        <CoachingSessionPanel
+          coachingSessionId="session-1"
+          coachingRelationshipId="rel-1"
+          actionDraft={Some({ body: "Follow up on hiring plan", nonce: 1 })}
+        />
+      </TooltipProvider>
+    )
+
+    // The render-time draft handler switches to Actions and opens the add
+    // form; the append signal seeds its body.
+    await waitFor(() => {
+      const textarea = screen.getAllByRole("textbox")[0] as HTMLTextAreaElement
+      expect(textarea.value).toBe("Follow up on hiring plan")
+    })
+  })
+
+  it("starts a fresh Add blank after a seeded form is closed", async () => {
+    const user = userEvent.setup()
+    setupMocks()
+    render(
+      <TooltipProvider>
+        <CoachingSessionPanel
+          coachingSessionId="session-1"
+          coachingRelationshipId="rel-1"
+          actionDraft={Some({ body: "Seeded from note", nonce: 1 })}
+        />
+      </TooltipProvider>
+    )
+
+    await waitFor(() => {
+      expect(
+        (screen.getAllByRole("textbox")[0] as HTMLTextAreaElement).value
+      ).toBe("Seeded from note")
+    })
+
+    // Close the seeded form, then re-open via the Add button. The append
+    // signal must have been cleared so the fresh form starts blank — and the
+    // still-present actionDraft prop must NOT re-seed it (nonce dedup).
+    await user.click(screen.getAllByRole("button", { name: /cancel/i })[0])
+    await user.click(screen.getAllByRole("button", { name: /^add$/i })[0])
+
+    await waitFor(() => {
+      expect(
+        (screen.getAllByRole("textbox")[0] as HTMLTextAreaElement).value
+      ).toBe("")
     })
   })
 

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Separator } from "@/components/ui/separator";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type Option, Some, None } from "@/types/option";
 
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 
@@ -120,8 +121,7 @@ export default function CoachingSessionsPage() {
       ? PanelSection.Actions
       : PanelSection.Goals;
 
-  const { userId, userSession } = useAuthStore((state) => ({
-    userId: state.userId,
+  const { userSession } = useAuthStore((state) => ({
     userSession: state.userSession,
   }));
 
@@ -137,6 +137,52 @@ export default function CoachingSessionsPage() {
 
   // Three-pane layout state (focus mode + transcript visibility). URL-backed.
   const layout = useCoachingSessionLayout();
+
+  // Bridge from the notes "Add as Action" selection to the panel's add-action
+  // form: bump a monotonic nonce so the panel reacts once per selection.
+  const [actionDraft, setActionDraft] =
+    useState<Option<{ body: string; nonce: number }>>(None);
+  const actionDraftNonce = useRef(0);
+  const syncedSectionNonce = useRef(0);
+
+  const handlePanelSectionChange = useCallback(
+    (section: PanelSection) => {
+      const newSearchParams = new URLSearchParams(searchParams);
+      if (section === PanelSection.Goals) {
+        // Remove panel parameter for default section to keep URL clean
+        newSearchParams.delete("panel");
+      } else {
+        newSearchParams.set("panel", section);
+      }
+
+      const newUrl = newSearchParams.toString()
+        ? `${window.location.pathname}?${newSearchParams.toString()}`
+        : window.location.pathname;
+
+      router.replace(newUrl, { scroll: false });
+    },
+    [searchParams, router]
+  );
+
+  const handleAddActionFromNote = useCallback(
+    (selectedText: string) => {
+      const trimmed = selectedText.trim();
+      if (!trimmed) return;
+      if (layout.isGoalsCollapsed) layout.toggleGoalsCollapsed();
+      actionDraftNonce.current += 1;
+      setActionDraft(Some({ body: trimmed, nonce: actionDraftNonce.current }));
+    },
+    [layout]
+  );
+
+  // Pin panel=actions once per draft, but only after the panel is expanded;
+  // gating on !isGoalsCollapsed avoids clobbering the focus/transcript params.
+  useEffect(() => {
+    if (!actionDraft.some || layout.isGoalsCollapsed) return;
+    if (actionDraft.val.nonce === syncedSectionNonce.current) return;
+    syncedSectionNonce.current = actionDraft.val.nonce;
+    handlePanelSectionChange(PanelSection.Actions);
+  }, [actionDraft, layout.isGoalsCollapsed, handlePanelSectionChange]);
 
   // Recording and transcription status — used for the header indicator.
   // TranscriptPanel calls the same hooks internally; SWR deduplicates the requests.
@@ -251,22 +297,6 @@ export default function CoachingSessionsPage() {
     toast.error("Failed to copy session link.");
   };
 
-  const handlePanelSectionChange = (section: PanelSection) => {
-    const newSearchParams = new URLSearchParams(searchParams);
-    if (section === PanelSection.Goals) {
-      // Remove panel parameter for default section to keep URL clean
-      newSearchParams.delete("panel");
-    } else {
-      newSearchParams.set("panel", section);
-    }
-
-    const newUrl = newSearchParams.toString()
-      ? `${window.location.pathname}?${newSearchParams.toString()}`
-      : window.location.pathname;
-
-    router.replace(newUrl, { scroll: false });
-  };
-
   const gridColumns = computeGridColumns(
     layout.focusedPanel,
     layout.isTranscriptOpen,
@@ -333,6 +363,7 @@ export default function CoachingSessionsPage() {
                 : false}
               defaultSection={panelSection}
               onSectionChange={handlePanelSectionChange}
+              actionDraft={actionDraft}
             />
           )}
 
@@ -348,9 +379,9 @@ export default function CoachingSessionsPage() {
 
           {shouldRenderNotes && (
             <CoachingTabsContainer
-              userId={userId}
               isMaximized={layout.isNotesMaximized}
               onToggleMaximize={layout.toggleNotesMaximized}
+              onAddActionFromNote={handleAddActionFromNote}
             />
           )}
         </div>

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -26,6 +26,7 @@ import type { Action } from "@/types/action";
 import type { Goal } from "@/types/goal";
 import { useLinkedGoalDisplay } from "@/lib/hooks/use-linked-goal-display";
 import { ItemStatus, Id } from "@/types/general";
+import { type Option, None } from "@/types/option";
 import { cn } from "@/components/lib/utils";
 import { DateTime } from "ts-luxon";
 
@@ -74,6 +75,8 @@ export interface CompactActionCardProps {
   onGoalChange?: (id: Id, goalId: Id | undefined) => void;
   /** When true, card starts in edit mode (used for new actions). */
   initialEditing?: boolean;
+  /** Text appended into the edit body on nonce change (add-card seeding). */
+  bodyAppend?: Option<{ text: string; nonce: number }>;
   /** Called when the user dismisses an initial-editing card. */
   onDismiss?: () => void;
   className?: string;
@@ -98,6 +101,7 @@ export function CompactActionCard({
   onGoalChange,
   highlighted = false,
   initialEditing = false,
+  bodyAppend = None,
   onDismiss,
   className,
 }: CompactActionCardProps) {
@@ -173,6 +177,7 @@ export function CompactActionCard({
             action={displayedAction}
             locale={locale}
             initialBody={body}
+            bodyAppend={bodyAppend}
             allAssignees={allAssignees}
             resolvedAssignees={resolvedAssignees}
             assigneeIds={assigneeIds}
@@ -483,6 +488,7 @@ function ActionEditForm({
   action,
   locale,
   initialBody,
+  bodyAppend = None,
   allAssignees,
   resolvedAssignees,
   assigneeIds,
@@ -498,6 +504,7 @@ function ActionEditForm({
   action: Action;
   locale: string;
   initialBody: string;
+  bodyAppend?: Option<{ text: string; nonce: number }>;
   allAssignees: { id: Id; name: string; initials: string }[];
   resolvedAssignees: { id: Id; name: string; initials: string }[];
   assigneeIds: Id[];
@@ -514,6 +521,16 @@ function ActionEditForm({
   const [isSaving, setIsSaving] = useState(false);
   const markdownRef = useRef<TextareaMarkdownRef>(null);
   const textareaWrapRef = useRef<HTMLDivElement>(null);
+
+  // Append notes-selection text once per nonce (empty body → seed).
+  const lastAppendNonce = useRef(0);
+  useEffect(() => {
+    if (!bodyAppend.some) return;
+    const { text, nonce } = bodyAppend.val;
+    if (nonce === lastAppendNonce.current) return;
+    lastAppendNonce.current = nonce;
+    setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text));
+  }, [bodyAppend]);
 
   // Trap scroll inside the textarea when it has overflow.
   // React's onWheel is passive so preventDefault is ignored. We attach a

--- a/src/components/ui/coaching-sessions/action-section-content.tsx
+++ b/src/components/ui/coaching-sessions/action-section-content.tsx
@@ -8,6 +8,7 @@ import type { Action } from "@/types/action";
 import type { Goal } from "@/types/goal";
 import type { Id } from "@/types/general";
 import type { ItemStatus } from "@/types/general";
+import { type Option, None } from "@/types/option";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { DateTime } from "ts-luxon";
 
@@ -31,6 +32,8 @@ export interface ActionSectionContentProps {
   coacheeName: string;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
+  /** Selected notes text to seed/append into the add-action form body. */
+  actionBodyAppend?: Option<{ text: string; nonce: number }>;
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
@@ -57,6 +60,7 @@ export function ActionSectionContent({
   coacheeName,
   isAddingAction,
   onAddingActionChange,
+  actionBodyAppend = None,
   onStatusChange,
   onDueDateChange,
   onAssigneesChange,
@@ -222,6 +226,7 @@ export function ActionSectionContent({
             <CompactActionCard
               action={newActionPlaceholder}
               initialEditing
+              bodyAppend={actionBodyAppend}
               onDelete={undefined}
               onDismiss={() => onAddingActionChange(false)}
               {...sharedCardProps}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
@@ -65,6 +65,7 @@ export function CoachingSessionPanelDesktop({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
+  actionBodyAppend,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -239,6 +240,7 @@ export function CoachingSessionPanelDesktop({
               coacheeName={coacheeName}
               isAddingAction={isAddingAction}
               onAddingActionChange={onAddingActionChange}
+              actionBodyAppend={actionBodyAppend}
               onStatusChange={onStatusChange}
               onDueDateChange={onDueDateChange}
               onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
@@ -49,6 +49,7 @@ export function CoachingSessionPanelMobile({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
+  actionBodyAppend,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -189,6 +190,7 @@ export function CoachingSessionPanelMobile({
                 coacheeName={coacheeName}
                 isAddingAction={isAddingAction}
                 onAddingActionChange={onAddingActionChange}
+                actionBodyAppend={actionBodyAppend}
                 onStatusChange={onStatusChange}
                 onDueDateChange={onDueDateChange}
                 onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/components/lib/utils";
 import { toast } from "@/components/ui/use-toast";
@@ -43,6 +43,7 @@ import {
 } from "@/types/goal";
 import type { Id } from "@/types/general";
 import { ItemStatus } from "@/types/general";
+import { type Option, Some, None } from "@/types/option";
 import { DateTime } from "ts-luxon";
 import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
 import { siteConfig } from "@/site.config";
@@ -93,6 +94,8 @@ export interface CoachingSessionPanelSharedProps {
   onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
+  /** Selected notes text to seed/append into the add-action form. */
+  actionBodyAppend: Option<{ text: string; nonce: number }>;
   locale: string;
   activeActionTab: ActionTab;
   onActiveActionTabChange: (tab: ActionTab) => void;
@@ -273,6 +276,8 @@ interface CoachingSessionPanelProps {
   defaultSection?: PanelSection;
   /** Called when the user switches sections, so the page can sync to URL */
   onSectionChange?: (section: PanelSection) => void;
+  /** Notes "Add as Action" selection; a new nonce opens/seeds the add-form. */
+  actionDraft?: Option<{ body: string; nonce: number }>;
 }
 
 export function CoachingSessionPanel({
@@ -283,6 +288,7 @@ export function CoachingSessionPanel({
   readOnly = false,
   defaultSection = PanelSection.Goals,
   onSectionChange: onSectionChangeExternal,
+  actionDraft = None,
 }: CoachingSessionPanelProps) {
   // ── Resolve user/relationship context for actions ───────────────
   const userId = useAuthStore((state) => state.userId);
@@ -683,6 +689,27 @@ export function CoachingSessionPanel({
   const [isAddingAction, setIsAddingAction] = useState(false);
   const [activeActionTab, setActiveActionTab] = useState<ActionTab>("new");
 
+  // Notes selection routed into the add-action form; appending to an empty
+  // body seeds it, so one signal covers both fresh-open and in-progress.
+  const [actionBodyAppend, setActionBodyAppend] =
+    useState<Option<{ text: string; nonce: number }>>(None);
+  const handledDraftNonce = useRef(0);
+
+  // Open the Actions add-form on a new draft nonce (render-time own-state
+  // adjustment, mirroring action-section-content's requiredTab pattern).
+  if (actionDraft.some && actionDraft.val.nonce !== handledDraftNonce.current) {
+    handledDraftNonce.current = actionDraft.val.nonce;
+    setActiveSection(PanelSection.Actions);
+    if (!isAddingAction) setIsAddingAction(true);
+    setActionBodyAppend(Some({ text: actionDraft.val.body, nonce: actionDraft.val.nonce }));
+  }
+
+  // Clear the append signal on close so a later fresh "Add" starts blank.
+  const handleAddingActionChange = useCallback((adding: boolean) => {
+    setIsAddingAction(adding);
+    if (!adding) setActionBodyAppend(None);
+  }, []);
+
   // ── Agreement state & handlers ──────────────────────────────────
 
   const [isAddingAgreement, setIsAddingAgreement] = useState(false);
@@ -803,7 +830,8 @@ export function CoachingSessionPanel({
     onGoalChange: handleGoalChange,
     onBodyChange: handleBodyChange,
     isAddingAction,
-    onAddingActionChange: setIsAddingAction,
+    onAddingActionChange: handleAddingActionChange,
+    actionBodyAppend,
     locale: siteConfig.locale,
     activeActionTab,
     onActiveActionTabChange: setActiveActionTab,

--- a/src/components/ui/coaching-sessions/coaching-tabs-container.tsx
+++ b/src/components/ui/coaching-sessions/coaching-tabs-container.tsx
@@ -1,102 +1,23 @@
 "use client";
 
-import { useCallback } from "react";
-import { toast } from "sonner";
 import { Maximize2, Minimize2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { CoachingNotes } from "@/components/ui/coaching-sessions/coaching-notes";
-import { useActionMutation } from "@/lib/api/actions";
-import { useUserActionsList } from "@/lib/api/user-actions";
-import { UserActionsScope } from "@/types/assigned-actions";
-import { ItemStatus, Id, EntityApiError } from "@/types/general";
-import { defaultAction } from "@/types/action";
-import type { Action } from "@/types/action";
-import { DateTime } from "ts-luxon";
-import { useCurrentCoachingSession } from "@/lib/hooks/use-current-coaching-session";
-import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 
 interface CoachingTabsContainerProps {
-  userId: Id;
   isMaximized?: boolean;
   onToggleMaximize?: () => void;
+  /** Forwards text selected in the notes to the panel's add-action flow. */
+  onAddActionFromNote: (selectedText: string) => void;
 }
 
 const CoachingTabsContainer = ({
-  userId,
   isMaximized = false,
   onToggleMaximize,
+  onAddActionFromNote,
 }: CoachingTabsContainerProps) => {
-  // Get coaching session ID and data from URL
-  const { currentCoachingSessionId } = useCurrentCoachingSession();
-
-  // Get coaching relationship data
-  const { currentCoachingRelationship } = useCurrentCoachingRelationship();
-
-  // SWR refresh handles for user action lists. The panel uses the same
-  // hooks with the same params, so SWR deduplicates the fetches — no extra
-  // network requests. We need these here so handleAddNoteAsAction can
-  // trigger the same cache revalidation.
-  const { refresh: refreshSessionActions } = useUserActionsList(
-    userId,
-    currentCoachingSessionId
-      ? { scope: UserActionsScope.Sessions, coaching_session_id: currentCoachingSessionId }
-      : undefined
-  );
-  const { refresh: refreshAllActions } = useUserActionsList(
-    userId,
-    currentCoachingRelationship
-      ? { scope: UserActionsScope.Sessions, coaching_relationship_id: currentCoachingRelationship.id }
-      : undefined
-  );
-
-  // Action mutation hook (for creating actions from notes)
-  const { create: createAction } = useActionMutation();
-
-  const handleActionAdded = useCallback((
-    body: string,
-    status: ItemStatus,
-    dueBy: DateTime,
-    assigneeIds?: Id[]
-  ): Promise<Action> => {
-    const newAction: Action = {
-      ...defaultAction(),
-      coaching_session_id: currentCoachingSessionId!,
-      user_id: userId,
-      body,
-      status,
-      due_by: dueBy,
-      assignee_ids: assigneeIds,
-    };
-    return createAction(newAction);
-  }, [currentCoachingSessionId, userId, createAction]);
-
-  // Create an action from selected text in coaching notes
-  const handleAddNoteAsAction = useCallback(async (selectedText: string) => {
-    if (!currentCoachingSessionId) return;
-
-    const trimmed = selectedText.trim();
-    if (!trimmed) return;
-
-    try {
-      await handleActionAdded(
-        trimmed,
-        ItemStatus.NotStarted,
-        DateTime.now().plus({ days: 7 }),
-      );
-      refreshSessionActions();
-      refreshAllActions();
-      toast.success("Action created from note");
-    } catch (err) {
-      if (err instanceof EntityApiError && err.isNetworkError()) {
-        toast.error("Failed to create action. Connection to service was lost.");
-      } else {
-        toast.error("Failed to create action.");
-      }
-    }
-  }, [currentCoachingSessionId, handleActionAdded, refreshSessionActions, refreshAllActions]);
-
   return (
     <Card className="row-span-1 h-full flex flex-col min-h-0 min-w-0">
       <CardHeader className="p-4 pb-0">
@@ -129,7 +50,7 @@ const CoachingTabsContainer = ({
 
       <CardContent className="p-4 pt-0 flex-1 flex flex-col min-h-0 min-w-0">
         <div className="mt-4 flex-1 flex flex-col min-h-0 min-w-0">
-          <CoachingNotes onAddAsAction={handleAddNoteAsAction} />
+          <CoachingNotes onAddAsAction={onAddActionFromNote} />
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Description
Selecting text in the coaching notes and choosing **"Add as Action"** now drives the existing manual add-action flow instead of silently creating a bare record. The selection becomes the new action's body in the Add form, so the coach can set status, due date, assignees, and goal before saving.

### Changes
* Notes selection now: expands the panel if collapsed, switches to the **Actions** section (syncing `?panel=actions`), opens the add form, and seeds its body with the selected text.
* If the add form is already open, the selection is **appended** to the in-progress body (a new paragraph) rather than replacing it.
* The notes card no longer creates the action directly; creation is deferred to the panel's existing **Save** path. The premature "Action created from note" toast is removed.
* Added a test covering body seeding + append-on-new-nonce.

### Screenshots / Videos Showing UI Changes (if applicable)

https://github.com/user-attachments/assets/dea56626-4fa1-4604-a639-05594285e4f9


### Testing Strategy
* `npx tsc --noEmit`, ESLint, and `npx vitest run __tests__/components/ui/coaching-sessions __tests__/app/coaching-sessions` all pass.
* Verified end-to-end against a running backend via Playwright — happy paths (expanded + collapsed→expand, seed, append, `panel=actions` in URL, Save persists) and sad paths (empty body disables Save; whitespace selection offers no "Add as Action").

### Concerns & Notes
* The `panel=actions` URL sync is deferred until the panel is expanded (gated on `!isGoalsCollapsed`) to avoid a same-tick `router.replace` clobber with the layout's focus/transcript params.
* Mobile: the action section lives in a `Sheet` whose open state is internal, so the seeded form is visible the next time the sheet is opened — auto-opening the mobile sheet is out of scope.
