### PR TITLE
Add agreements and goals from notes selection

### DIFF
--- a/__tests__/app/coaching-sessions/coaching-session-page.test.tsx
+++ b/__tests__/app/coaching-sessions/coaching-session-page.test.tsx
@@ -80,25 +80,34 @@ vi.mock('@/lib/hooks/use-sidebar', () => ({
 }))
 
 vi.mock('@/components/ui/coaching-sessions/coaching-session-panel', () => ({
-  CoachingSessionPanel: ({ readOnly, actionDraft }: any) => (
+  CoachingSessionPanel: ({ readOnly, noteSelection }: any) => (
     <div
       data-testid="coaching-session-panel"
       data-readonly={String(!!readOnly)}
-      data-draft-body={actionDraft?.some ? actionDraft.val.body : ''}
+      data-draft-section={noteSelection?.some ? noteSelection.val.section : ''}
+      data-draft-text={noteSelection?.some ? noteSelection.val.text : ''}
     >Goals</div>
   )
 }))
 
 vi.mock('@/components/ui/coaching-sessions/coaching-tabs-container', () => ({
-  CoachingTabsContainer: ({ onAddActionFromNote }: any) => (
+  CoachingTabsContainer: ({ onAddFromNote }: any) => (
     <div data-testid="coaching-tabs-container">
       <button
-        data-testid="trigger-add-from-note"
-        onClick={() => onAddActionFromNote('  Hello from the notes  ')}
-      >Add from note</button>
+        data-testid="trigger-add-action"
+        onClick={() => onAddFromNote('actions', '  Hello from the notes  ')}
+      >Add as action</button>
       <button
-        data-testid="trigger-add-from-note-blank"
-        onClick={() => onAddActionFromNote('   ')}
+        data-testid="trigger-add-agreement"
+        onClick={() => onAddFromNote('agreements', 'Weekly retro every Friday')}
+      >Add as agreement</button>
+      <button
+        data-testid="trigger-add-goal"
+        onClick={() => onAddFromNote('goals', 'Ship the onboarding revamp')}
+      >Add as goal</button>
+      <button
+        data-testid="trigger-add-blank"
+        onClick={() => onAddFromNote('actions', '   ')}
       >Add from blank note</button>
     </div>
   )
@@ -691,13 +700,14 @@ describe('CoachingSessionsPage - Panel visibility across URL states', () => {
 })
 
 /**
- * Test Suite: Add action from notes selection
+ * Test Suite: Add from notes selection
  *
- * Validates the page-level bridge from the notes "Add as Action" affordance:
- * the selected text is trimmed and handed to the panel as the action draft,
- * and (when the panel is already expanded) the URL is pinned to panel=actions.
+ * Validates the page-level bridge from the notes "Add as …" affordance: the
+ * selected text is trimmed and handed to the panel as a NoteSelection carrying
+ * its target section, and (when the panel is already expanded) the URL is
+ * pinned to panel=<section>. One mechanism, all three entity sections.
  */
-describe('CoachingSessionsPage - Add action from notes selection', () => {
+describe('CoachingSessionsPage - Add from notes selection', () => {
   const mockReplace = vi.fn()
 
   beforeEach(() => {
@@ -731,29 +741,40 @@ describe('CoachingSessionsPage - Add action from notes selection', () => {
     })
   })
 
-  it('passes the trimmed selection to the panel and pins panel=actions in the URL', async () => {
-    const user = userEvent.setup()
-    render(
-      <TestProviders>
-        <CoachingSessionsPage />
-      </TestProviders>
-    )
-
-    await user.click(screen.getByTestId('trigger-add-from-note'))
-
-    // Trim guard: surrounding whitespace from the selection is stripped.
-    expect(
-      screen.getByTestId('coaching-session-panel').getAttribute('data-draft-body')
-    ).toBe('Hello from the notes')
-
-    // Panel is expanded by default, so the deferred URL sync fires.
-    await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith(
-        expect.stringContaining('panel=actions'),
-        expect.objectContaining({ scroll: false })
+  it.each([
+    { testId: 'trigger-add-action', section: 'actions', text: 'Hello from the notes' },
+    { testId: 'trigger-add-agreement', section: 'agreements', text: 'Weekly retro every Friday' },
+    { testId: 'trigger-add-goal', section: 'goals', text: 'Ship the onboarding revamp' },
+  ])(
+    'passes the trimmed selection to the panel and pins panel=$section in the URL',
+    async ({ testId, section, text }) => {
+      const user = userEvent.setup()
+      render(
+        <TestProviders>
+          <CoachingSessionsPage />
+        </TestProviders>
       )
-    })
-  })
+
+      await user.click(screen.getByTestId(testId))
+
+      // Trim guard + correct section/text handed to the panel.
+      const panel = screen.getByTestId('coaching-session-panel')
+      expect(panel.getAttribute('data-draft-section')).toBe(section)
+      expect(panel.getAttribute('data-draft-text')).toBe(text)
+
+      // Panel is expanded by default, so the deferred URL sync fires. Goals is
+      // the default section, so its param is removed to keep the URL clean;
+      // the other two pin panel=<section>.
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith(
+          section === 'goals'
+            ? expect.not.stringContaining('panel=')
+            : expect.stringContaining(`panel=${section}`),
+          expect.objectContaining({ scroll: false })
+        )
+      })
+    }
+  )
 
   it('ignores a whitespace-only selection (no draft, no URL change)', async () => {
     const user = userEvent.setup()
@@ -763,14 +784,14 @@ describe('CoachingSessionsPage - Add action from notes selection', () => {
       </TestProviders>
     )
 
-    await user.click(screen.getByTestId('trigger-add-from-note-blank'))
+    await user.click(screen.getByTestId('trigger-add-blank'))
 
     // Guard bails before setting a draft or touching the URL.
     expect(
-      screen.getByTestId('coaching-session-panel').getAttribute('data-draft-body')
+      screen.getByTestId('coaching-session-panel').getAttribute('data-draft-text')
     ).toBe('')
     expect(mockReplace).not.toHaveBeenCalledWith(
-      expect.stringContaining('panel=actions'),
+      expect.stringContaining('panel='),
       expect.anything()
     )
   })

--- a/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
@@ -287,13 +287,13 @@ describe("ActionSectionContent", () => {
       expect(onAddingActionChange).toHaveBeenCalledWith(false);
     });
 
-    it("prefills the add-form body from a notes selection, then appends on a new nonce", async () => {
+    it("fills the add-form body from a notes selection, then appends on a new nonce", async () => {
       const { rerender } = render(
         <Wrapper>
           <ActionSectionContent
             {...baseProps({
               isAddingAction: true,
-              actionBodyPrefill: Some({ text: "First selection", nonce: 1 }),
+              actionBodyAppend: Some({ text: "First selection", nonce: 1 }),
             })}
           />
         </Wrapper>
@@ -308,7 +308,7 @@ describe("ActionSectionContent", () => {
           <ActionSectionContent
             {...baseProps({
               isAddingAction: true,
-              actionBodyPrefill: Some({ text: "Second selection", nonce: 2 }),
+              actionBodyAppend: Some({ text: "Second selection", nonce: 2 }),
             })}
           />
         </Wrapper>

--- a/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-section-content.test.tsx
@@ -287,13 +287,13 @@ describe("ActionSectionContent", () => {
       expect(onAddingActionChange).toHaveBeenCalledWith(false);
     });
 
-    it("seeds the add-form body from a notes selection, then appends on a new nonce", async () => {
+    it("prefills the add-form body from a notes selection, then appends on a new nonce", async () => {
       const { rerender } = render(
         <Wrapper>
           <ActionSectionContent
             {...baseProps({
               isAddingAction: true,
-              actionBodyAppend: Some({ text: "First selection", nonce: 1 }),
+              actionBodyPrefill: Some({ text: "First selection", nonce: 1 }),
             })}
           />
         </Wrapper>
@@ -308,7 +308,7 @@ describe("ActionSectionContent", () => {
           <ActionSectionContent
             {...baseProps({
               isAddingAction: true,
-              actionBodyAppend: Some({ text: "Second selection", nonce: 2 }),
+              actionBodyPrefill: Some({ text: "Second selection", nonce: 2 }),
             })}
           />
         </Wrapper>

--- a/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
@@ -342,57 +342,81 @@ describe("CoachingSessionPanel", () => {
     })
   })
 
-  it("opens the Actions add-form seeded with a notes selection", async () => {
-    setupMocks()
-    render(
-      <TooltipProvider>
-        <CoachingSessionPanel
-          coachingSessionId="session-1"
-          coachingRelationshipId="rel-1"
-          actionDraft={Some({ body: "Follow up on hiring plan", nonce: 1 })}
-        />
-      </TooltipProvider>
-    )
+  // One mechanism, three entities — a NoteSelection for section X opens X's
+  // add-form seeded with the text in its primary field (body for Actions /
+  // Agreements, title for Goals). Asserts observable form state, not the
+  // internal target registry.
+  const seedCases = [
+    { section: PanelSection.Actions, text: "Follow up on hiring plan" },
+    { section: PanelSection.Agreements, text: "Weekly retro every Friday" },
+    { section: PanelSection.Goals, text: "Ship the onboarding revamp" },
+  ] as const
 
-    // The render-time draft handler switches to Actions and opens the add
-    // form; the append signal seeds its body.
-    await waitFor(() => {
-      const textarea = screen.getAllByRole("textbox")[0] as HTMLTextAreaElement
-      expect(textarea.value).toBe("Follow up on hiring plan")
-    })
-  })
+  it.each(seedCases)(
+    "opens the $section add-form seeded with a notes selection",
+    async ({ section, text }) => {
+      setupMocks()
+      render(
+        <TooltipProvider>
+          <CoachingSessionPanel
+            coachingSessionId="session-1"
+            coachingRelationshipId="rel-1"
+            noteSelection={Some({ section, text, nonce: 1 })}
+          />
+        </TooltipProvider>
+      )
 
-  it("starts a fresh Add blank after a seeded form is closed", async () => {
-    const user = userEvent.setup()
-    setupMocks()
-    render(
-      <TooltipProvider>
-        <CoachingSessionPanel
-          coachingSessionId="session-1"
-          coachingRelationshipId="rel-1"
-          actionDraft={Some({ body: "Seeded from note", nonce: 1 })}
-        />
-      </TooltipProvider>
-    )
+      await waitFor(() => {
+        const values = screen
+          .getAllByRole("textbox")
+          .map((el) => (el as HTMLInputElement | HTMLTextAreaElement).value)
+        expect(values).toContain(text)
+      })
+    }
+  )
 
-    await waitFor(() => {
-      expect(
-        (screen.getAllByRole("textbox")[0] as HTMLTextAreaElement).value
-      ).toBe("Seeded from note")
-    })
+  // Body-seeded entities (Actions, Agreements) reuse the same card with a
+  // persistent add-state, so the seed must be cleared on close or a fresh
+  // "Add" would re-show it.
+  it.each([
+    { section: PanelSection.Actions, text: "Seeded action" },
+    { section: PanelSection.Agreements, text: "Seeded agreement" },
+  ] as const)(
+    "starts a fresh $section Add blank after a seeded form is closed",
+    async ({ section, text }) => {
+      const user = userEvent.setup()
+      setupMocks()
+      render(
+        <TooltipProvider>
+          <CoachingSessionPanel
+            coachingSessionId="session-1"
+            coachingRelationshipId="rel-1"
+            noteSelection={Some({ section, text, nonce: 1 })}
+          />
+        </TooltipProvider>
+      )
 
-    // Close the seeded form, then re-open via the Add button. The append
-    // signal must have been cleared so the fresh form starts blank — and the
-    // still-present actionDraft prop must NOT re-seed it (nonce dedup).
-    await user.click(screen.getAllByRole("button", { name: /cancel/i })[0])
-    await user.click(screen.getAllByRole("button", { name: /^add$/i })[0])
+      await waitFor(() => {
+        const values = screen
+          .getAllByRole("textbox")
+          .map((el) => (el as HTMLTextAreaElement).value)
+        expect(values).toContain(text)
+      })
 
-    await waitFor(() => {
-      expect(
-        (screen.getAllByRole("textbox")[0] as HTMLTextAreaElement).value
-      ).toBe("")
-    })
-  })
+      // Close the seeded form, then re-open via Add. The seed must have been
+      // cleared, and the still-present noteSelection (same nonce) must NOT
+      // re-seed it.
+      await user.click(screen.getAllByRole("button", { name: /cancel/i })[0])
+      await user.click(screen.getAllByRole("button", { name: /^add$/i })[0])
+
+      await waitFor(() => {
+        const values = screen
+          .getAllByRole("textbox")
+          .map((el) => (el as HTMLTextAreaElement).value)
+        expect(values).not.toContain(text)
+      })
+    }
+  )
 
   it("undo restores the deleted agreement", async () => {
     const user = userEvent.setup()

--- a/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/coaching-session-panel.test.tsx
@@ -343,17 +343,17 @@ describe("CoachingSessionPanel", () => {
   })
 
   // One mechanism, three entities — a NoteSelection for section X opens X's
-  // add-form seeded with the text in its primary field (body for Actions /
+  // add-form prefilled with the text in its primary field (body for Actions /
   // Agreements, title for Goals). Asserts observable form state, not the
   // internal target registry.
-  const seedCases = [
+  const prefillCases = [
     { section: PanelSection.Actions, text: "Follow up on hiring plan" },
     { section: PanelSection.Agreements, text: "Weekly retro every Friday" },
     { section: PanelSection.Goals, text: "Ship the onboarding revamp" },
   ] as const
 
-  it.each(seedCases)(
-    "opens the $section add-form seeded with a notes selection",
+  it.each(prefillCases)(
+    "opens the $section add-form prefilled with a notes selection",
     async ({ section, text }) => {
       setupMocks()
       render(
@@ -375,14 +375,14 @@ describe("CoachingSessionPanel", () => {
     }
   )
 
-  // Body-seeded entities (Actions, Agreements) reuse the same card with a
-  // persistent add-state, so the seed must be cleared on close or a fresh
+  // Body-prefilled entities (Actions, Agreements) reuse the same card with a
+  // persistent add-state, so the prefill must be cleared on close or a fresh
   // "Add" would re-show it.
   it.each([
-    { section: PanelSection.Actions, text: "Seeded action" },
-    { section: PanelSection.Agreements, text: "Seeded agreement" },
+    { section: PanelSection.Actions, text: "Prefilled action" },
+    { section: PanelSection.Agreements, text: "Prefilled agreement" },
   ] as const)(
-    "starts a fresh $section Add blank after a seeded form is closed",
+    "starts a fresh $section Add blank after a prefilled form is closed",
     async ({ section, text }) => {
       const user = userEvent.setup()
       setupMocks()
@@ -403,9 +403,9 @@ describe("CoachingSessionPanel", () => {
         expect(values).toContain(text)
       })
 
-      // Close the seeded form, then re-open via Add. The seed must have been
+      // Close the prefilled form, then re-open via Add. The prefill must have been
       // cleared, and the still-present noteSelection (same nonce) must NOT
-      // re-seed it.
+      // re-prefill it.
       await user.click(screen.getAllByRole("button", { name: /cancel/i })[0])
       await user.click(screen.getAllByRole("button", { name: /^add$/i })[0])
 

--- a/__tests__/components/ui/tiptap-ui/selection-bubble-menu.test.tsx
+++ b/__tests__/components/ui/tiptap-ui/selection-bubble-menu.test.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import userEvent from "@testing-library/user-event";
 import { EditorProvider } from "@tiptap/react";
 import Document from "@tiptap/extension-document";
 import Paragraph from "@tiptap/extension-paragraph";
@@ -135,7 +134,7 @@ describe("shouldShowSelectionMenu", () => {
 // ---------------------------------------------------------------------------
 
 describe("SelectionBubbleMenu", () => {
-  const mockOnAddAsAction = vi.fn();
+  const mockOnAddAs = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -152,16 +151,14 @@ describe("SelectionBubbleMenu", () => {
         content={content}
         immediatelyRender={false}
       >
-        <SelectionBubbleMenu onAddAsAction={mockOnAddAsAction} />
+        <SelectionBubbleMenu onAddAs={mockOnAddAs} />
       </EditorProvider>
     );
   };
 
   it("renders without crashing when no editor is available", () => {
     // SelectionBubbleMenu without an EditorProvider should return null
-    renderWithProviders(
-      <SelectionBubbleMenu onAddAsAction={mockOnAddAsAction} />
-    );
+    renderWithProviders(<SelectionBubbleMenu onAddAs={mockOnAddAs} />);
     // No errors thrown = pass
   });
 
@@ -179,7 +176,7 @@ describe("SelectionBubbleMenu", () => {
     // tests require programmatic selection which is limited in jsdom.
   });
 
-  it("does not call onAddAsAction before user interaction", async () => {
+  it("does not call onAddAs before user interaction", async () => {
     renderEditor("<p>Some note text to select</p>");
 
     await waitFor(() => {
@@ -187,7 +184,7 @@ describe("SelectionBubbleMenu", () => {
       expect(editor).toBeInTheDocument();
     });
 
-    expect(mockOnAddAsAction).not.toHaveBeenCalled();
+    expect(mockOnAddAs).not.toHaveBeenCalled();
   });
 
   it("does not call clipboard.writeText before user interaction", async () => {
@@ -204,10 +201,7 @@ describe("SelectionBubbleMenu", () => {
   it("accepts an optional editor prop", () => {
     // Passing editor=null should not crash
     renderWithProviders(
-      <SelectionBubbleMenu
-        editor={null}
-        onAddAsAction={mockOnAddAsAction}
-      />
+      <SelectionBubbleMenu editor={null} onAddAs={mockOnAddAs} />
     );
     // No errors thrown = pass
   });

--- a/__tests__/e2e/add-from-notes-selection.spec.ts
+++ b/__tests__/e2e/add-from-notes-selection.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect, type Page } from '@playwright/test'
+import {
+  setupAuthentication,
+  mockCommonApiRoutes,
+  MOCK_USER_ID,
+  SINGLE_RELATIONSHIP,
+} from './helpers'
+
+// ---------------------------------------------------------------------------
+// Lean E2E for the "Add as …" notes-selection feature.
+//
+// The seed itself originates in the TipTap collab notes editor, which is not
+// reachable under mocked routes (it needs a live collab JWT + websocket and a
+// 10s offline-editing fallback). That seam is covered by unit/integration
+// tests and verified manually. This spec covers the part that IS reachable in
+// the real browser: for each panel section, the add-flow the selection drives
+// opens its add-form, and (for agreements) Save persists via the create POST.
+// ---------------------------------------------------------------------------
+
+const SESSION_ID = 'session-add-from-notes'
+const RELATIONSHIP_ID = SINGLE_RELATIONSHIP[0].id
+
+// Make the signed-in user the coach so the panel is editable (the add-flows
+// are hidden when readOnly), and date the session in the future so it isn't
+// treated as a past, read-only session.
+const MOCK_RELATIONSHIP = { ...SINGLE_RELATIONSHIP[0], coach_id: MOCK_USER_ID }
+
+const MOCK_SESSION = {
+  id: SESSION_ID,
+  coaching_relationship_id: RELATIONSHIP_ID,
+  date: '2027-03-25T10:00:00Z',
+  created_at: '2026-03-01T00:00:00Z',
+  updated_at: '2026-03-01T00:00:00Z',
+}
+
+async function setupCoachingSessionPage(page: Page) {
+  const relStateJson = JSON.stringify({
+    state: { currentCoachingRelationshipId: RELATIONSHIP_ID },
+    version: 1,
+  })
+  await page.addInitScript(
+    (json) => sessionStorage.setItem('coaching-relationship-state-store', json),
+    relStateJson
+  )
+
+  await mockCommonApiRoutes(page, {
+    relationships: [MOCK_RELATIONSHIP],
+    coachingSessions: [MOCK_SESSION],
+  })
+
+  await page.route(`**/coaching_sessions/${SESSION_ID}`, async (route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: MOCK_SESSION }),
+      })
+    } else {
+      await route.continue()
+    }
+  })
+
+  await page.route(
+    `**/organizations/org-1/coaching_relationships/${RELATIONSHIP_ID}`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: MOCK_RELATIONSHIP }),
+      })
+    }
+  )
+
+  await page.route(`**/users/${MOCK_USER_ID}/actions**`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    })
+  })
+
+  await page.route(`**/coaching_sessions/${SESSION_ID}/goals`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    })
+  })
+
+  await page.route('**/coaching_sessions/goals**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: [] }),
+    })
+  })
+}
+
+async function dismissDevErrorOverlay(page: Page) {
+  const overlay = page.locator('nextjs-portal')
+  if (await overlay.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await page.keyboard.press('Escape')
+    await page.waitForTimeout(300)
+  }
+}
+
+test.describe('Add from notes selection: panel add-flows', () => {
+  test.beforeEach(async ({ page, context }) => {
+    await setupAuthentication(page, context)
+    await setupCoachingSessionPage(page)
+  })
+
+  test('Actions section opens an add-form with a body editor', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, 'Desktop panel layout test only')
+
+    await page.route('**/agreements**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [] }),
+      })
+    })
+
+    await page.goto(`/coaching-sessions/${SESSION_ID}?panel=actions`)
+    await dismissDevErrorOverlay(page)
+
+    await expect(page.getByTestId('action-tab-new')).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole('button', { name: /^add$/i }).first().click()
+
+    // The new-action card mounts in edit mode with a body editor.
+    const sessionContent = page.getByTestId('session-section-content')
+    await expect(sessionContent.getByRole('textbox').first()).toBeVisible()
+  })
+
+  test('Goals section reaches the create-goal form with a title field', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, 'Desktop panel layout test only')
+
+    await page.route('**/agreements**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [] }),
+      })
+    })
+
+    await page.goto(`/coaching-sessions/${SESSION_ID}?panel=goals`)
+    await dismissDevErrorOverlay(page)
+
+    // Add → browse view → Create new → the create form (title-first).
+    await page.getByRole('button', { name: /^add$/i }).first().click()
+    await page.getByRole('button', { name: /create new/i }).first().click()
+
+    await expect(
+      page.getByPlaceholder(/what do you want to achieve/i)
+    ).toBeVisible({ timeout: 15_000 })
+  })
+
+  test('Agreements section opens an add-form and Save persists via the create POST', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(!!isMobile, 'Desktop panel layout test only')
+
+    let createdBody: string | null = null
+    await page.route('**/agreements**', async (route) => {
+      const req = route.request()
+      if (req.method() === 'POST') {
+        const payload = req.postDataJSON() as { body?: string }
+        createdBody = payload?.body ?? null
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            data: {
+              id: 'agreement-new',
+              coaching_session_id: SESSION_ID,
+              body: createdBody,
+              created_at: '2026-03-25T10:00:00Z',
+              updated_at: '2026-03-25T10:00:00Z',
+            },
+          }),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [] }),
+        })
+      }
+    })
+
+    await page.goto(`/coaching-sessions/${SESSION_ID}?panel=agreements`)
+    await dismissDevErrorOverlay(page)
+
+    await page.getByRole('button', { name: /^add$/i }).first().click()
+
+    const editor = page.getByRole('textbox').first()
+    await expect(editor).toBeVisible({ timeout: 15_000 })
+    await editor.fill('Weekly retro every Friday')
+
+    await page.getByRole('button', { name: /^save$/i }).first().click()
+
+    await expect.poll(() => createdBody).toBe('Weekly retro every Friday')
+  })
+})

--- a/__tests__/e2e/add-from-notes-selection.spec.ts
+++ b/__tests__/e2e/add-from-notes-selection.spec.ts
@@ -9,7 +9,7 @@ import {
 // ---------------------------------------------------------------------------
 // Lean E2E for the "Add as …" notes-selection feature.
 //
-// The seed itself originates in the TipTap collab notes editor, which is not
+// The prefill itself originates in the TipTap collab notes editor, which is not
 // reachable under mocked routes (it needs a live collab JWT + websocket and a
 // 10s offline-editing fallback). That seam is covered by unit/integration
 // tests and verified manually. This spec covers the part that IS reachable in

--- a/__tests__/lib/hooks/use-add-from-notes.test.tsx
+++ b/__tests__/lib/hooks/use-add-from-notes.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useAddFromNotes } from "@/lib/hooks/use-add-from-notes";
+import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
+
+// The hook owns the selection state + nonce + the "pin section once per nonce
+// when expanded" effect. It delegates the URL write to the injected
+// `pinSection` and the panel expansion to `toggleGoalsCollapsed`, so we assert
+// behavior through the returned API and those callbacks.
+
+describe("useAddFromNotes", () => {
+  let pinSection: ReturnType<typeof vi.fn>;
+  let toggleGoalsCollapsed: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    pinSection = vi.fn();
+    toggleGoalsCollapsed = vi.fn();
+  });
+
+  const setup = (isGoalsCollapsed: boolean) =>
+    renderHook(
+      ({ collapsed }: { collapsed: boolean }) =>
+        useAddFromNotes({
+          isGoalsCollapsed: collapsed,
+          toggleGoalsCollapsed,
+          pinSection,
+        }),
+      { initialProps: { collapsed: isGoalsCollapsed } }
+    );
+
+  it("starts with no selection", () => {
+    const { result } = setup(false);
+    expect(result.current.selection.some).toBe(false);
+  });
+
+  it("ignores a whitespace-only selection (no selection, no URL change)", () => {
+    const { result } = setup(false);
+    act(() => result.current.addFromNote(PanelSection.Actions, "   "));
+    expect(result.current.selection.some).toBe(false);
+    expect(pinSection).not.toHaveBeenCalled();
+  });
+
+  it("emits a trimmed selection carrying the section, and pins it when expanded", () => {
+    const { result } = setup(false);
+    act(() =>
+      result.current.addFromNote(PanelSection.Agreements, "  do the thing  ")
+    );
+
+    expect(result.current.selection.some).toBe(true);
+    if (result.current.selection.some) {
+      expect(result.current.selection.val.section).toBe(PanelSection.Agreements);
+      expect(result.current.selection.val.text).toBe("do the thing");
+    }
+    expect(pinSection).toHaveBeenCalledWith(PanelSection.Agreements);
+  });
+
+  it("bumps the nonce on each call", () => {
+    const { result } = setup(false);
+    act(() => result.current.addFromNote(PanelSection.Actions, "one"));
+    const first =
+      result.current.selection.some && result.current.selection.val.nonce;
+    act(() => result.current.addFromNote(PanelSection.Actions, "two"));
+    const second =
+      result.current.selection.some && result.current.selection.val.nonce;
+    expect(typeof first).toBe("number");
+    expect(second).toBe((first as number) + 1);
+  });
+
+  it("expands the panel when collapsed and defers the URL pin until expanded", () => {
+    const { result, rerender } = setup(true);
+    act(() => result.current.addFromNote(PanelSection.Goals, "a goal"));
+
+    // Collapsed: request expansion, but do not pin the section yet (would
+    // clobber the layout's focus/transcript params on the same tick).
+    expect(toggleGoalsCollapsed).toHaveBeenCalledTimes(1);
+    expect(pinSection).not.toHaveBeenCalled();
+
+    // Once expanded, the deferred pin fires exactly once for this nonce.
+    rerender({ collapsed: false });
+    expect(pinSection).toHaveBeenCalledTimes(1);
+    expect(pinSection).toHaveBeenCalledWith(PanelSection.Goals);
+  });
+
+  it("pins each section only once per nonce", () => {
+    const { result, rerender } = setup(false);
+    act(() => result.current.addFromNote(PanelSection.Actions, "x"));
+    rerender({ collapsed: false }); // unrelated re-render
+    expect(pinSection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/hooks/use-field-prefill.test.tsx
+++ b/__tests__/lib/hooks/use-field-prefill.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 
-import { useSeededField } from "@/lib/hooks/use-seeded-field";
+import { useFieldPrefill } from "@/lib/hooks/use-field-prefill";
 import { type Option, Some, None } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
 
@@ -10,17 +10,17 @@ import type { NoteField } from "@/types/note-selection";
 // passes, so we assert the closure is invoked with the right text at the
 // right times — never the hook's internals.
 
-describe("useSeededField", () => {
+describe("useFieldPrefill", () => {
   it("does not call apply when the field is None", () => {
     const apply = vi.fn();
-    renderHook(() => useSeededField(None, apply));
+    renderHook(() => useFieldPrefill(None, apply));
     expect(apply).not.toHaveBeenCalled();
   });
 
   it("calls apply with the text when a field is present", () => {
     const apply = vi.fn();
     renderHook(() =>
-      useSeededField(Some({ text: "hello", nonce: 1 }), apply)
+      useFieldPrefill(Some({ text: "hello", nonce: 1 }), apply)
     );
     expect(apply).toHaveBeenCalledTimes(1);
     expect(apply).toHaveBeenCalledWith("hello");
@@ -29,7 +29,7 @@ describe("useSeededField", () => {
   it("does not re-apply on re-render with the same nonce", () => {
     const apply = vi.fn();
     const { rerender } = renderHook(
-      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      ({ field }: { field: Option<NoteField> }) => useFieldPrefill(field, apply),
       { initialProps: { field: Some({ text: "hello", nonce: 1 }) } }
     );
     // Same nonce, new object identity — must still be deduped.
@@ -40,7 +40,7 @@ describe("useSeededField", () => {
   it("applies again when the nonce advances", () => {
     const apply = vi.fn();
     const { rerender } = renderHook(
-      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      ({ field }: { field: Option<NoteField> }) => useFieldPrefill(field, apply),
       { initialProps: { field: Some({ text: "first", nonce: 1 }) } }
     );
     rerender({ field: Some({ text: "second", nonce: 2 }) });
@@ -50,13 +50,13 @@ describe("useSeededField", () => {
   });
 
   it("supports an append policy at the call site", () => {
-    // Mirrors Action/Agreement body seeding.
+    // Mirrors Action/Agreement body prefilling.
     let body = "";
     const apply = (t: string) => {
       body = body.trim() ? `${body}\n\n${t}` : t;
     };
     const { rerender } = renderHook(
-      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      ({ field }: { field: Option<NoteField> }) => useFieldPrefill(field, apply),
       { initialProps: { field: Some({ text: "First", nonce: 1 }) } }
     );
     expect(body).toBe("First");
@@ -65,16 +65,16 @@ describe("useSeededField", () => {
   });
 
   it("supports a replace-if-empty policy at the call site", () => {
-    // Mirrors Goal title seeding: only seed when the field is still empty.
+    // Mirrors Goal title prefilling: only prefill when the field is still empty.
     let title = "";
     const apply = (t: string) => {
       title = title.trim() ? title : t;
     };
     const { rerender } = renderHook(
-      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
-      { initialProps: { field: Some({ text: "Seeded title", nonce: 1 }) } }
+      ({ field }: { field: Option<NoteField> }) => useFieldPrefill(field, apply),
+      { initialProps: { field: Some({ text: "Prefilled title", nonce: 1 }) } }
     );
-    expect(title).toBe("Seeded title");
+    expect(title).toBe("Prefilled title");
     // User has since typed; a new nonce must not clobber it.
     title = "User typed";
     rerender({ field: Some({ text: "Other", nonce: 2 }) });

--- a/__tests__/lib/hooks/use-seeded-field.test.tsx
+++ b/__tests__/lib/hooks/use-seeded-field.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useSeededField } from "@/lib/hooks/use-seeded-field";
+import { type Option, Some, None } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
+
+// These tests exercise the hook through its (field, apply) contract only.
+// The append-vs-replace policy lives in the `apply` closure each call site
+// passes, so we assert the closure is invoked with the right text at the
+// right times — never the hook's internals.
+
+describe("useSeededField", () => {
+  it("does not call apply when the field is None", () => {
+    const apply = vi.fn();
+    renderHook(() => useSeededField(None, apply));
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it("calls apply with the text when a field is present", () => {
+    const apply = vi.fn();
+    renderHook(() =>
+      useSeededField(Some({ text: "hello", nonce: 1 }), apply)
+    );
+    expect(apply).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledWith("hello");
+  });
+
+  it("does not re-apply on re-render with the same nonce", () => {
+    const apply = vi.fn();
+    const { rerender } = renderHook(
+      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      { initialProps: { field: Some({ text: "hello", nonce: 1 }) } }
+    );
+    // Same nonce, new object identity — must still be deduped.
+    rerender({ field: Some({ text: "hello", nonce: 1 }) });
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies again when the nonce advances", () => {
+    const apply = vi.fn();
+    const { rerender } = renderHook(
+      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      { initialProps: { field: Some({ text: "first", nonce: 1 }) } }
+    );
+    rerender({ field: Some({ text: "second", nonce: 2 }) });
+    expect(apply).toHaveBeenCalledTimes(2);
+    expect(apply).toHaveBeenNthCalledWith(1, "first");
+    expect(apply).toHaveBeenNthCalledWith(2, "second");
+  });
+
+  it("supports an append policy at the call site", () => {
+    // Mirrors Action/Agreement body seeding.
+    let body = "";
+    const apply = (t: string) => {
+      body = body.trim() ? `${body}\n\n${t}` : t;
+    };
+    const { rerender } = renderHook(
+      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      { initialProps: { field: Some({ text: "First", nonce: 1 }) } }
+    );
+    expect(body).toBe("First");
+    rerender({ field: Some({ text: "Second", nonce: 2 }) });
+    expect(body).toBe("First\n\nSecond");
+  });
+
+  it("supports a replace-if-empty policy at the call site", () => {
+    // Mirrors Goal title seeding: only seed when the field is still empty.
+    let title = "";
+    const apply = (t: string) => {
+      title = title.trim() ? title : t;
+    };
+    const { rerender } = renderHook(
+      ({ field }: { field: Option<NoteField> }) => useSeededField(field, apply),
+      { initialProps: { field: Some({ text: "Seeded title", nonce: 1 }) } }
+    );
+    expect(title).toBe("Seeded title");
+    // User has since typed; a new nonce must not clobber it.
+    title = "User typed";
+    rerender({ field: Some({ text: "Other", nonce: 2 }) });
+    expect(title).toBe("User typed");
+  });
+});

--- a/src/app/coaching-sessions/[id]/page.tsx
+++ b/src/app/coaching-sessions/[id]/page.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { Separator } from "@/components/ui/separator";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { type Option, Some, None } from "@/types/option";
+import { useCallback, useEffect, useRef } from "react";
 
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useAddFromNotes } from "@/lib/hooks/use-add-from-notes";
 
 import { siteConfig } from "@/site.config";
 import { CoachingSessionTitle } from "@/components/ui/coaching-sessions/coaching-session-title";
@@ -138,13 +138,6 @@ export default function CoachingSessionsPage() {
   // Three-pane layout state (focus mode + transcript visibility). URL-backed.
   const layout = useCoachingSessionLayout();
 
-  // Bridge from the notes "Add as Action" selection to the panel's add-action
-  // form: bump a monotonic nonce so the panel reacts once per selection.
-  const [actionDraft, setActionDraft] =
-    useState<Option<{ body: string; nonce: number }>>(None);
-  const actionDraftNonce = useRef(0);
-  const syncedSectionNonce = useRef(0);
-
   const handlePanelSectionChange = useCallback(
     (section: PanelSection) => {
       const newSearchParams = new URLSearchParams(searchParams);
@@ -164,25 +157,13 @@ export default function CoachingSessionsPage() {
     [searchParams, router]
   );
 
-  const handleAddActionFromNote = useCallback(
-    (selectedText: string) => {
-      const trimmed = selectedText.trim();
-      if (!trimmed) return;
-      if (layout.isGoalsCollapsed) layout.toggleGoalsCollapsed();
-      actionDraftNonce.current += 1;
-      setActionDraft(Some({ body: trimmed, nonce: actionDraftNonce.current }));
-    },
-    [layout]
-  );
-
-  // Pin panel=actions once per draft, but only after the panel is expanded;
-  // gating on !isGoalsCollapsed avoids clobbering the focus/transcript params.
-  useEffect(() => {
-    if (!actionDraft.some || layout.isGoalsCollapsed) return;
-    if (actionDraft.val.nonce === syncedSectionNonce.current) return;
-    syncedSectionNonce.current = actionDraft.val.nonce;
-    handlePanelSectionChange(PanelSection.Actions);
-  }, [actionDraft, layout.isGoalsCollapsed, handlePanelSectionChange]);
+  // Bridge the notes "Add as …" affordance to the panel: a selection becomes a
+  // NoteSelection carrying its target section, pinned to the URL once expanded.
+  const { selection: noteSelection, addFromNote } = useAddFromNotes({
+    isGoalsCollapsed: layout.isGoalsCollapsed,
+    toggleGoalsCollapsed: layout.toggleGoalsCollapsed,
+    pinSection: handlePanelSectionChange,
+  });
 
   // Recording and transcription status — used for the header indicator.
   // TranscriptPanel calls the same hooks internally; SWR deduplicates the requests.
@@ -363,7 +344,7 @@ export default function CoachingSessionsPage() {
                 : false}
               defaultSection={panelSection}
               onSectionChange={handlePanelSectionChange}
-              actionDraft={actionDraft}
+              noteSelection={noteSelection}
             />
           )}
 
@@ -381,7 +362,7 @@ export default function CoachingSessionsPage() {
             <CoachingTabsContainer
               isMaximized={layout.isNotesMaximized}
               onToggleMaximize={layout.toggleNotesMaximized}
-              onAddActionFromNote={handleAddActionFromNote}
+              onAddFromNote={addFromNote}
             />
           )}
         </div>

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -77,8 +77,8 @@ export interface CompactActionCardProps {
   onGoalChange?: (id: Id, goalId: Id | undefined) => void;
   /** When true, card starts in edit mode (used for new actions). */
   initialEditing?: boolean;
-  /** Text appended into the edit body on nonce change (add-card prefilling). */
-  bodyPrefill?: Option<NoteField>;
+  /** Notes selection appended into the edit body on nonce change. */
+  bodyAppend?: Option<NoteField>;
   /** Called when the user dismisses an initial-editing card. */
   onDismiss?: () => void;
   className?: string;
@@ -103,7 +103,7 @@ export function CompactActionCard({
   onGoalChange,
   highlighted = false,
   initialEditing = false,
-  bodyPrefill = None,
+  bodyAppend = None,
   onDismiss,
   className,
 }: CompactActionCardProps) {
@@ -179,7 +179,7 @@ export function CompactActionCard({
             action={displayedAction}
             locale={locale}
             initialBody={body}
-            bodyPrefill={bodyPrefill}
+            bodyAppend={bodyAppend}
             allAssignees={allAssignees}
             resolvedAssignees={resolvedAssignees}
             assigneeIds={assigneeIds}
@@ -490,7 +490,7 @@ function ActionEditForm({
   action,
   locale,
   initialBody,
-  bodyPrefill = None,
+  bodyAppend = None,
   allAssignees,
   resolvedAssignees,
   assigneeIds,
@@ -506,7 +506,7 @@ function ActionEditForm({
   action: Action;
   locale: string;
   initialBody: string;
-  bodyPrefill?: Option<NoteField>;
+  bodyAppend?: Option<NoteField>;
   allAssignees: { id: Id; name: string; initials: string }[];
   resolvedAssignees: { id: Id; name: string; initials: string }[];
   assigneeIds: Id[];
@@ -524,8 +524,8 @@ function ActionEditForm({
   const markdownRef = useRef<TextareaMarkdownRef>(null);
   const textareaWrapRef = useRef<HTMLDivElement>(null);
 
-  // Append notes-selection text once per nonce (empty body → prefill).
-  useFieldPrefill(bodyPrefill, (text) =>
+  // Append the notes selection once per nonce (an empty body is just filled).
+  useFieldPrefill(bodyAppend, (text) =>
     setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
   );
 

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -28,7 +28,7 @@ import { useLinkedGoalDisplay } from "@/lib/hooks/use-linked-goal-display";
 import { ItemStatus, Id } from "@/types/general";
 import { type Option, None } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
-import { useSeededField } from "@/lib/hooks/use-seeded-field";
+import { useFieldPrefill } from "@/lib/hooks/use-field-prefill";
 import { cn } from "@/components/lib/utils";
 import { DateTime } from "ts-luxon";
 
@@ -77,8 +77,8 @@ export interface CompactActionCardProps {
   onGoalChange?: (id: Id, goalId: Id | undefined) => void;
   /** When true, card starts in edit mode (used for new actions). */
   initialEditing?: boolean;
-  /** Text appended into the edit body on nonce change (add-card seeding). */
-  bodyAppend?: Option<NoteField>;
+  /** Text appended into the edit body on nonce change (add-card prefilling). */
+  bodyPrefill?: Option<NoteField>;
   /** Called when the user dismisses an initial-editing card. */
   onDismiss?: () => void;
   className?: string;
@@ -103,7 +103,7 @@ export function CompactActionCard({
   onGoalChange,
   highlighted = false,
   initialEditing = false,
-  bodyAppend = None,
+  bodyPrefill = None,
   onDismiss,
   className,
 }: CompactActionCardProps) {
@@ -179,7 +179,7 @@ export function CompactActionCard({
             action={displayedAction}
             locale={locale}
             initialBody={body}
-            bodyAppend={bodyAppend}
+            bodyPrefill={bodyPrefill}
             allAssignees={allAssignees}
             resolvedAssignees={resolvedAssignees}
             assigneeIds={assigneeIds}
@@ -490,7 +490,7 @@ function ActionEditForm({
   action,
   locale,
   initialBody,
-  bodyAppend = None,
+  bodyPrefill = None,
   allAssignees,
   resolvedAssignees,
   assigneeIds,
@@ -506,7 +506,7 @@ function ActionEditForm({
   action: Action;
   locale: string;
   initialBody: string;
-  bodyAppend?: Option<NoteField>;
+  bodyPrefill?: Option<NoteField>;
   allAssignees: { id: Id; name: string; initials: string }[];
   resolvedAssignees: { id: Id; name: string; initials: string }[];
   assigneeIds: Id[];
@@ -524,8 +524,8 @@ function ActionEditForm({
   const markdownRef = useRef<TextareaMarkdownRef>(null);
   const textareaWrapRef = useRef<HTMLDivElement>(null);
 
-  // Append notes-selection text once per nonce (empty body → seed).
-  useSeededField(bodyAppend, (text) =>
+  // Append notes-selection text once per nonce (empty body → prefill).
+  useFieldPrefill(bodyPrefill, (text) =>
     setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
   );
 

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -27,6 +27,8 @@ import type { Goal } from "@/types/goal";
 import { useLinkedGoalDisplay } from "@/lib/hooks/use-linked-goal-display";
 import { ItemStatus, Id } from "@/types/general";
 import { type Option, None } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
+import { useSeededField } from "@/lib/hooks/use-seeded-field";
 import { cn } from "@/components/lib/utils";
 import { DateTime } from "ts-luxon";
 
@@ -76,7 +78,7 @@ export interface CompactActionCardProps {
   /** When true, card starts in edit mode (used for new actions). */
   initialEditing?: boolean;
   /** Text appended into the edit body on nonce change (add-card seeding). */
-  bodyAppend?: Option<{ text: string; nonce: number }>;
+  bodyAppend?: Option<NoteField>;
   /** Called when the user dismisses an initial-editing card. */
   onDismiss?: () => void;
   className?: string;
@@ -504,7 +506,7 @@ function ActionEditForm({
   action: Action;
   locale: string;
   initialBody: string;
-  bodyAppend?: Option<{ text: string; nonce: number }>;
+  bodyAppend?: Option<NoteField>;
   allAssignees: { id: Id; name: string; initials: string }[];
   resolvedAssignees: { id: Id; name: string; initials: string }[];
   assigneeIds: Id[];
@@ -523,14 +525,9 @@ function ActionEditForm({
   const textareaWrapRef = useRef<HTMLDivElement>(null);
 
   // Append notes-selection text once per nonce (empty body → seed).
-  const lastAppendNonce = useRef(0);
-  useEffect(() => {
-    if (!bodyAppend.some) return;
-    const { text, nonce } = bodyAppend.val;
-    if (nonce === lastAppendNonce.current) return;
-    lastAppendNonce.current = nonce;
-    setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text));
-  }, [bodyAppend]);
+  useSeededField(bodyAppend, (text) =>
+    setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
+  );
 
   // Trap scroll inside the textarea when it has overflow.
   // React's onWheel is passive so preventDefault is ignored. We attach a

--- a/src/components/ui/coaching-sessions/action-section-content.tsx
+++ b/src/components/ui/coaching-sessions/action-section-content.tsx
@@ -32,8 +32,8 @@ export interface ActionSectionContentProps {
   coacheeName: string;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
-  /** Selected notes text to prefill (append into) the add-action form body. */
-  actionBodyPrefill?: Option<{ text: string; nonce: number }>;
+  /** Selected notes text appended into the add-action form body. */
+  actionBodyAppend?: Option<{ text: string; nonce: number }>;
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
@@ -60,7 +60,7 @@ export function ActionSectionContent({
   coacheeName,
   isAddingAction,
   onAddingActionChange,
-  actionBodyPrefill = None,
+  actionBodyAppend = None,
   onStatusChange,
   onDueDateChange,
   onAssigneesChange,
@@ -226,7 +226,7 @@ export function ActionSectionContent({
             <CompactActionCard
               action={newActionPlaceholder}
               initialEditing
-              bodyPrefill={actionBodyPrefill}
+              bodyAppend={actionBodyAppend}
               onDelete={undefined}
               onDismiss={() => onAddingActionChange(false)}
               {...sharedCardProps}

--- a/src/components/ui/coaching-sessions/action-section-content.tsx
+++ b/src/components/ui/coaching-sessions/action-section-content.tsx
@@ -32,8 +32,8 @@ export interface ActionSectionContentProps {
   coacheeName: string;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
-  /** Selected notes text to seed/append into the add-action form body. */
-  actionBodyAppend?: Option<{ text: string; nonce: number }>;
+  /** Selected notes text to prefill (append into) the add-action form body. */
+  actionBodyPrefill?: Option<{ text: string; nonce: number }>;
   onStatusChange: (id: Id, newStatus: ItemStatus) => void;
   onDueDateChange: (id: Id, newDueBy: DateTime) => void;
   onAssigneesChange: (id: Id, assigneeIds: Id[]) => void;
@@ -60,7 +60,7 @@ export function ActionSectionContent({
   coacheeName,
   isAddingAction,
   onAddingActionChange,
-  actionBodyAppend = None,
+  actionBodyPrefill = None,
   onStatusChange,
   onDueDateChange,
   onAssigneesChange,
@@ -226,7 +226,7 @@ export function ActionSectionContent({
             <CompactActionCard
               action={newActionPlaceholder}
               initialEditing
-              bodyAppend={actionBodyAppend}
+              bodyPrefill={actionBodyPrefill}
               onDelete={undefined}
               onDismiss={() => onAddingActionChange(false)}
               {...sharedCardProps}

--- a/src/components/ui/coaching-sessions/agreement-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/agreement-card-compact.tsx
@@ -14,7 +14,7 @@ import { ContentExpandable } from "@/components/ui/content-expandable";
 import type { Agreement } from "@/types/agreement";
 import { type Option, None } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
-import { useSeededField } from "@/lib/hooks/use-seeded-field";
+import { useFieldPrefill } from "@/lib/hooks/use-field-prefill";
 
 // ── Compact Agreement Card (flip-card interaction) ───────────────────
 //
@@ -30,8 +30,8 @@ export interface CompactAgreementCardProps {
   onDelete?: (id: string) => void;
   /** When true, card starts flipped to edit mode (used for new agreements). */
   initialEditing?: boolean;
-  /** Text appended into the edit body on nonce change (add-card seeding). */
-  bodyAppend?: Option<NoteField>;
+  /** Text appended into the edit body on nonce change (add-card prefilling). */
+  bodyPrefill?: Option<NoteField>;
   /** Called when the user cancels out of initial editing (dismisses the card). */
   onDismiss?: () => void;
 }
@@ -42,7 +42,7 @@ export function CompactAgreementCard({
   onSave,
   onDelete,
   initialEditing = false,
-  bodyAppend = None,
+  bodyPrefill = None,
   onDismiss,
 }: CompactAgreementCardProps) {
   const canInteract = Boolean(onSave || onDelete || initialEditing);
@@ -73,7 +73,7 @@ export function CompactAgreementCard({
         isEditing ? (
           <AgreementEditForm
             initialBody={body}
-            bodyAppend={bodyAppend}
+            bodyPrefill={bodyPrefill}
             onSave={async (newBody) => {
               if (onSave) await onSave(newBody);
               if (!initialEditing) onEditEnd();
@@ -219,20 +219,20 @@ function AgreementBackFace({
 
 function AgreementEditForm({
   initialBody,
-  bodyAppend = None,
+  bodyPrefill = None,
   onSave,
   onCancel,
 }: {
   initialBody: string;
-  bodyAppend?: Option<NoteField>;
+  bodyPrefill?: Option<NoteField>;
   onSave: (body: string) => Promise<void>;
   onCancel: () => void;
 }) {
   const [body, setBody] = useState(initialBody);
   const [isSaving, setIsSaving] = useState(false);
 
-  // Append notes-selection text once per nonce (empty body → seed).
-  useSeededField(bodyAppend, (text) =>
+  // Append notes-selection text once per nonce (empty body → prefill).
+  useFieldPrefill(bodyPrefill, (text) =>
     setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
   );
 

--- a/src/components/ui/coaching-sessions/agreement-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/agreement-card-compact.tsx
@@ -30,8 +30,8 @@ export interface CompactAgreementCardProps {
   onDelete?: (id: string) => void;
   /** When true, card starts flipped to edit mode (used for new agreements). */
   initialEditing?: boolean;
-  /** Text appended into the edit body on nonce change (add-card prefilling). */
-  bodyPrefill?: Option<NoteField>;
+  /** Notes selection appended into the edit body on nonce change. */
+  bodyAppend?: Option<NoteField>;
   /** Called when the user cancels out of initial editing (dismisses the card). */
   onDismiss?: () => void;
 }
@@ -42,7 +42,7 @@ export function CompactAgreementCard({
   onSave,
   onDelete,
   initialEditing = false,
-  bodyPrefill = None,
+  bodyAppend = None,
   onDismiss,
 }: CompactAgreementCardProps) {
   const canInteract = Boolean(onSave || onDelete || initialEditing);
@@ -73,7 +73,7 @@ export function CompactAgreementCard({
         isEditing ? (
           <AgreementEditForm
             initialBody={body}
-            bodyPrefill={bodyPrefill}
+            bodyAppend={bodyAppend}
             onSave={async (newBody) => {
               if (onSave) await onSave(newBody);
               if (!initialEditing) onEditEnd();
@@ -219,20 +219,20 @@ function AgreementBackFace({
 
 function AgreementEditForm({
   initialBody,
-  bodyPrefill = None,
+  bodyAppend = None,
   onSave,
   onCancel,
 }: {
   initialBody: string;
-  bodyPrefill?: Option<NoteField>;
+  bodyAppend?: Option<NoteField>;
   onSave: (body: string) => Promise<void>;
   onCancel: () => void;
 }) {
   const [body, setBody] = useState(initialBody);
   const [isSaving, setIsSaving] = useState(false);
 
-  // Append notes-selection text once per nonce (empty body → prefill).
-  useFieldPrefill(bodyPrefill, (text) =>
+  // Append the notes selection once per nonce (an empty body is just filled).
+  useFieldPrefill(bodyAppend, (text) =>
     setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
   );
 

--- a/src/components/ui/coaching-sessions/agreement-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/agreement-card-compact.tsx
@@ -12,6 +12,9 @@ import {
 import { BaseCardCompactEditable } from "@/components/ui/base-card-compact-editable";
 import { ContentExpandable } from "@/components/ui/content-expandable";
 import type { Agreement } from "@/types/agreement";
+import { type Option, None } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
+import { useSeededField } from "@/lib/hooks/use-seeded-field";
 
 // ── Compact Agreement Card (flip-card interaction) ───────────────────
 //
@@ -27,6 +30,8 @@ export interface CompactAgreementCardProps {
   onDelete?: (id: string) => void;
   /** When true, card starts flipped to edit mode (used for new agreements). */
   initialEditing?: boolean;
+  /** Text appended into the edit body on nonce change (add-card seeding). */
+  bodyAppend?: Option<NoteField>;
   /** Called when the user cancels out of initial editing (dismisses the card). */
   onDismiss?: () => void;
 }
@@ -37,6 +42,7 @@ export function CompactAgreementCard({
   onSave,
   onDelete,
   initialEditing = false,
+  bodyAppend = None,
   onDismiss,
 }: CompactAgreementCardProps) {
   const canInteract = Boolean(onSave || onDelete || initialEditing);
@@ -67,6 +73,7 @@ export function CompactAgreementCard({
         isEditing ? (
           <AgreementEditForm
             initialBody={body}
+            bodyAppend={bodyAppend}
             onSave={async (newBody) => {
               if (onSave) await onSave(newBody);
               if (!initialEditing) onEditEnd();
@@ -212,15 +219,22 @@ function AgreementBackFace({
 
 function AgreementEditForm({
   initialBody,
+  bodyAppend = None,
   onSave,
   onCancel,
 }: {
   initialBody: string;
+  bodyAppend?: Option<NoteField>;
   onSave: (body: string) => Promise<void>;
   onCancel: () => void;
 }) {
   const [body, setBody] = useState(initialBody);
   const [isSaving, setIsSaving] = useState(false);
+
+  // Append notes-selection text once per nonce (empty body → seed).
+  useSeededField(bodyAppend, (text) =>
+    setBody((prev) => (prev.trim() ? `${prev}\n\n${text}` : text))
+  );
 
   const handleSave = useCallback(async () => {
     if (!body.trim()) return;

--- a/src/components/ui/coaching-sessions/agreement-section-content.tsx
+++ b/src/components/ui/coaching-sessions/agreement-section-content.tsx
@@ -12,8 +12,8 @@ export interface AgreementSectionContentProps {
   locale: string;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
-  /** Selected notes text to prefill into the add-agreement form body. */
-  agreementBodyPrefill?: Option<NoteField>;
+  /** Selected notes text appended into the add-agreement form body. */
+  agreementBodyAppend?: Option<NoteField>;
   onAgreementCreate?: (body: string) => Promise<void>;
   onAgreementEdit?: (id: string, body: string) => Promise<void>;
   onAgreementDelete?: (id: string) => void;
@@ -25,7 +25,7 @@ export function AgreementSectionContent({
   locale,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyPrefill = None,
+  agreementBodyAppend = None,
   onAgreementCreate,
   onAgreementEdit,
   onAgreementDelete,
@@ -42,7 +42,7 @@ export function AgreementSectionContent({
           agreement={newAgreementPlaceholder}
           locale={locale}
           initialEditing
-          bodyPrefill={agreementBodyPrefill}
+          bodyAppend={agreementBodyAppend}
           onSave={onAgreementCreate}
           onDismiss={() => onAddingAgreementChange(false)}
         />

--- a/src/components/ui/coaching-sessions/agreement-section-content.tsx
+++ b/src/components/ui/coaching-sessions/agreement-section-content.tsx
@@ -12,8 +12,8 @@ export interface AgreementSectionContentProps {
   locale: string;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
-  /** Selected notes text to seed/append into the add-agreement form body. */
-  agreementBodyAppend?: Option<NoteField>;
+  /** Selected notes text to prefill into the add-agreement form body. */
+  agreementBodyPrefill?: Option<NoteField>;
   onAgreementCreate?: (body: string) => Promise<void>;
   onAgreementEdit?: (id: string, body: string) => Promise<void>;
   onAgreementDelete?: (id: string) => void;
@@ -25,7 +25,7 @@ export function AgreementSectionContent({
   locale,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyAppend = None,
+  agreementBodyPrefill = None,
   onAgreementCreate,
   onAgreementEdit,
   onAgreementDelete,
@@ -42,7 +42,7 @@ export function AgreementSectionContent({
           agreement={newAgreementPlaceholder}
           locale={locale}
           initialEditing
-          bodyAppend={agreementBodyAppend}
+          bodyPrefill={agreementBodyPrefill}
           onSave={onAgreementCreate}
           onDismiss={() => onAddingAgreementChange(false)}
         />

--- a/src/components/ui/coaching-sessions/agreement-section-content.tsx
+++ b/src/components/ui/coaching-sessions/agreement-section-content.tsx
@@ -4,12 +4,16 @@ import { useMemo } from "react";
 import { CompactAgreementCard } from "@/components/ui/coaching-sessions/agreement-card-compact";
 import { defaultAgreement } from "@/types/agreement";
 import type { Agreement } from "@/types/agreement";
+import { type Option, None } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
 
 export interface AgreementSectionContentProps {
   agreements: Agreement[];
   locale: string;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
+  /** Selected notes text to seed/append into the add-agreement form body. */
+  agreementBodyAppend?: Option<NoteField>;
   onAgreementCreate?: (body: string) => Promise<void>;
   onAgreementEdit?: (id: string, body: string) => Promise<void>;
   onAgreementDelete?: (id: string) => void;
@@ -21,6 +25,7 @@ export function AgreementSectionContent({
   locale,
   isAddingAgreement,
   onAddingAgreementChange,
+  agreementBodyAppend = None,
   onAgreementCreate,
   onAgreementEdit,
   onAgreementDelete,
@@ -37,6 +42,7 @@ export function AgreementSectionContent({
           agreement={newAgreementPlaceholder}
           locale={locale}
           initialEditing
+          bodyAppend={agreementBodyAppend}
           onSave={onAgreementCreate}
           onDismiss={() => onAddingAgreementChange(false)}
         />

--- a/src/components/ui/coaching-sessions/coaching-notes.tsx
+++ b/src/components/ui/coaching-sessions/coaching-notes.tsx
@@ -6,6 +6,7 @@ import { FileText } from "lucide-react";
 import { SimpleToolbar } from "@/components/ui/coaching-sessions/coaching-notes/simple-toolbar";
 import { LinkBubbleMenu } from "@/components/ui/tiptap-ui/link-bubble-menu/link-bubble-menu";
 import { SelectionBubbleMenu } from "@/components/ui/tiptap-ui/selection-bubble-menu/selection-bubble-menu";
+import type { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
 import { useEditorCache } from "@/components/ui/coaching-sessions/editor-cache-context";
 import { Spinner } from "@/components/ui/spinner";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -21,10 +22,10 @@ const PREPARING_HINT_DELAY_MS = 1500;
 // Main component: orchestrates editor state and rendering logic
 
 interface CoachingNotesProps {
-  onAddAsAction?: (selectedText: string) => void;
+  onAddAs?: (section: PanelSection, selectedText: string) => void;
 }
 
-const CoachingNotes = ({ onAddAsAction }: CoachingNotesProps) => {
+const CoachingNotes = ({ onAddAs }: CoachingNotesProps) => {
   const { extensions, isReady, isLoading, error, resetCache } = useEditorCache();
 
   if (error) {
@@ -35,7 +36,7 @@ const CoachingNotes = ({ onAddAsAction }: CoachingNotesProps) => {
     return <LoadingState />;
   }
 
-  return renderReadyEditor(extensions, isReady, onAddAsAction);
+  return renderReadyEditor(extensions, isReady, onAddAs);
 };
 
 const LoadingState = () => {
@@ -93,10 +94,10 @@ const renderErrorState = (error: Error | null, onRetry: () => void) => (
 const renderReadyEditor = (
   extensions: Extensions,
   isReady: boolean,
-  onAddAsAction?: (selectedText: string) => void,
+  onAddAs?: (section: PanelSection, selectedText: string) => void,
 ) => {
   try {
-    return renderReadyEditorContent(extensions, isReady, onAddAsAction);
+    return renderReadyEditorContent(extensions, isReady, onAddAs);
   } catch (error) {
     console.error("Editor initialization failed:", error);
     return (
@@ -119,7 +120,7 @@ const renderReadyEditor = (
 const renderReadyEditorContent = (
   extensions: Extensions,
   isReady: boolean,
-  onAddAsAction?: (selectedText: string) => void,
+  onAddAs?: (section: PanelSection, selectedText: string) => void,
 ) => (
   <div className="coaching-notes-editor">
     <EditorProvider
@@ -145,7 +146,7 @@ const renderReadyEditorContent = (
       }
     >
       <LinkBubbleMenu />
-      {onAddAsAction && <SelectionBubbleMenu onAddAsAction={onAddAsAction} />}
+      {onAddAs && <SelectionBubbleMenu onAddAs={onAddAs} />}
     </EditorProvider>
   </div>
 );

--- a/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
@@ -48,7 +48,7 @@ export function CoachingSessionPanelDesktop({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyPrefill,
+  agreementBodyAppend,
   goalTitlePrefill,
   // Action props
   reviewActions,
@@ -67,7 +67,7 @@ export function CoachingSessionPanelDesktop({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
-  actionBodyPrefill,
+  actionBodyAppend,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -226,7 +226,7 @@ export function CoachingSessionPanelDesktop({
               locale={locale}
               isAddingAgreement={isAddingAgreement}
               onAddingAgreementChange={onAddingAgreementChange}
-              agreementBodyPrefill={agreementBodyPrefill}
+              agreementBodyAppend={agreementBodyAppend}
               onAgreementCreate={onAgreementCreate}
               onAgreementEdit={onAgreementEdit}
               onAgreementDelete={onAgreementDelete}
@@ -244,7 +244,7 @@ export function CoachingSessionPanelDesktop({
               coacheeName={coacheeName}
               isAddingAction={isAddingAction}
               onAddingActionChange={onAddingActionChange}
-              actionBodyPrefill={actionBodyPrefill}
+              actionBodyAppend={actionBodyAppend}
               onStatusChange={onStatusChange}
               onDueDateChange={onDueDateChange}
               onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
@@ -48,8 +48,8 @@ export function CoachingSessionPanelDesktop({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyAppend,
-  goalTitleSeed,
+  agreementBodyPrefill,
+  goalTitlePrefill,
   // Action props
   reviewActions,
   sessionActions,
@@ -67,7 +67,7 @@ export function CoachingSessionPanelDesktop({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
-  actionBodyAppend,
+  actionBodyPrefill,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -218,7 +218,7 @@ export function CoachingSessionPanelDesktop({
               readOnly={readOnly}
               onUnlink={onUnlink}
               onUpdateGoal={onUpdateGoal}
-              titleSeed={goalTitleSeed}
+              titlePrefill={goalTitlePrefill}
             />
           ) : activeSection === PanelSection.Agreements ? (
             <AgreementSectionContent
@@ -226,7 +226,7 @@ export function CoachingSessionPanelDesktop({
               locale={locale}
               isAddingAgreement={isAddingAgreement}
               onAddingAgreementChange={onAddingAgreementChange}
-              agreementBodyAppend={agreementBodyAppend}
+              agreementBodyPrefill={agreementBodyPrefill}
               onAgreementCreate={onAgreementCreate}
               onAgreementEdit={onAgreementEdit}
               onAgreementDelete={onAgreementDelete}
@@ -244,7 +244,7 @@ export function CoachingSessionPanelDesktop({
               coacheeName={coacheeName}
               isAddingAction={isAddingAction}
               onAddingActionChange={onAddingActionChange}
-              actionBodyAppend={actionBodyAppend}
+              actionBodyPrefill={actionBodyPrefill}
               onStatusChange={onStatusChange}
               onDueDateChange={onDueDateChange}
               onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-desktop.tsx
@@ -48,6 +48,8 @@ export function CoachingSessionPanelDesktop({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
+  agreementBodyAppend,
+  goalTitleSeed,
   // Action props
   reviewActions,
   sessionActions,
@@ -216,6 +218,7 @@ export function CoachingSessionPanelDesktop({
               readOnly={readOnly}
               onUnlink={onUnlink}
               onUpdateGoal={onUpdateGoal}
+              titleSeed={goalTitleSeed}
             />
           ) : activeSection === PanelSection.Agreements ? (
             <AgreementSectionContent
@@ -223,6 +226,7 @@ export function CoachingSessionPanelDesktop({
               locale={locale}
               isAddingAgreement={isAddingAgreement}
               onAddingAgreementChange={onAddingAgreementChange}
+              agreementBodyAppend={agreementBodyAppend}
               onAgreementCreate={onAgreementCreate}
               onAgreementEdit={onAgreementEdit}
               onAgreementDelete={onAgreementDelete}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
@@ -32,8 +32,8 @@ export function CoachingSessionPanelMobile({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyAppend,
-  goalTitleSeed,
+  agreementBodyPrefill,
+  goalTitlePrefill,
   // Action props
   reviewActions,
   sessionActions,
@@ -51,7 +51,7 @@ export function CoachingSessionPanelMobile({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
-  actionBodyAppend,
+  actionBodyPrefill,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -168,7 +168,7 @@ export function CoachingSessionPanelMobile({
                 readOnly={readOnly}
                 onUnlink={handleUnlink}
                 onUpdateGoal={onUpdateGoal}
-                titleSeed={goalTitleSeed}
+                titlePrefill={goalTitlePrefill}
               />
             ) : activeSection === PanelSection.Agreements ? (
               <AgreementSectionContent
@@ -176,7 +176,7 @@ export function CoachingSessionPanelMobile({
                 locale={locale}
                 isAddingAgreement={isAddingAgreement}
                 onAddingAgreementChange={onAddingAgreementChange}
-                agreementBodyAppend={agreementBodyAppend}
+                agreementBodyPrefill={agreementBodyPrefill}
                 onAgreementCreate={onAgreementCreate}
                 onAgreementEdit={onAgreementEdit}
                 onAgreementDelete={onAgreementDelete}
@@ -194,7 +194,7 @@ export function CoachingSessionPanelMobile({
                 coacheeName={coacheeName}
                 isAddingAction={isAddingAction}
                 onAddingActionChange={onAddingActionChange}
-                actionBodyAppend={actionBodyAppend}
+                actionBodyPrefill={actionBodyPrefill}
                 onStatusChange={onStatusChange}
                 onDueDateChange={onDueDateChange}
                 onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
@@ -32,7 +32,7 @@ export function CoachingSessionPanelMobile({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
-  agreementBodyPrefill,
+  agreementBodyAppend,
   goalTitlePrefill,
   // Action props
   reviewActions,
@@ -51,7 +51,7 @@ export function CoachingSessionPanelMobile({
   onBodyChange,
   isAddingAction,
   onAddingActionChange,
-  actionBodyPrefill,
+  actionBodyAppend,
   activeActionTab,
   onActiveActionTabChange,
   locale,
@@ -176,7 +176,7 @@ export function CoachingSessionPanelMobile({
                 locale={locale}
                 isAddingAgreement={isAddingAgreement}
                 onAddingAgreementChange={onAddingAgreementChange}
-                agreementBodyPrefill={agreementBodyPrefill}
+                agreementBodyAppend={agreementBodyAppend}
                 onAgreementCreate={onAgreementCreate}
                 onAgreementEdit={onAgreementEdit}
                 onAgreementDelete={onAgreementDelete}
@@ -194,7 +194,7 @@ export function CoachingSessionPanelMobile({
                 coacheeName={coacheeName}
                 isAddingAction={isAddingAction}
                 onAddingActionChange={onAddingActionChange}
-                actionBodyPrefill={actionBodyPrefill}
+                actionBodyAppend={actionBodyAppend}
                 onStatusChange={onStatusChange}
                 onDueDateChange={onDueDateChange}
                 onAssigneesChange={onAssigneesChange}

--- a/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel-mobile.tsx
@@ -32,6 +32,8 @@ export function CoachingSessionPanelMobile({
   onAgreementCreate,
   isAddingAgreement,
   onAddingAgreementChange,
+  agreementBodyAppend,
+  goalTitleSeed,
   // Action props
   reviewActions,
   sessionActions,
@@ -166,6 +168,7 @@ export function CoachingSessionPanelMobile({
                 readOnly={readOnly}
                 onUnlink={handleUnlink}
                 onUpdateGoal={onUpdateGoal}
+                titleSeed={goalTitleSeed}
               />
             ) : activeSection === PanelSection.Agreements ? (
               <AgreementSectionContent
@@ -173,6 +176,7 @@ export function CoachingSessionPanelMobile({
                 locale={locale}
                 isAddingAgreement={isAddingAgreement}
                 onAddingAgreementChange={onAddingAgreementChange}
+                agreementBodyAppend={agreementBodyAppend}
                 onAgreementCreate={onAgreementCreate}
                 onAgreementEdit={onAgreementEdit}
                 onAgreementDelete={onAgreementDelete}

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -76,8 +76,8 @@ export interface CoachingSessionPanelSharedProps {
   onAgreementCreate?: (body: string) => Promise<void>;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
-  /** Selected notes text to prefill into the add-agreement form. */
-  agreementBodyPrefill: Option<NoteField>;
+  /** Selected notes text appended into the add-agreement form body. */
+  agreementBodyAppend: Option<NoteField>;
   // Action data
   reviewActions: Action[];
   sessionActions: Action[];
@@ -97,8 +97,8 @@ export interface CoachingSessionPanelSharedProps {
   onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
-  /** Selected notes text to prefill into the add-action form. */
-  actionBodyPrefill: Option<NoteField>;
+  /** Selected notes text appended into the add-action form body. */
+  actionBodyAppend: Option<NoteField>;
   /** Selected notes text to prefill the new-goal title field. */
   goalTitlePrefill: Option<NoteField>;
   locale: string;
@@ -716,8 +716,8 @@ export function CoachingSessionPanel({
   // Notes "Add as …" prefill signals. Appending to an empty body fills it, so
   // one signal covers both fresh-open and in-progress add-forms; goals prefill
   // the title (replace-if-empty) since that is their primary field.
-  const [actionBodyPrefill, setActionBodyPrefill] = useState<Option<NoteField>>(None);
-  const [agreementBodyPrefill, setAgreementBodyPrefill] = useState<Option<NoteField>>(None);
+  const [actionBodyAppend, setActionBodyAppend] = useState<Option<NoteField>>(None);
+  const [agreementBodyAppend, setAgreementBodyAppend] = useState<Option<NoteField>>(None);
   const [goalTitlePrefill, setGoalTitlePrefill] = useState<Option<NoteField>>(None);
   const handledNonce = useRef(0);
 
@@ -734,11 +734,11 @@ export function CoachingSessionPanel({
     },
     [PanelSection.Agreements]: {
       open: () => setIsAddingAgreement(true),
-      prefill: setAgreementBodyPrefill,
+      prefill: setAgreementBodyAppend,
     },
     [PanelSection.Actions]: {
       open: () => setIsAddingAction(true),
-      prefill: setActionBodyPrefill,
+      prefill: setActionBodyAppend,
     },
   };
 
@@ -748,8 +748,8 @@ export function CoachingSessionPanel({
   const clearPrefill = useMemo<Record<PanelSection, () => void>>(
     () => ({
       [PanelSection.Goals]: () => setGoalTitlePrefill(None),
-      [PanelSection.Agreements]: () => setAgreementBodyPrefill(None),
-      [PanelSection.Actions]: () => setActionBodyPrefill(None),
+      [PanelSection.Agreements]: () => setAgreementBodyAppend(None),
+      [PanelSection.Actions]: () => setActionBodyAppend(None),
     }),
     []
   );
@@ -889,7 +889,7 @@ export function CoachingSessionPanel({
     onAgreementCreate: handleAgreementCreate,
     isAddingAgreement,
     onAddingAgreementChange: handleAddingAgreementChange,
-    agreementBodyPrefill,
+    agreementBodyAppend,
     // Action data
     reviewActions: panelReviewActions,
     sessionActions,
@@ -907,7 +907,7 @@ export function CoachingSessionPanel({
     onBodyChange: handleBodyChange,
     isAddingAction,
     onAddingActionChange: handleAddingActionChange,
-    actionBodyPrefill,
+    actionBodyAppend,
     goalTitlePrefill,
     locale: siteConfig.locale,
     activeActionTab,

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/components/lib/utils";
 import { toast } from "@/components/ui/use-toast";
@@ -44,6 +44,7 @@ import {
 import type { Id } from "@/types/general";
 import { ItemStatus } from "@/types/general";
 import { type Option, Some, None } from "@/types/option";
+import type { NoteField, NoteSelection } from "@/types/note-selection";
 import { DateTime } from "ts-luxon";
 import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
 import { siteConfig } from "@/site.config";
@@ -75,6 +76,8 @@ export interface CoachingSessionPanelSharedProps {
   onAgreementCreate?: (body: string) => Promise<void>;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
+  /** Selected notes text to seed/append into the add-agreement form. */
+  agreementBodyAppend: Option<NoteField>;
   // Action data
   reviewActions: Action[];
   sessionActions: Action[];
@@ -95,10 +98,24 @@ export interface CoachingSessionPanelSharedProps {
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
   /** Selected notes text to seed/append into the add-action form. */
-  actionBodyAppend: Option<{ text: string; nonce: number }>;
+  actionBodyAppend: Option<NoteField>;
+  /** Selected notes text to seed the new-goal title field. */
+  goalTitleSeed: Option<NoteField>;
   locale: string;
   activeActionTab: ActionTab;
   onActiveActionTabChange: (tab: ActionTab) => void;
+}
+
+// A section's hooks for receiving a notes selection. Every section supplies
+// the same three methods, so routing a selection (and clearing it on close)
+// needs no per-entity branching at the call sites.
+interface NoteSelectionTarget {
+  /** Enter this section's add-flow. */
+  open(): void;
+  /** Route the selected text into this section's seeded field. */
+  seed(field: Option<NoteField>): void;
+  /** Drop the seed when the add-flow closes. */
+  clear(): void;
 }
 
 // ── Shared helpers for desktop and mobile layouts ─────────────────────
@@ -161,12 +178,15 @@ export function GoalFlowPages({
   readOnly,
   onUnlink,
   onUpdateGoal,
+  titleSeed = None,
 }: {
   linkedGoals: Goal[];
   goalFlow: ReturnType<typeof useGoalFlow>;
   readOnly: boolean;
   onUnlink: (goalId: string) => void;
   onUpdateGoal: (goalId: string, title: string, body: string) => Promise<void>;
+  /** Notes selection seeding the new-goal title (replace-if-empty). */
+  titleSeed?: Option<NoteField>;
 }) {
   const { flow } = goalFlow;
 
@@ -247,6 +267,7 @@ export function GoalFlowPages({
             onSubmit={goalFlow.handleFormSubmit}
             onCancel={goalFlow.handleBack}
             submitLabel="Save"
+            titleSeed={titleSeed}
           />
         </SlidePanel>
       );
@@ -276,8 +297,11 @@ interface CoachingSessionPanelProps {
   defaultSection?: PanelSection;
   /** Called when the user switches sections, so the page can sync to URL */
   onSectionChange?: (section: PanelSection) => void;
-  /** Notes "Add as Action" selection; a new nonce opens/seeds the add-form. */
-  actionDraft?: Option<{ body: string; nonce: number }>;
+  /**
+   * Notes "Add as …" selection routed to a section's add-flow; a new nonce
+   * opens that section's add-form and seeds the appropriate field.
+   */
+  noteSelection?: Option<NoteSelection>;
 }
 
 export function CoachingSessionPanel({
@@ -288,7 +312,7 @@ export function CoachingSessionPanel({
   readOnly = false,
   defaultSection = PanelSection.Goals,
   onSectionChange: onSectionChangeExternal,
-  actionDraft = None,
+  noteSelection = None,
 }: CoachingSessionPanelProps) {
   // ── Resolve user/relationship context for actions ───────────────
   const userId = useAuthStore((state) => state.userId);
@@ -688,31 +712,66 @@ export function CoachingSessionPanel({
 
   const [isAddingAction, setIsAddingAction] = useState(false);
   const [activeActionTab, setActiveActionTab] = useState<ActionTab>("new");
+  const [isAddingAgreement, setIsAddingAgreement] = useState(false);
 
-  // Notes selection routed into the add-action form; appending to an empty
-  // body seeds it, so one signal covers both fresh-open and in-progress.
-  const [actionBodyAppend, setActionBodyAppend] =
-    useState<Option<{ text: string; nonce: number }>>(None);
-  const handledDraftNonce = useRef(0);
+  // Notes "Add as …" seeds. Appending to an empty body seeds it, so one
+  // signal covers both fresh-open and in-progress add-forms; goals seed the
+  // title (replace-if-empty) since that is their primary field.
+  const [actionBodyAppend, setActionBodyAppend] = useState<Option<NoteField>>(None);
+  const [agreementBodyAppend, setAgreementBodyAppend] = useState<Option<NoteField>>(None);
+  const [goalTitleSeed, setGoalTitleSeed] = useState<Option<NoteField>>(None);
+  const handledNonce = useRef(0);
 
-  // Open the Actions add-form on a new draft nonce (render-time own-state
-  // adjustment, mirroring action-section-content's requiredTab pattern).
-  if (actionDraft.some && actionDraft.val.nonce !== handledDraftNonce.current) {
-    handledDraftNonce.current = actionDraft.val.nonce;
-    setActiveSection(PanelSection.Actions);
-    if (!isAddingAction) setIsAddingAction(true);
-    setActionBodyAppend(Some({ text: actionDraft.val.body, nonce: actionDraft.val.nonce }));
+  // Each section receives a notes selection through the same interface, so the
+  // dispatch below and the clear-on-close handlers need no per-entity switch.
+  const noteTargets: Record<PanelSection, NoteSelectionTarget> = {
+    [PanelSection.Goals]: {
+      // At the goal cap, creation requires a swap first; both routes land on
+      // the create form, where the seeded title is applied on mount.
+      open: () => (atLimit ? goalFlow.handleAddGoalClick() : goalFlow.handleCreateNewClick()),
+      seed: setGoalTitleSeed,
+      clear: () => setGoalTitleSeed(None),
+    },
+    [PanelSection.Agreements]: {
+      open: () => setIsAddingAgreement(true),
+      seed: setAgreementBodyAppend,
+      clear: () => setAgreementBodyAppend(None),
+    },
+    [PanelSection.Actions]: {
+      open: () => setIsAddingAction(true),
+      seed: setActionBodyAppend,
+      clear: () => setActionBodyAppend(None),
+    },
+  };
+
+  // Open the target section's add-form on a new selection nonce (render-time
+  // own-state adjustment, mirroring action-section-content's requiredTab).
+  if (noteSelection.some && noteSelection.val.nonce !== handledNonce.current) {
+    handledNonce.current = noteSelection.val.nonce;
+    const { section, text, nonce } = noteSelection.val;
+    setActiveSection(section);
+    noteTargets[section].open();
+    noteTargets[section].seed(Some({ text, nonce }));
   }
 
-  // Clear the append signal on close so a later fresh "Add" starts blank.
-  const handleAddingActionChange = useCallback((adding: boolean) => {
+  // Clear a section's seed when its add-flow closes, so a later fresh "Add"
+  // starts blank and the still-present selection (same nonce) won't re-seed.
+  const handleAddingActionChange = (adding: boolean) => {
     setIsAddingAction(adding);
-    if (!adding) setActionBodyAppend(None);
-  }, []);
+    if (!adding) noteTargets[PanelSection.Actions].clear();
+  };
+  const handleAddingAgreementChange = (adding: boolean) => {
+    setIsAddingAgreement(adding);
+    if (!adding) noteTargets[PanelSection.Agreements].clear();
+  };
+
+  // The goal create form unmounts when the flow leaves Creating; drop the
+  // title seed once it returns to Idle so a manual "Add Goal" starts blank.
+  useEffect(() => {
+    if (goalFlow.flow.step === GoalFlowStep.Idle) setGoalTitleSeed(None);
+  }, [goalFlow.flow.step]);
 
   // ── Agreement state & handlers ──────────────────────────────────
-
-  const [isAddingAgreement, setIsAddingAgreement] = useState(false);
 
   const handleAgreementCreate = useCallback(async (body: string) => {
     try {
@@ -813,7 +872,8 @@ export function CoachingSessionPanel({
     onAgreementDelete: handleAgreementDelete,
     onAgreementCreate: handleAgreementCreate,
     isAddingAgreement,
-    onAddingAgreementChange: setIsAddingAgreement,
+    onAddingAgreementChange: handleAddingAgreementChange,
+    agreementBodyAppend,
     // Action data
     reviewActions: panelReviewActions,
     sessionActions,
@@ -832,6 +892,7 @@ export function CoachingSessionPanel({
     isAddingAction,
     onAddingActionChange: handleAddingActionChange,
     actionBodyAppend,
+    goalTitleSeed,
     locale: siteConfig.locale,
     activeActionTab,
     onActiveActionTabChange: setActiveActionTab,

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -76,8 +76,8 @@ export interface CoachingSessionPanelSharedProps {
   onAgreementCreate?: (body: string) => Promise<void>;
   isAddingAgreement: boolean;
   onAddingAgreementChange: (adding: boolean) => void;
-  /** Selected notes text to seed/append into the add-agreement form. */
-  agreementBodyAppend: Option<NoteField>;
+  /** Selected notes text to prefill into the add-agreement form. */
+  agreementBodyPrefill: Option<NoteField>;
   // Action data
   reviewActions: Action[];
   sessionActions: Action[];
@@ -97,10 +97,10 @@ export interface CoachingSessionPanelSharedProps {
   onBodyChange: (id: Id, newBody: string, assigneeIds?: Id[], goalId?: Id, dueBy?: DateTime) => Promise<void>;
   isAddingAction: boolean;
   onAddingActionChange: (adding: boolean) => void;
-  /** Selected notes text to seed/append into the add-action form. */
-  actionBodyAppend: Option<NoteField>;
-  /** Selected notes text to seed the new-goal title field. */
-  goalTitleSeed: Option<NoteField>;
+  /** Selected notes text to prefill into the add-action form. */
+  actionBodyPrefill: Option<NoteField>;
+  /** Selected notes text to prefill the new-goal title field. */
+  goalTitlePrefill: Option<NoteField>;
   locale: string;
   activeActionTab: ActionTab;
   onActiveActionTabChange: (tab: ActionTab) => void;
@@ -108,13 +108,13 @@ export interface CoachingSessionPanelSharedProps {
 
 // How a section receives a routed notes selection. Every section supplies the
 // same two methods, so the render-time dispatch needs no per-entity branching.
-// (Clearing the seed on close is a stable operation handled separately via
-// `clearSeed` so the change handlers can stay memoized.)
+// (Clearing the prefill on close is a stable operation handled separately via
+// `clearPrefill` so the change handlers can stay memoized.)
 interface NoteSelectionTarget {
   /** Enter this section's add-flow. */
   open(): void;
-  /** Route the selected text into this section's seeded field. */
-  seed(field: Option<NoteField>): void;
+  /** Route the selected text into this section's prefilled field. */
+  prefill(field: Option<NoteField>): void;
 }
 
 // ── Shared helpers for desktop and mobile layouts ─────────────────────
@@ -177,15 +177,15 @@ export function GoalFlowPages({
   readOnly,
   onUnlink,
   onUpdateGoal,
-  titleSeed = None,
+  titlePrefill = None,
 }: {
   linkedGoals: Goal[];
   goalFlow: ReturnType<typeof useGoalFlow>;
   readOnly: boolean;
   onUnlink: (goalId: string) => void;
   onUpdateGoal: (goalId: string, title: string, body: string) => Promise<void>;
-  /** Notes selection seeding the new-goal title (replace-if-empty). */
-  titleSeed?: Option<NoteField>;
+  /** Notes selection prefilling the new-goal title (replace-if-empty). */
+  titlePrefill?: Option<NoteField>;
 }) {
   const { flow } = goalFlow;
 
@@ -266,7 +266,7 @@ export function GoalFlowPages({
             onSubmit={goalFlow.handleFormSubmit}
             onCancel={goalFlow.handleBack}
             submitLabel="Save"
-            titleSeed={titleSeed}
+            titlePrefill={titlePrefill}
           />
         </SlidePanel>
       );
@@ -298,7 +298,7 @@ interface CoachingSessionPanelProps {
   onSectionChange?: (section: PanelSection) => void;
   /**
    * Notes "Add as …" selection routed to a section's add-flow; a new nonce
-   * opens that section's add-form and seeds the appropriate field.
+   * opens that section's add-form and prefills the appropriate field.
    */
   noteSelection?: Option<NoteSelection>;
 }
@@ -713,43 +713,43 @@ export function CoachingSessionPanel({
   const [activeActionTab, setActiveActionTab] = useState<ActionTab>("new");
   const [isAddingAgreement, setIsAddingAgreement] = useState(false);
 
-  // Notes "Add as …" seeds. Appending to an empty body seeds it, so one
-  // signal covers both fresh-open and in-progress add-forms; goals seed the
-  // title (replace-if-empty) since that is their primary field.
-  const [actionBodyAppend, setActionBodyAppend] = useState<Option<NoteField>>(None);
-  const [agreementBodyAppend, setAgreementBodyAppend] = useState<Option<NoteField>>(None);
-  const [goalTitleSeed, setGoalTitleSeed] = useState<Option<NoteField>>(None);
+  // Notes "Add as …" prefill signals. Appending to an empty body fills it, so
+  // one signal covers both fresh-open and in-progress add-forms; goals prefill
+  // the title (replace-if-empty) since that is their primary field.
+  const [actionBodyPrefill, setActionBodyPrefill] = useState<Option<NoteField>>(None);
+  const [agreementBodyPrefill, setAgreementBodyPrefill] = useState<Option<NoteField>>(None);
+  const [goalTitlePrefill, setGoalTitlePrefill] = useState<Option<NoteField>>(None);
   const handledNonce = useRef(0);
 
-  // Render-time dispatch targets: each section opens its add-flow and seeds
+  // Render-time dispatch targets: each section opens its add-flow and prefills
   // its field through the same interface, so the dispatch below needs no
   // per-entity switch. Rebuilt each render because `open` reads the live
-  // `atLimit`/`goalFlow`; clearing is hoisted to `clearSeed` (below) instead.
+  // `atLimit`/`goalFlow`; clearing is hoisted to `clearPrefill` (below) instead.
   const noteTargets: Record<PanelSection, NoteSelectionTarget> = {
     [PanelSection.Goals]: {
       // At the goal cap, creation requires a swap first; both routes land on
-      // the create form, where the seeded title is applied on mount.
+      // the create form, where the prefilled title is applied on mount.
       open: () => (atLimit ? goalFlow.handleAddGoalClick() : goalFlow.handleCreateNewClick()),
-      seed: setGoalTitleSeed,
+      prefill: setGoalTitlePrefill,
     },
     [PanelSection.Agreements]: {
       open: () => setIsAddingAgreement(true),
-      seed: setAgreementBodyAppend,
+      prefill: setAgreementBodyPrefill,
     },
     [PanelSection.Actions]: {
       open: () => setIsAddingAction(true),
-      seed: setActionBodyAppend,
+      prefill: setActionBodyPrefill,
     },
   };
 
   // One uniform clear mechanism, shared by the change handlers and the
   // goal-idle effect. Stable (useState setters never change identity), so the
   // handlers below can stay memoized.
-  const clearSeed = useMemo<Record<PanelSection, () => void>>(
+  const clearPrefill = useMemo<Record<PanelSection, () => void>>(
     () => ({
-      [PanelSection.Goals]: () => setGoalTitleSeed(None),
-      [PanelSection.Agreements]: () => setAgreementBodyAppend(None),
-      [PanelSection.Actions]: () => setActionBodyAppend(None),
+      [PanelSection.Goals]: () => setGoalTitlePrefill(None),
+      [PanelSection.Agreements]: () => setAgreementBodyPrefill(None),
+      [PanelSection.Actions]: () => setActionBodyPrefill(None),
     }),
     []
   );
@@ -761,31 +761,31 @@ export function CoachingSessionPanel({
     const { section, text, nonce } = noteSelection.val;
     setActiveSection(section);
     noteTargets[section].open();
-    noteTargets[section].seed(Some({ text, nonce }));
+    noteTargets[section].prefill(Some({ text, nonce }));
   }
 
-  // Clear a section's seed when its add-flow closes, so a later fresh "Add"
-  // starts blank and the still-present selection (same nonce) won't re-seed.
+  // Clear a section's prefill when its add-flow closes, so a later fresh "Add"
+  // starts blank and the still-present selection (same nonce) won't re-prefill.
   const handleAddingActionChange = useCallback(
     (adding: boolean) => {
       setIsAddingAction(adding);
-      if (!adding) clearSeed[PanelSection.Actions]();
+      if (!adding) clearPrefill[PanelSection.Actions]();
     },
-    [clearSeed]
+    [clearPrefill]
   );
   const handleAddingAgreementChange = useCallback(
     (adding: boolean) => {
       setIsAddingAgreement(adding);
-      if (!adding) clearSeed[PanelSection.Agreements]();
+      if (!adding) clearPrefill[PanelSection.Agreements]();
     },
-    [clearSeed]
+    [clearPrefill]
   );
 
   // The goal create form unmounts when the flow leaves Creating; drop the
-  // title seed once it returns to Idle so a manual "Add Goal" starts blank.
+  // title prefill once it returns to Idle so a manual "Add Goal" starts blank.
   useEffect(() => {
-    if (goalFlow.flow.step === GoalFlowStep.Idle) clearSeed[PanelSection.Goals]();
-  }, [goalFlow.flow.step, clearSeed]);
+    if (goalFlow.flow.step === GoalFlowStep.Idle) clearPrefill[PanelSection.Goals]();
+  }, [goalFlow.flow.step, clearPrefill]);
 
   // ── Agreement state & handlers ──────────────────────────────────
 
@@ -889,7 +889,7 @@ export function CoachingSessionPanel({
     onAgreementCreate: handleAgreementCreate,
     isAddingAgreement,
     onAddingAgreementChange: handleAddingAgreementChange,
-    agreementBodyAppend,
+    agreementBodyPrefill,
     // Action data
     reviewActions: panelReviewActions,
     sessionActions,
@@ -907,8 +907,8 @@ export function CoachingSessionPanel({
     onBodyChange: handleBodyChange,
     isAddingAction,
     onAddingActionChange: handleAddingActionChange,
-    actionBodyAppend,
-    goalTitleSeed,
+    actionBodyPrefill,
+    goalTitlePrefill,
     locale: siteConfig.locale,
     activeActionTab,
     onActiveActionTabChange: setActiveActionTab,

--- a/src/components/ui/coaching-sessions/coaching-session-panel.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-panel.tsx
@@ -106,16 +106,15 @@ export interface CoachingSessionPanelSharedProps {
   onActiveActionTabChange: (tab: ActionTab) => void;
 }
 
-// A section's hooks for receiving a notes selection. Every section supplies
-// the same three methods, so routing a selection (and clearing it on close)
-// needs no per-entity branching at the call sites.
+// How a section receives a routed notes selection. Every section supplies the
+// same two methods, so the render-time dispatch needs no per-entity branching.
+// (Clearing the seed on close is a stable operation handled separately via
+// `clearSeed` so the change handlers can stay memoized.)
 interface NoteSelectionTarget {
   /** Enter this section's add-flow. */
   open(): void;
   /** Route the selected text into this section's seeded field. */
   seed(field: Option<NoteField>): void;
-  /** Drop the seed when the add-flow closes. */
-  clear(): void;
 }
 
 // ── Shared helpers for desktop and mobile layouts ─────────────────────
@@ -722,27 +721,38 @@ export function CoachingSessionPanel({
   const [goalTitleSeed, setGoalTitleSeed] = useState<Option<NoteField>>(None);
   const handledNonce = useRef(0);
 
-  // Each section receives a notes selection through the same interface, so the
-  // dispatch below and the clear-on-close handlers need no per-entity switch.
+  // Render-time dispatch targets: each section opens its add-flow and seeds
+  // its field through the same interface, so the dispatch below needs no
+  // per-entity switch. Rebuilt each render because `open` reads the live
+  // `atLimit`/`goalFlow`; clearing is hoisted to `clearSeed` (below) instead.
   const noteTargets: Record<PanelSection, NoteSelectionTarget> = {
     [PanelSection.Goals]: {
       // At the goal cap, creation requires a swap first; both routes land on
       // the create form, where the seeded title is applied on mount.
       open: () => (atLimit ? goalFlow.handleAddGoalClick() : goalFlow.handleCreateNewClick()),
       seed: setGoalTitleSeed,
-      clear: () => setGoalTitleSeed(None),
     },
     [PanelSection.Agreements]: {
       open: () => setIsAddingAgreement(true),
       seed: setAgreementBodyAppend,
-      clear: () => setAgreementBodyAppend(None),
     },
     [PanelSection.Actions]: {
       open: () => setIsAddingAction(true),
       seed: setActionBodyAppend,
-      clear: () => setActionBodyAppend(None),
     },
   };
+
+  // One uniform clear mechanism, shared by the change handlers and the
+  // goal-idle effect. Stable (useState setters never change identity), so the
+  // handlers below can stay memoized.
+  const clearSeed = useMemo<Record<PanelSection, () => void>>(
+    () => ({
+      [PanelSection.Goals]: () => setGoalTitleSeed(None),
+      [PanelSection.Agreements]: () => setAgreementBodyAppend(None),
+      [PanelSection.Actions]: () => setActionBodyAppend(None),
+    }),
+    []
+  );
 
   // Open the target section's add-form on a new selection nonce (render-time
   // own-state adjustment, mirroring action-section-content's requiredTab).
@@ -756,20 +766,26 @@ export function CoachingSessionPanel({
 
   // Clear a section's seed when its add-flow closes, so a later fresh "Add"
   // starts blank and the still-present selection (same nonce) won't re-seed.
-  const handleAddingActionChange = (adding: boolean) => {
-    setIsAddingAction(adding);
-    if (!adding) noteTargets[PanelSection.Actions].clear();
-  };
-  const handleAddingAgreementChange = (adding: boolean) => {
-    setIsAddingAgreement(adding);
-    if (!adding) noteTargets[PanelSection.Agreements].clear();
-  };
+  const handleAddingActionChange = useCallback(
+    (adding: boolean) => {
+      setIsAddingAction(adding);
+      if (!adding) clearSeed[PanelSection.Actions]();
+    },
+    [clearSeed]
+  );
+  const handleAddingAgreementChange = useCallback(
+    (adding: boolean) => {
+      setIsAddingAgreement(adding);
+      if (!adding) clearSeed[PanelSection.Agreements]();
+    },
+    [clearSeed]
+  );
 
   // The goal create form unmounts when the flow leaves Creating; drop the
   // title seed once it returns to Idle so a manual "Add Goal" starts blank.
   useEffect(() => {
-    if (goalFlow.flow.step === GoalFlowStep.Idle) setGoalTitleSeed(None);
-  }, [goalFlow.flow.step]);
+    if (goalFlow.flow.step === GoalFlowStep.Idle) clearSeed[PanelSection.Goals]();
+  }, [goalFlow.flow.step, clearSeed]);
 
   // ── Agreement state & handlers ──────────────────────────────────
 

--- a/src/components/ui/coaching-sessions/coaching-tabs-container.tsx
+++ b/src/components/ui/coaching-sessions/coaching-tabs-container.tsx
@@ -5,18 +5,19 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { CoachingNotes } from "@/components/ui/coaching-sessions/coaching-notes";
+import type { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
 
 interface CoachingTabsContainerProps {
   isMaximized?: boolean;
   onToggleMaximize?: () => void;
-  /** Forwards text selected in the notes to the panel's add-action flow. */
-  onAddActionFromNote: (selectedText: string) => void;
+  /** Forwards text selected in the notes to a panel section's add-flow. */
+  onAddFromNote: (section: PanelSection, selectedText: string) => void;
 }
 
 const CoachingTabsContainer = ({
   isMaximized = false,
   onToggleMaximize,
-  onAddActionFromNote,
+  onAddFromNote,
 }: CoachingTabsContainerProps) => {
   return (
     <Card className="row-span-1 h-full flex flex-col min-h-0 min-w-0">
@@ -50,7 +51,7 @@ const CoachingTabsContainer = ({
 
       <CardContent className="p-4 pt-0 flex-1 flex flex-col min-h-0 min-w-0">
         <div className="mt-4 flex-1 flex flex-col min-h-0 min-w-0">
-          <CoachingNotes onAddAsAction={onAddActionFromNote} />
+          <CoachingNotes onAddAs={onAddFromNote} />
         </div>
       </CardContent>
     </Card>

--- a/src/components/ui/coaching-sessions/goal-create-form.tsx
+++ b/src/components/ui/coaching-sessions/goal-create-form.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { type Option, None } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
-import { useSeededField } from "@/lib/hooks/use-seeded-field";
+import { useFieldPrefill } from "@/lib/hooks/use-field-prefill";
 
 // ── Goal Create Form ────────────────────────────────────────────────
 
@@ -13,24 +13,24 @@ export interface GoalCreateFormProps {
   onCancel: () => void;
   /** Label for the submit button */
   submitLabel: string;
-  /** Notes selection seeding the title once, only while it is still empty. */
-  titleSeed?: Option<NoteField>;
+  /** Notes selection prefilling the title once, only while it is still empty. */
+  titlePrefill?: Option<NoteField>;
 }
 
 export function GoalCreateForm({
   onSubmit,
   onCancel,
   submitLabel,
-  titleSeed = None,
+  titlePrefill = None,
 }: GoalCreateFormProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [showBody, setShowBody] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Seed the title from a notes selection, but never clobber what the coach
+  // Prefill the title from a notes selection, but never clobber what the coach
   // has already typed.
-  useSeededField(titleSeed, (text) =>
+  useFieldPrefill(titlePrefill, (text) =>
     setTitle((prev) => (prev.trim() ? prev : text))
   );
 

--- a/src/components/ui/coaching-sessions/goal-create-form.tsx
+++ b/src/components/ui/coaching-sessions/goal-create-form.tsx
@@ -2,6 +2,9 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Button } from "@/components/ui/button";
+import { type Option, None } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
+import { useSeededField } from "@/lib/hooks/use-seeded-field";
 
 // ── Goal Create Form ────────────────────────────────────────────────
 
@@ -10,17 +13,26 @@ export interface GoalCreateFormProps {
   onCancel: () => void;
   /** Label for the submit button */
   submitLabel: string;
+  /** Notes selection seeding the title once, only while it is still empty. */
+  titleSeed?: Option<NoteField>;
 }
 
 export function GoalCreateForm({
   onSubmit,
   onCancel,
   submitLabel,
+  titleSeed = None,
 }: GoalCreateFormProps) {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
   const [showBody, setShowBody] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Seed the title from a notes selection, but never clobber what the coach
+  // has already typed.
+  useSeededField(titleSeed, (text) =>
+    setTitle((prev) => (prev.trim() ? prev : text))
+  );
 
   // Auto-focus on mount
   const setInputRef = useCallback((el: HTMLInputElement | null) => {

--- a/src/components/ui/tiptap-ui/selection-bubble-menu/selection-bubble-menu.tsx
+++ b/src/components/ui/tiptap-ui/selection-bubble-menu/selection-bubble-menu.tsx
@@ -1,12 +1,13 @@
 import { useState, useCallback, useEffect } from "react";
 import type { Editor } from "@tiptap/react";
 import { BubbleMenu, type BubbleMenuProps } from "@tiptap/react/menus";
-import { Copy, ListPlus, X } from "lucide-react";
+import { Copy, Handshake, ListPlus, Target, X } from "lucide-react";
 import { toast } from "sonner";
 
 import { useTiptapEditor } from "@/lib/hooks/use-tiptap-editor";
 import { Button } from "@/components/ui/tiptap-ui-primitive/button";
 import { Separator } from "@/components/ui/tiptap-ui-primitive/separator";
+import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
 
 import "@/components/ui/tiptap-ui/selection-bubble-menu/selection-bubble-menu.scss";
 
@@ -56,12 +57,13 @@ export function shouldShowSelectionMenu({
 
 export interface SelectionBubbleMenuProps {
   editor?: Editor | null;
-  onAddAsAction: (selectedText: string) => void;
+  /** Routes the trimmed selection to a panel section's add-flow. */
+  onAddAs: (section: PanelSection, selectedText: string) => void;
 }
 
 export function SelectionBubbleMenu({
   editor: providedEditor,
-  onAddAsAction,
+  onAddAs,
 }: SelectionBubbleMenuProps) {
   const editor = useTiptapEditor(providedEditor);
   const [dismissed, setDismissed] = useState(false);
@@ -142,12 +144,15 @@ export function SelectionBubbleMenu({
     }
   }, [getSelectedText]);
 
-  const handleAddAsAction = useCallback(() => {
-    const text = getSelectedText().trim();
-    if (!text) return;
-    setDismissed(true);
-    onAddAsAction(text);
-  }, [getSelectedText, onAddAsAction]);
+  const handleAddAs = useCallback(
+    (section: PanelSection) => {
+      const text = getSelectedText().trim();
+      if (!text) return;
+      setDismissed(true);
+      onAddAs(section, text);
+    },
+    [getSelectedText, onAddAs]
+  );
 
   const handleDismiss = useCallback(() => {
     setDismissed(true);
@@ -198,12 +203,32 @@ export function SelectionBubbleMenu({
 
         <Button
           type="button"
-          onClick={handleAddAsAction}
+          onClick={() => handleAddAs(PanelSection.Actions)}
           tooltip="Add as Action"
           data-style="ghost"
           aria-label="Add as Action"
         >
           <ListPlus className="tiptap-button-icon" />
+        </Button>
+
+        <Button
+          type="button"
+          onClick={() => handleAddAs(PanelSection.Agreements)}
+          tooltip="Add as Agreement"
+          data-style="ghost"
+          aria-label="Add as Agreement"
+        >
+          <Handshake className="tiptap-button-icon" />
+        </Button>
+
+        <Button
+          type="button"
+          onClick={() => handleAddAs(PanelSection.Goals)}
+          tooltip="Add as Goal"
+          data-style="ghost"
+          aria-label="Add as Goal"
+        >
+          <Target className="tiptap-button-icon" />
         </Button>
 
         <Separator orientation="vertical" />

--- a/src/lib/hooks/use-add-from-notes.ts
+++ b/src/lib/hooks/use-add-from-notes.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type Option, Some, None } from "@/types/option";
+import type { NoteSelection } from "@/types/note-selection";
+import { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
+
+export interface UseAddFromNotesParams {
+  /** Whether the panel column is currently collapsed. */
+  isGoalsCollapsed: boolean;
+  /** Expands the panel column. */
+  toggleGoalsCollapsed: () => void;
+  /** Writes ?panel=<section> to the URL. */
+  pinSection: (section: PanelSection) => void;
+}
+
+export interface UseAddFromNotesResult {
+  selection: Option<NoteSelection>;
+  addFromNote: (section: PanelSection, text: string) => void;
+}
+
+/**
+ * Bridges the notes "Add as …" affordance to the panel: a trimmed selection
+ * becomes a {@link NoteSelection} carrying its target section, bumping a
+ * monotonic nonce so the panel reacts once per selection. The section is
+ * pinned to the URL once per nonce, but only after the panel is expanded —
+ * gating on `!isGoalsCollapsed` avoids clobbering the layout's
+ * focus/transcript params on the same tick.
+ */
+export function useAddFromNotes({
+  isGoalsCollapsed,
+  toggleGoalsCollapsed,
+  pinSection,
+}: UseAddFromNotesParams): UseAddFromNotesResult {
+  const [selection, setSelection] = useState<Option<NoteSelection>>(None);
+  const nonceRef = useRef(0);
+  const pinnedNonce = useRef(0);
+
+  const addFromNote = useCallback(
+    (section: PanelSection, text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      if (isGoalsCollapsed) toggleGoalsCollapsed();
+      nonceRef.current += 1;
+      setSelection(Some({ section, text: trimmed, nonce: nonceRef.current }));
+    },
+    [isGoalsCollapsed, toggleGoalsCollapsed]
+  );
+
+  useEffect(() => {
+    if (!selection.some || isGoalsCollapsed) return;
+    if (selection.val.nonce === pinnedNonce.current) return;
+    pinnedNonce.current = selection.val.nonce;
+    pinSection(selection.val.section);
+  }, [selection, isGoalsCollapsed, pinSection]);
+
+  return { selection, addFromNote };
+}

--- a/src/lib/hooks/use-field-prefill.ts
+++ b/src/lib/hooks/use-field-prefill.ts
@@ -3,17 +3,17 @@ import type { Option } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
 
 /**
- * Applies a {@link NoteField}'s text once per distinct nonce. The caller's
- * `apply` closure owns the append-vs-replace policy; this hook only handles
- * the nonce dedup so the same selection is never applied twice.
+ * Prefills a form field from a {@link NoteField}, once per distinct nonce. The
+ * caller's `apply` closure owns the append-vs-replace policy; this hook only
+ * handles the nonce dedup so the same value is never applied twice.
  */
-export function useSeededField(
+export function useFieldPrefill(
   field: Option<NoteField>,
   apply: (text: string) => void
 ): void {
   const lastNonce = useRef(0);
-  // Keep the latest closure without re-firing the seed effect on its identity.
-  // Declared before the seed effect so it commits first on every render.
+  // Keep the latest closure without re-firing the prefill effect on its
+  // identity. Declared before the prefill effect so it commits first.
   const applyRef = useRef(apply);
   useEffect(() => {
     applyRef.current = apply;

--- a/src/lib/hooks/use-seeded-field.ts
+++ b/src/lib/hooks/use-seeded-field.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from "react";
+import type { Option } from "@/types/option";
+import type { NoteField } from "@/types/note-selection";
+
+/**
+ * Applies a {@link NoteField}'s text once per distinct nonce. The caller's
+ * `apply` closure owns the append-vs-replace policy; this hook only handles
+ * the nonce dedup so the same selection is never applied twice.
+ */
+export function useSeededField(
+  field: Option<NoteField>,
+  apply: (text: string) => void
+): void {
+  const lastNonce = useRef(0);
+  // Keep the latest closure without re-firing the seed effect on its identity.
+  // Declared before the seed effect so it commits first on every render.
+  const applyRef = useRef(apply);
+  useEffect(() => {
+    applyRef.current = apply;
+  });
+
+  useEffect(() => {
+    if (!field.some || field.val.nonce === lastNonce.current) return;
+    lastNonce.current = field.val.nonce;
+    applyRef.current(field.val.text);
+  }, [field]);
+}

--- a/src/types/note-selection.ts
+++ b/src/types/note-selection.ts
@@ -8,7 +8,7 @@ export interface NoteField {
 }
 
 // Page → panel signal: a NoteField destined for a specific section's
-// add-flow. Extending NoteField makes the seed conversion (a NoteSelection IS
+// add-flow. Extending NoteField makes the prefill conversion (a NoteSelection IS
 // a NoteField plus a section) type-checked rather than reconstructed by hand.
 export interface NoteSelection extends NoteField {
   section: PanelSection;

--- a/src/types/note-selection.ts
+++ b/src/types/note-selection.ts
@@ -1,0 +1,15 @@
+import type { PanelSection } from "@/components/ui/coaching-sessions/coaching-session-panel-selector";
+
+// A note's selected text destined for a single form field (body or title).
+// The nonce lets a consumer apply the same text once per distinct selection.
+export interface NoteField {
+  text: string;
+  nonce: number;
+}
+
+// Page → panel signal: which add-flow to open, with the selected text.
+export interface NoteSelection {
+  section: PanelSection;
+  text: string;
+  nonce: number;
+}

--- a/src/types/note-selection.ts
+++ b/src/types/note-selection.ts
@@ -7,9 +7,9 @@ export interface NoteField {
   nonce: number;
 }
 
-// Page → panel signal: which add-flow to open, with the selected text.
-export interface NoteSelection {
+// Page → panel signal: a NoteField destined for a specific section's
+// add-flow. Extending NoteField makes the seed conversion (a NoteSelection IS
+// a NoteField plus a section) type-checked rather than reconstructed by hand.
+export interface NoteSelection extends NoteField {
   section: PanelSection;
-  text: string;
-  nonce: number;
 }


### PR DESCRIPTION
## Description
Generalizes the action-only **"Add as Action from notes"** flow (PR #407) into a reusable pattern that drives **Actions, Agreements, and Goals** from selected coaching-notes text. Selecting text now offers three inline buttons in the notes bubble menu; each opens the corresponding panel add-form seeded with the selection.

### Changes
- **Shared core (tested once):**
  - `src/types/note-selection.ts` — `NoteField` / `NoteSelection`
  - `src/lib/hooks/use-seeded-field.ts` — nonce-dedup seed mechanism (append vs replace policy lives at each call site)
  - `src/lib/hooks/use-add-from-notes.ts` — page→panel bridge generalized over any `PanelSection` (trim guard, monotonic nonce, deferred `?panel=<section>` URL sync gated on panel expansion)
- **Registry dispatch (no switch):** the panel routes a selection through a `Record<PanelSection, NoteSelectionTarget>` where each section supplies the same `open()` / `seed()` / `clear()`; the render-time dispatch and clear-on-close both go through it.
- **Three inline buttons** in `SelectionBubbleMenu` (`onAddAs(section, text)`); Action/Agreement seed the **body** (append), Goal seeds the **title** (replace-if-empty).
- `ActionEditForm` refactored onto the shared `useSeededField` (dogfooding; behavior unchanged).

### Testing Strategy
- `npx tsc --noEmit`, ESLint, and the full Vitest suite (**1365 tests**) pass.
- New unit tests: `use-seeded-field`, `use-add-from-notes`, parametrized panel + page tests across all three sections.
- Lean Playwright E2E (`add-from-notes-selection.spec.ts`) across chromium/firefox/webkit: each section's add-form opens via deep link; agreement Save fires the create POST.
- **Verified end-to-end against a running backend** (live collab notes editor) — all happy paths (Action/Agreement/Goal seed + persist, append-to-in-progress-body, collapsed→expand + URL pin) and sad paths (whitespace-only selection offers no buttons; empty body disables Save).

### Notes
- The seed itself originates in the TipTap collab notes editor, which isn't reachable under mocked Playwright routes (needs a collab JWT + a 10s offline-editing fallback). That selection→seed seam is covered by unit tests and manual real-backend verification rather than the automated E2E.
- Mobile: the action/agreement section lives in a `Sheet` with internal open state; auto-opening the mobile sheet remains out of scope (unchanged from #407).