### PR TITLE
Coaching Session Series: first-class entity for recurring sessions

### DIFF
--- a/__tests__/components/ui/dashboard/dashboard-container.test.tsx
+++ b/__tests__/components/ui/dashboard/dashboard-container.test.tsx
@@ -29,6 +29,7 @@ import { DashboardContainer } from "@/components/ui/dashboard/dashboard-containe
 
 const upcomingSessionRefreshSpy = vi.fn();
 const coachingSessionsCardRefreshSpy = vi.fn();
+const coachingSeriesCardRefreshSpy = vi.fn();
 
 vi.mock("@/components/ui/dashboard/upcoming-session-card", () => ({
   UpcomingSessionCard: ({
@@ -64,7 +65,16 @@ vi.mock("@/components/ui/dashboard/goals-overview-card", () => ({
 }));
 
 vi.mock("@/components/ui/dashboard/coaching-series-card", () => ({
-  CoachingSeriesCard: () => <div data-testid="coaching-series-card-stub" />,
+  CoachingSeriesCard: ({
+    onRefreshNeeded,
+  }: {
+    onRefreshNeeded?: (fn: () => void) => void;
+  }) => {
+    useEffect(() => {
+      onRefreshNeeded?.(coachingSeriesCardRefreshSpy);
+    }, [onRefreshNeeded]);
+    return <div data-testid="coaching-series-card-stub" />;
+  },
 }));
 
 vi.mock("@/components/ui/dashboard/dashboard-header", () => ({
@@ -146,18 +156,20 @@ describe("DashboardContainer auto-refresh wiring", () => {
     // either dropped a prop or stopped passing it.
     expect(upcomingSessionRefreshSpy).not.toHaveBeenCalled();
     expect(coachingSessionsCardRefreshSpy).not.toHaveBeenCalled();
+    expect(coachingSeriesCardRefreshSpy).not.toHaveBeenCalled();
     // The card *stubs* are responsible for invoking onRefreshNeeded
     // with these spies; the assertion above just establishes the
     // baseline. The next test exercises the call path.
   });
 
-  it("invokes BOTH card refreshes when the create/edit dialog closes", () => {
+  it("invokes ALL card refreshes when the create/edit dialog closes", () => {
     render(<DashboardContainer />);
 
     // Pre-state: refreshes haven't been called as a result of dialog
     // close yet (they're plumbed but the dialog is closed at mount).
     upcomingSessionRefreshSpy.mockClear();
     coachingSessionsCardRefreshSpy.mockClear();
+    coachingSeriesCardRefreshSpy.mockClear();
 
     // Open the dialog via the header stub.
     fireEvent.click(screen.getByTestId("open-dialog-stub"));
@@ -169,23 +181,27 @@ describe("DashboardContainer auto-refresh wiring", () => {
       fireEvent.click(screen.getByTestId("close-dialog-stub"));
     });
 
-    // The contract: dialog-close fires both refreshes. If a future
-    // refactor wires the dialog's onOpenChange to a path that only
-    // refreshes one card (or neither), this assertion will fail.
+    // The contract: dialog-close fires every card's refresh. A recurring
+    // create adds a series too, so the series card is part of this set. If a
+    // future refactor wires the dialog's onOpenChange to a path that only
+    // refreshes some cards, this assertion will fail.
     expect(upcomingSessionRefreshSpy).toHaveBeenCalledTimes(1);
     expect(coachingSessionsCardRefreshSpy).toHaveBeenCalledTimes(1);
+    expect(coachingSeriesCardRefreshSpy).toHaveBeenCalledTimes(1);
   });
 
   it("does not fire refreshes on initial mount (only on dialog close)", () => {
     upcomingSessionRefreshSpy.mockClear();
     coachingSessionsCardRefreshSpy.mockClear();
+    coachingSeriesCardRefreshSpy.mockClear();
 
     render(<DashboardContainer />);
 
-    // Mount alone — no dialog interaction yet — must not fire either
+    // Mount alone — no dialog interaction yet — must not fire any
     // refresh. If it did, every dashboard render would re-fetch, which
     // would also break SWR's cache-warmth semantics elsewhere.
     expect(upcomingSessionRefreshSpy).not.toHaveBeenCalled();
     expect(coachingSessionsCardRefreshSpy).not.toHaveBeenCalled();
+    expect(coachingSeriesCardRefreshSpy).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/components/ui/dashboard/dashboard-container.test.tsx
+++ b/__tests__/components/ui/dashboard/dashboard-container.test.tsx
@@ -124,6 +124,15 @@ vi.mock("@/lib/providers/auth-store-provider", () => ({
     selector({ userSession: undefined }),
 }));
 
+vi.mock(
+  "@/lib/providers/coaching-sessions-card-filter-store-provider",
+  () => ({
+    useCoachingSessionsCardFilterStore: (
+      selector: (s: { relationshipFilter: string | undefined }) => unknown
+    ) => selector({ relationshipFilter: undefined }),
+  })
+);
+
 describe("DashboardContainer auto-refresh wiring", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/__tests__/components/ui/dashboard/dashboard-container.test.tsx
+++ b/__tests__/components/ui/dashboard/dashboard-container.test.tsx
@@ -63,6 +63,10 @@ vi.mock("@/components/ui/dashboard/goals-overview-card", () => ({
   GoalsOverviewCard: () => <div data-testid="goals-overview-card-stub" />,
 }));
 
+vi.mock("@/components/ui/dashboard/coaching-series-card", () => ({
+  CoachingSeriesCard: () => <div data-testid="coaching-series-card-stub" />,
+}));
+
 vi.mock("@/components/ui/dashboard/dashboard-header", () => ({
   DashboardHeader: ({ onCreateSession }: { onCreateSession: () => void }) => (
     <button data-testid="open-dialog-stub" onClick={onCreateSession}>
@@ -113,6 +117,11 @@ vi.mock("@/lib/hooks/use-current-coaching-relationship", () => ({
 }));
 vi.mock("@/lib/hooks/use-auto-select-single-relationship", () => ({
   useAutoSelectSingleRelationship: () => undefined,
+}));
+
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  useAuthStore: (selector: (s: { userSession?: { id: string } }) => unknown) =>
+    selector({ userSession: undefined }),
 }));
 
 describe("DashboardContainer auto-refresh wiring", () => {

--- a/__tests__/integration/coaching-session-duration.integration.test.tsx
+++ b/__tests__/integration/coaching-session-duration.integration.test.tsx
@@ -42,16 +42,12 @@ vi.mock("@/lib/api/users", () => ({
 
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
-const mockCreateRecurring = vi.fn();
 vi.mock("@/lib/api/coaching-sessions", () => ({
   useCoachingSessionList: () => ({ refresh: vi.fn() }),
   useCoachingSessionMutation: () => ({
     create: mockCreate,
     update: mockUpdate,
   }),
-  CoachingSessionApi: {
-    createRecurring: (...args: unknown[]) => mockCreateRecurring(...args),
-  },
 }));
 
 vi.mock("@/lib/api/coaching-relationships", () => ({

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -77,8 +77,6 @@ export function CoachingSeriesCard({
         "Recurring series deleted. Future sessions were removed; past sessions were kept."
       );
       setDeleteState({ kind: "closed" });
-      // The series list uses a tuple SWR key the mutation hook can't
-      // auto-invalidate, and deleting drops future sessions — refresh both.
       refresh();
       onSeriesMutated?.();
     } catch {

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CalendarClock, CalendarRange, MoreVertical, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -37,6 +37,10 @@ interface CoachingSeriesCardProps {
   relationshipId: Id | null;
   canManage?: boolean;
   onSeriesMutated?: () => void;
+  /** Surfaces the card's SWR refresh to the parent so it can revalidate after
+   *  the create/edit dialog closes. The series list uses a tuple SWR key the
+   *  mutation hook can't auto-invalidate. Mirrors the other dashboard cards. */
+  onRefreshNeeded?: (refresh: () => void) => void;
 }
 
 type DeleteState =
@@ -53,9 +57,20 @@ export function CoachingSeriesCard({
   relationshipId,
   canManage = false,
   onSeriesMutated,
+  onRefreshNeeded,
 }: CoachingSeriesCardProps) {
   const { series, isLoading, isError, refresh } =
     useCoachingSessionSeriesList(relationshipId);
+
+  // Register a stable refresh wrapper once; the ref keeps it pointed at the
+  // latest SWR mutator as relationshipId (and thus the key) changes.
+  const refreshRef = useRef(refresh);
+  useEffect(() => {
+    refreshRef.current = refresh;
+  });
+  useEffect(() => {
+    onRefreshNeeded?.(() => refreshRef.current());
+  }, [onRefreshNeeded]);
   const { delete: deleteSeries } = useCoachingSessionSeriesMutation();
   const [deleteState, setDeleteState] = useState<DeleteState>({
     kind: "closed",

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreVertical, Trash2 } from "lucide-react";
+import { CalendarRange, MoreVertical, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,14 +15,17 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 import { DeleteSeriesDialog } from "@/components/ui/dashboard/delete-series-dialog";
+import { SeriesDetailDialog } from "@/components/ui/dashboard/series-detail-dialog";
 import {
   useCoachingSessionSeriesList,
   useCoachingSessionSeriesMutation,
 } from "@/lib/api/coaching-session-series";
+import { getBrowserTimezone } from "@/lib/timezone-utils";
 import {
   CoachingSessionSeries,
   formatSeriesRule,
@@ -56,6 +59,10 @@ export function CoachingSeriesCard({
   const [deleteState, setDeleteState] = useState<DeleteState>({
     kind: "closed",
   });
+  const [detailSeries, setDetailSeries] = useState<CoachingSessionSeries | null>(
+    null
+  );
+  const userTimezone = getBrowserTimezone();
 
   const handleConfirmDelete = async () => {
     if (deleteState.kind !== "pending") return;
@@ -117,19 +124,24 @@ export function CoachingSeriesCard({
                     {s.rule.duration_minutes}-minute sessions
                   </span>
                 </div>
-                {canManage && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        aria-label="Series actions"
-                        className="rounded-full h-8 w-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
-                      >
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      aria-label="Series actions"
+                      className="rounded-full h-8 w-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => setDetailSeries(s)}>
+                      <CalendarRange className="mr-2 h-4 w-4" />
+                      View sessions
+                    </DropdownMenuItem>
+                    {canManage && <DropdownMenuSeparator />}
+                    {canManage && (
                       <DropdownMenuItem
                         onClick={() =>
                           setDeleteState({ kind: "pending", series: s })
@@ -139,9 +151,9 @@ export function CoachingSeriesCard({
                         <Trash2 className="mr-2 h-4 w-4" />
                         Delete series
                       </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </li>
             ))}
           </ul>
@@ -155,6 +167,12 @@ export function CoachingSeriesCard({
         isDeleting={deleteState.kind === "deleting"}
         onCancel={() => setDeleteState({ kind: "closed" })}
         onConfirm={handleConfirmDelete}
+      />
+
+      <SeriesDetailDialog
+        series={detailSeries}
+        userTimezone={userTimezone}
+        onClose={() => setDetailSeries(null)}
       />
     </Card>
   );

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -26,6 +26,7 @@ import {
   useCoachingSessionSeriesList,
   useCoachingSessionSeriesMutation,
 } from "@/lib/api/coaching-session-series";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
 import {
   CoachingSessionSeries,
@@ -59,8 +60,13 @@ export function CoachingSeriesCard({
   onSeriesMutated,
   onRefreshNeeded,
 }: CoachingSeriesCardProps) {
+  const userSession = useAuthStore((s) => s.userSession);
+  // Must match the timezone the create/reschedule forms write with, so the
+  // stored UTC `until` round-trips back to the same local date.
+  const userTimezone = userSession?.timezone || getBrowserTimezone();
+
   const { series, isLoading, isError, refresh } =
-    useCoachingSessionSeriesList(relationshipId);
+    useCoachingSessionSeriesList(relationshipId, userTimezone);
 
   // Register a stable refresh wrapper once; the ref keeps it pointed at the
   // latest SWR mutator as relationshipId (and thus the key) changes.
@@ -71,7 +77,7 @@ export function CoachingSeriesCard({
   useEffect(() => {
     onRefreshNeeded?.(() => refreshRef.current());
   }, [onRefreshNeeded]);
-  const { delete: deleteSeries } = useCoachingSessionSeriesMutation();
+  const { delete: deleteSeries } = useCoachingSessionSeriesMutation(userTimezone);
   const [deleteState, setDeleteState] = useState<DeleteState>({
     kind: "closed",
   });
@@ -80,7 +86,6 @@ export function CoachingSeriesCard({
   );
   const [rescheduleSeries, setRescheduleSeries] =
     useState<CoachingSessionSeries | null>(null);
-  const userTimezone = getBrowserTimezone();
 
   const handleConfirmDelete = async () => {
     if (deleteState.kind !== "pending") return;

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { useCoachingSessionSeriesList } from "@/lib/api/coaching-session-series";
+import { formatSeriesRule } from "@/types/coaching-session-series";
+import { Id } from "@/types/general";
+
+interface CoachingSeriesCardProps {
+  /** Relationship whose series to list; null shows a "select a relationship" prompt. */
+  relationshipId: Id | null;
+}
+
+/**
+ * Lists the recurring-session series for the selected coaching relationship.
+ * Metadata only — the per-series sessions live behind the detail endpoint.
+ */
+export function CoachingSeriesCard({ relationshipId }: CoachingSeriesCardProps) {
+  const { series, isLoading, isError } =
+    useCoachingSessionSeriesList(relationshipId);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Recurring sessions</CardTitle>
+        <CardDescription>
+          Recurrence schedules for the selected coaching relationship.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!relationshipId ? (
+          <p className="text-sm text-muted-foreground">
+            Select a coaching relationship to see its recurring sessions.
+          </p>
+        ) : isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Spinner /> Loading recurring sessions…
+          </div>
+        ) : isError ? (
+          <p className="text-sm text-destructive">
+            Couldn&apos;t load recurring sessions. Please try again.
+          </p>
+        ) : series.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No recurring sessions for this relationship.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {series.map((s) => (
+              <li key={s.id} className="flex flex-col gap-0.5 py-3 first:pt-0">
+                <span className="font-medium">{formatSeriesRule(s.rule)}</span>
+                <span className="text-sm text-muted-foreground">
+                  {s.rule.duration_minutes}-minute sessions
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CalendarRange, MoreVertical, Trash2 } from "lucide-react";
+import { CalendarClock, CalendarRange, MoreVertical, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
 import { DeleteSeriesDialog } from "@/components/ui/dashboard/delete-series-dialog";
+import { RescheduleSeriesDialog } from "@/components/ui/dashboard/reschedule-series-dialog";
 import { SeriesDetailDialog } from "@/components/ui/dashboard/series-detail-dialog";
 import {
   useCoachingSessionSeriesList,
@@ -62,6 +63,8 @@ export function CoachingSeriesCard({
   const [detailSeries, setDetailSeries] = useState<CoachingSessionSeries | null>(
     null
   );
+  const [rescheduleSeries, setRescheduleSeries] =
+    useState<CoachingSessionSeries | null>(null);
   const userTimezone = getBrowserTimezone();
 
   const handleConfirmDelete = async () => {
@@ -140,6 +143,12 @@ export function CoachingSeriesCard({
                       <CalendarRange className="mr-2 h-4 w-4" />
                       View sessions
                     </DropdownMenuItem>
+                    {canManage && (
+                      <DropdownMenuItem onClick={() => setRescheduleSeries(s)}>
+                        <CalendarClock className="mr-2 h-4 w-4" />
+                        Reschedule
+                      </DropdownMenuItem>
+                    )}
                     {canManage && <DropdownMenuSeparator />}
                     {canManage && (
                       <DropdownMenuItem
@@ -173,6 +182,15 @@ export function CoachingSeriesCard({
         series={detailSeries}
         userTimezone={userTimezone}
         onClose={() => setDetailSeries(null)}
+      />
+
+      <RescheduleSeriesDialog
+        series={rescheduleSeries}
+        onClose={() => setRescheduleSeries(null)}
+        onRescheduled={() => {
+          refresh();
+          onSeriesMutated?.();
+        }}
       />
     </Card>
   );

--- a/src/components/ui/dashboard/coaching-series-card.tsx
+++ b/src/components/ui/dashboard/coaching-series-card.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import { useState } from "react";
+import { MoreVertical, Trash2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -7,23 +11,71 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
-import { useCoachingSessionSeriesList } from "@/lib/api/coaching-session-series";
-import { formatSeriesRule } from "@/types/coaching-session-series";
+import { DeleteSeriesDialog } from "@/components/ui/dashboard/delete-series-dialog";
+import {
+  useCoachingSessionSeriesList,
+  useCoachingSessionSeriesMutation,
+} from "@/lib/api/coaching-session-series";
+import {
+  CoachingSessionSeries,
+  formatSeriesRule,
+} from "@/types/coaching-session-series";
 import { Id } from "@/types/general";
 
 interface CoachingSeriesCardProps {
-  /** Relationship whose series to list; null shows a "select a relationship" prompt. */
   relationshipId: Id | null;
+  canManage?: boolean;
+  onSeriesMutated?: () => void;
 }
 
+type DeleteState =
+  | { kind: "closed" }
+  | { kind: "pending"; series: CoachingSessionSeries }
+  | { kind: "deleting"; series: CoachingSessionSeries };
+
 /**
- * Lists the recurring-session series for the selected coaching relationship.
- * Metadata only — the per-series sessions live behind the detail endpoint.
+ * Lists the recurring-session series for the selected coaching relationship
+ * and lets coaches delete one. Metadata only — the per-series sessions live
+ * behind the detail endpoint.
  */
-export function CoachingSeriesCard({ relationshipId }: CoachingSeriesCardProps) {
-  const { series, isLoading, isError } =
+export function CoachingSeriesCard({
+  relationshipId,
+  canManage = false,
+  onSeriesMutated,
+}: CoachingSeriesCardProps) {
+  const { series, isLoading, isError, refresh } =
     useCoachingSessionSeriesList(relationshipId);
+  const { delete: deleteSeries } = useCoachingSessionSeriesMutation();
+  const [deleteState, setDeleteState] = useState<DeleteState>({
+    kind: "closed",
+  });
+
+  const handleConfirmDelete = async () => {
+    if (deleteState.kind !== "pending") return;
+    const target = deleteState.series;
+    setDeleteState({ kind: "deleting", series: target });
+    try {
+      await deleteSeries(target.id);
+      toast.success(
+        "Recurring series deleted. Future sessions were removed; past sessions were kept."
+      );
+      setDeleteState({ kind: "closed" });
+      // The series list uses a tuple SWR key the mutation hook can't
+      // auto-invalidate, and deleting drops future sessions — refresh both.
+      refresh();
+      onSeriesMutated?.();
+    } catch {
+      toast.error("Couldn't delete the recurring series. Please try again.");
+      setDeleteState({ kind: "pending", series: target });
+    }
+  };
 
   return (
     <Card>
@@ -53,16 +105,57 @@ export function CoachingSeriesCard({ relationshipId }: CoachingSeriesCardProps) 
         ) : (
           <ul className="divide-y divide-border">
             {series.map((s) => (
-              <li key={s.id} className="flex flex-col gap-0.5 py-3 first:pt-0">
-                <span className="font-medium">{formatSeriesRule(s.rule)}</span>
-                <span className="text-sm text-muted-foreground">
-                  {s.rule.duration_minutes}-minute sessions
-                </span>
+              <li
+                key={s.id}
+                className="flex items-center justify-between gap-2 py-3 first:pt-0"
+              >
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="font-medium truncate">
+                    {formatSeriesRule(s.rule)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {s.rule.duration_minutes}-minute sessions
+                  </span>
+                </div>
+                {canManage && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Series actions"
+                        className="rounded-full h-8 w-8 shrink-0 text-muted-foreground/60 hover:text-foreground"
+                      >
+                        <MoreVertical className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() =>
+                          setDeleteState({ kind: "pending", series: s })
+                        }
+                        className="text-destructive focus:text-destructive focus:bg-destructive/10"
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete series
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
               </li>
             ))}
           </ul>
         )}
       </CardContent>
+
+      <DeleteSeriesDialog
+        series={
+          deleteState.kind === "closed" ? undefined : deleteState.series
+        }
+        isDeleting={deleteState.kind === "deleting"}
+        onCancel={() => setDeleteState({ kind: "closed" })}
+        onConfirm={handleConfirmDelete}
+      />
     </Card>
   );
 }

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -227,7 +227,7 @@ export default function CoachingSessionForm({
       recurrence,
       duration_minutes: durationMinutes,
     };
-    const created = await CoachingSessionSeriesApi.create(payload);
+    const created = await CoachingSessionSeriesApi.create(payload, userTimezone);
     const count = created.coaching_sessions.length;
     toast.success(
       `Created ${count} recurring session${count === 1 ? "" : "s"}.`

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -39,6 +39,7 @@ import {
   Recurrence,
   Weekday,
   recurrenceToPayload,
+  untilDateToUtcDateTime,
   validateRecurrence,
   weekdayFromLuxon,
 } from "@/types/recurrence";
@@ -217,6 +218,9 @@ export default function CoachingSessionForm({
       byWeekdays,
       end
     );
+    if (recurrence.until) {
+      recurrence.until = untilDateToUtcDateTime(recurrence.until, userTimezone);
+    }
     const payload: CreateRecurringSessionRequest = {
       coaching_relationship_id: relationshipId,
       start_at: dateTime,

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -8,15 +8,6 @@ import { Calendar } from "@/components/ui/calendar";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
-import { Input } from "@/components/ui/input";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-import { Calendar as CalendarIcon } from "lucide-react";
 import { cn } from "@/components/lib/utils";
 import {
   Select,
@@ -45,21 +36,15 @@ import { toast } from "sonner";
 import { Provider } from "@/types/provider";
 import {
   CreateRecurringSessionRequest,
-  Frequency,
-  MAX_INTERVAL,
-  MAX_OCCURRENCES,
   Recurrence,
-  RecurrenceEnd,
-  WEEKDAYS_ORDERED,
   Weekday,
-  frequencyLabel,
-  frequencySupportsWeekdays,
   recurrenceToPayload,
   validateRecurrence,
   weekdayFromLuxon,
-  weekdayLabel,
 } from "@/types/recurrence";
 import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
+import { RecurrenceFields } from "@/components/ui/dashboard/recurrence-fields";
+import { useRecurrenceState } from "@/lib/hooks/use-recurrence-state";
 import {
   isDurationValidationError,
   validateDurationMinutes,
@@ -163,56 +148,35 @@ export default function CoachingSessionForm({
 
   // ── Recurrence state (create mode only) ─────────────────────────────
   const [isRecurring, setIsRecurring] = useState(false);
-  const [frequency, setFrequency] = useState<Frequency>(Frequency.Weekly);
-  const [interval, setInterval] = useState<number>(1);
-  const [byWeekdays, setByWeekdays] = useState<Weekday[]>([]);
-  const [end, setEnd] = useState<RecurrenceEnd>({ kind: "count", count: 4 });
 
-  const showTwoCol = mode === "create";
-
-  // Computes a default end date for the "On" option so the user never sees
-  // an empty-state "Pick an end date" error before they've had a chance to
-  // act. Anchored to sessionDate when set, otherwise today; both fall back
-  // to + 4 weeks (matches the count default of 4 occurrences for weekly).
-  const defaultUntilDate = (): string => {
-    const userTimezone = userSession?.timezone || getBrowserTimezone();
-    const anchor = sessionDate
-      ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
-      : DateTime.now().setZone(userTimezone);
-    return anchor.plus({ weeks: 4 }).toFormat("yyyy-MM-dd");
-  };
+  const userTimezone = userSession?.timezone || getBrowserTimezone();
 
   // The weekday of the start date (in the user's timezone). When recurring
   // is on with weekly/biweekly + by_weekdays, the backend requires this
-  // weekday to be included — otherwise 422. We auto-seed the selection so
-  // the obvious case Just Works.
+  // weekday to be included — otherwise 422. The hook auto-seeds it.
   const startWeekday = useMemo<Weekday | null>(() => {
     if (!sessionDate) return null;
-    const userTimezone = userSession?.timezone || getBrowserTimezone();
     const local = DateTime.fromJSDate(sessionDate).setZone(userTimezone);
     return weekdayFromLuxon(local.weekday);
-  }, [sessionDate, userSession?.timezone]);
+  }, [sessionDate, userTimezone]);
 
-  // Auto-seed by_weekdays so the user never sees an empty selection. Prefer
-  // the start_at weekday; fall back to today's weekday in the user's
-  // timezone when no session date is set yet. We never overwrite an
-  // explicit user choice — only fill an empty selection.
-  useEffect(() => {
-    if (!isRecurring) return;
-    if (!frequencySupportsWeekdays(frequency)) return;
-    if (byWeekdays.length !== 0) return;
-    const userTimezone = userSession?.timezone || getBrowserTimezone();
-    const seed =
-      startWeekday ??
-      weekdayFromLuxon(DateTime.now().setZone(userTimezone).weekday);
-    setByWeekdays([seed]);
-  }, [
-    isRecurring,
+  const {
     frequency,
+    setFrequency,
+    interval,
+    setInterval,
+    byWeekdays,
+    setByWeekdays,
+    end,
+    setEnd,
+    reset: resetRecurrence,
+  } = useRecurrenceState({
+    enabled: isRecurring,
     startWeekday,
-    byWeekdays.length,
-    userSession?.timezone,
-  ]);
+    timezone: userTimezone,
+  });
+
+  const showTwoCol = mode === "create";
 
   const resetForm = () => {
     setSessionDate(undefined);
@@ -223,10 +187,7 @@ export default function CoachingSessionForm({
     hasUserEditedDurationRef.current = false;
     setSelectedRelationshipId(currentCoachingRelationshipId ?? "");
     setIsRecurring(false);
-    setFrequency(Frequency.Weekly);
-    setInterval(1);
-    setByWeekdays([]);
-    setEnd({ kind: "count", count: 4 });
+    resetRecurrence();
     setIsSubmitting(false);
     onOpenChange(false);
   };
@@ -477,175 +438,25 @@ export default function CoachingSessionForm({
           </div>
 
           {isRecurring && (
-            <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-2">
-                  <Label htmlFor="recurrence-frequency">Frequency</Label>
-                  <Select
-                    value={frequency}
-                    onValueChange={(v) => setFrequency(v as Frequency)}
-                    disabled={isSubmitting}
-                  >
-                    <SelectTrigger id="recurrence-frequency">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {Object.values(Frequency).map((f) => (
-                        <SelectItem key={f} value={f}>
-                          {frequencyLabel(f)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="recurrence-interval">Every</Label>
-                  <Input
-                    id="recurrence-interval"
-                    type="number"
-                    min={1}
-                    max={MAX_INTERVAL}
-                    value={interval}
-                    onChange={(e) => {
-                      const next = parseInt(e.target.value, 10);
-                      setInterval(Number.isFinite(next) && next >= 1 ? next : 1);
-                    }}
-                    disabled={isSubmitting}
-                  />
-                </div>
-              </div>
-
-              {frequencySupportsWeekdays(frequency) && (
-                <div className="space-y-2">
-                  <Label>On these days</Label>
-                  <ToggleGroup
-                    type="multiple"
-                    value={byWeekdays}
-                    onValueChange={(v) => setByWeekdays(v as Weekday[])}
-                    disabled={isSubmitting}
-                    className="justify-start flex-wrap"
-                  >
-                    {WEEKDAYS_ORDERED.map((d) => (
-                      <ToggleGroupItem
-                        key={d}
-                        value={d}
-                        aria-label={weekdayLabel(d)}
-                        className="w-10"
-                      >
-                        {weekdayLabel(d).slice(0, 1)}
-                      </ToggleGroupItem>
-                    ))}
-                  </ToggleGroup>
-                  {startWeekday && (
-                    <p className="text-xs text-muted-foreground">
-                      Your first session is on a {weekdayLabel(startWeekday)}, which must stay selected.
-                    </p>
-                  )}
-                </div>
-              )}
-
-              <div className="space-y-2">
-                <Label>Ends</Label>
-                <RadioGroup
-                  value={end.kind}
-                  onValueChange={(v) =>
-                    setEnd(
-                      v === "count"
-                        ? { kind: "count", count: end.kind === "count" ? end.count : 4 }
-                        : {
-                            kind: "until",
-                            until:
-                              end.kind === "until" && end.until
-                                ? end.until
-                                : defaultUntilDate(),
-                          }
-                    )
-                  }
-                  disabled={isSubmitting}
-                >
-                  <div className="flex items-center gap-3">
-                    <RadioGroupItem id="end-count" value="count" />
-                    <Label htmlFor="end-count" className="cursor-pointer">
-                      After
-                    </Label>
-                    <Input
-                      type="number"
-                      min={1}
-                      max={MAX_OCCURRENCES}
-                      value={end.kind === "count" ? end.count : ""}
-                      onChange={(e) => {
-                        const next = parseInt(e.target.value, 10);
-                        setEnd({
-                          kind: "count",
-                          count: Number.isFinite(next) && next >= 1 ? next : 1,
-                        });
-                      }}
-                      disabled={isSubmitting || end.kind !== "count"}
-                      className="w-20"
-                    />
-                    <span className="text-sm text-muted-foreground">
-                      occurrences
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <RadioGroupItem id="end-until" value="until" />
-                    <Label htmlFor="end-until" className="cursor-pointer">
-                      On
-                    </Label>
-                    <Popover>
-                      <PopoverTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={isSubmitting || end.kind !== "until"}
-                          className={cn(
-                            "h-9 gap-2 font-normal",
-                            end.kind === "until" && end.until
-                              ? ""
-                              : "text-muted-foreground"
-                          )}
-                        >
-                          <CalendarIcon className="h-4 w-4" />
-                          {end.kind === "until" && end.until
-                            ? DateTime.fromISO(end.until).toLocaleString(
-                                DateTime.DATE_MED
-                              )
-                            : "Pick a date"}
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent
-                        className="w-auto p-0"
-                        align="start"
-                      >
-                        <Calendar
-                          mode="single"
-                          selected={
-                            end.kind === "until" && end.until
-                              ? new Date(`${end.until}T00:00:00`)
-                              : undefined
-                          }
-                          onSelect={(date) =>
-                            setEnd({
-                              kind: "until",
-                              until: date
-                                ? DateTime.fromJSDate(date).toFormat(
-                                    "yyyy-MM-dd"
-                                  )
-                                : "",
-                            })
-                          }
-                        />
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                </RadioGroup>
-              </div>
-
-              {recurrenceError && (
-                <p className="text-sm text-destructive">{recurrenceError}</p>
-              )}
-            </div>
+            <RecurrenceFields
+              frequency={frequency}
+              onFrequencyChange={setFrequency}
+              interval={interval}
+              onIntervalChange={setInterval}
+              byWeekdays={byWeekdays}
+              onByWeekdaysChange={setByWeekdays}
+              end={end}
+              onEndChange={setEnd}
+              startWeekday={startWeekday}
+              startDate={
+                sessionDate
+                  ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
+                  : null
+              }
+              timezone={userTimezone}
+              disabled={isSubmitting}
+              error={recurrenceError}
+            />
           )}
         </div>
       )}

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -27,10 +27,10 @@ import {
 } from "@/components/ui/select";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
 import {
-  CoachingSessionApi,
   useCoachingSessionList,
   useCoachingSessionMutation,
 } from "@/lib/api/coaching-sessions";
+import { CoachingSessionSeriesApi } from "@/lib/api/coaching-session-series";
 import { useOAuthConnections } from "@/lib/api/oauth-connection";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
@@ -262,9 +262,10 @@ export default function CoachingSessionForm({
       recurrence,
       duration_minutes: durationMinutes,
     };
-    const created = await CoachingSessionApi.createRecurring(payload);
+    const created = await CoachingSessionSeriesApi.create(payload);
+    const count = created.coaching_sessions.length;
     toast.success(
-      `Created ${created.length} recurring session${created.length === 1 ? "" : "s"}.`
+      `Created ${count} recurring session${count === 1 ? "" : "s"}.`
     );
   };
 

--- a/src/components/ui/dashboard/dashboard-container.tsx
+++ b/src/components/ui/dashboard/dashboard-container.tsx
@@ -12,6 +12,7 @@ import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 import { useAutoSelectSingleRelationship } from "@/lib/hooks/use-auto-select-single-relationship";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useCoachingSessionsCardFilterStore } from "@/lib/providers/coaching-sessions-card-filter-store-provider";
 import { isUserCoachInRelationship } from "@/types/coaching-relationship";
 import type { CoachingSession, EnrichedCoachingSession } from "@/types/coaching-session";
 
@@ -27,13 +28,22 @@ export function DashboardContainer() {
   const {
     currentCoachingRelationshipId,
     setCurrentCoachingRelationshipId,
-    currentCoachingRelationship,
   } = useCurrentCoachingRelationship();
   const userId = useAuthStore((s) => s.userSession?.id);
+
+  // Scope the series card to the relationship the user actually picks in the
+  // sessions-card filter (its own store). `currentCoachingRelationshipId` is
+  // not driven by that selector, so the card would otherwise never see one.
+  const seriesRelationshipId = useCoachingSessionsCardFilterStore(
+    (s) => s.relationshipFilter
+  );
+  const seriesRelationship = relationships?.find(
+    (r) => r.id === seriesRelationshipId
+  );
   const canManageSeries =
     !!userId &&
-    !!currentCoachingRelationship &&
-    isUserCoachInRelationship(userId, currentCoachingRelationship);
+    !!seriesRelationship &&
+    isUserCoachInRelationship(userId, seriesRelationship);
   useAutoSelectSingleRelationship(
     relationships,
     isLoadingRelationships,
@@ -106,7 +116,7 @@ export function DashboardContainer() {
 
       <div className="w-full mt-8">
         <CoachingSeriesCard
-          relationshipId={currentCoachingRelationshipId || null}
+          relationshipId={seriesRelationshipId ?? null}
           canManage={canManageSeries}
           onSeriesMutated={handleSeriesMutated}
         />

--- a/src/components/ui/dashboard/dashboard-container.tsx
+++ b/src/components/ui/dashboard/dashboard-container.tsx
@@ -57,6 +57,7 @@ export function DashboardContainer() {
   >();
   const [refreshUpcomingSession, setRefreshUpcomingSession] = useState<(() => void) | null>(() => null);
   const [refreshSessionsCard, setRefreshSessionsCard] = useState<(() => void) | null>(() => null);
+  const [refreshSeriesCard, setRefreshSeriesCard] = useState<(() => void) | null>(() => null);
 
   const handleOpenDialog = (session?: CoachingSession | EnrichedCoachingSession) => {
     setSessionToEdit(session);
@@ -74,6 +75,7 @@ export function DashboardContainer() {
     // card until a hard reload.
     refreshUpcomingSession?.();
     refreshSessionsCard?.();
+    refreshSeriesCard?.();
   };
 
   // Stable references so the cards' onRefreshNeeded useEffects don't
@@ -84,6 +86,10 @@ export function DashboardContainer() {
   );
   const handleSessionsCardRefreshNeeded = useCallback(
     (refreshFn: () => void) => setRefreshSessionsCard(() => refreshFn),
+    [],
+  );
+  const handleSeriesCardRefreshNeeded = useCallback(
+    (refreshFn: () => void) => setRefreshSeriesCard(() => refreshFn),
     [],
   );
 
@@ -119,6 +125,7 @@ export function DashboardContainer() {
           relationshipId={seriesRelationshipId ?? null}
           canManage={canManageSeries}
           onSeriesMutated={handleSeriesMutated}
+          onRefreshNeeded={handleSeriesCardRefreshNeeded}
         />
       </div>
       <CoachingSessionDialog

--- a/src/components/ui/dashboard/dashboard-container.tsx
+++ b/src/components/ui/dashboard/dashboard-container.tsx
@@ -11,6 +11,8 @@ import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
 import { useAutoSelectSingleRelationship } from "@/lib/hooks/use-auto-select-single-relationship";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { isUserCoachInRelationship } from "@/types/coaching-relationship";
 import type { CoachingSession, EnrichedCoachingSession } from "@/types/coaching-session";
 
 export function DashboardContainer() {
@@ -25,7 +27,13 @@ export function DashboardContainer() {
   const {
     currentCoachingRelationshipId,
     setCurrentCoachingRelationshipId,
+    currentCoachingRelationship,
   } = useCurrentCoachingRelationship();
+  const userId = useAuthStore((s) => s.userSession?.id);
+  const canManageSeries =
+    !!userId &&
+    !!currentCoachingRelationship &&
+    isUserCoachInRelationship(userId, currentCoachingRelationship);
   useAutoSelectSingleRelationship(
     relationships,
     isLoadingRelationships,
@@ -69,6 +77,11 @@ export function DashboardContainer() {
     [],
   );
 
+  const handleSeriesMutated = useCallback(() => {
+    refreshUpcomingSession?.();
+    refreshSessionsCard?.();
+  }, [refreshUpcomingSession, refreshSessionsCard]);
+
   return (
     <>
       <DashboardHeader onCreateSession={() => handleOpenDialog()} />
@@ -92,7 +105,11 @@ export function DashboardContainer() {
       </div>
 
       <div className="w-full mt-8">
-        <CoachingSeriesCard relationshipId={currentCoachingRelationshipId || null} />
+        <CoachingSeriesCard
+          relationshipId={currentCoachingRelationshipId || null}
+          canManage={canManageSeries}
+          onSeriesMutated={handleSeriesMutated}
+        />
       </div>
       <CoachingSessionDialog
         open={dialogOpen}

--- a/src/components/ui/dashboard/dashboard-container.tsx
+++ b/src/components/ui/dashboard/dashboard-container.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { CoachingSessionDialog } from "@/components/ui/dashboard/coaching-session-dialog";
+import { CoachingSeriesCard } from "@/components/ui/dashboard/coaching-series-card";
 import { CoachingSessionsCard } from "@/components/ui/dashboard/coaching-sessions-card";
 import { DashboardHeader } from "@/components/ui/dashboard/dashboard-header";
 import { GoalsOverviewCard } from "@/components/ui/dashboard/goals-overview-card";
@@ -88,6 +89,10 @@ export function DashboardContainer() {
           onReschedule={handleOpenDialog}
           onRefreshNeeded={handleSessionsCardRefreshNeeded}
         />
+      </div>
+
+      <div className="w-full mt-8">
+        <CoachingSeriesCard relationshipId={currentCoachingRelationshipId || null} />
       </div>
       <CoachingSessionDialog
         open={dialogOpen}

--- a/src/components/ui/dashboard/delete-series-dialog.tsx
+++ b/src/components/ui/dashboard/delete-series-dialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/components/lib/utils";
+import {
+  CoachingSessionSeries,
+  formatSeriesRule,
+} from "@/types/coaching-session-series";
+
+export interface DeleteSeriesDialogProps {
+  series: CoachingSessionSeries | undefined;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteSeriesDialog({
+  series,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: DeleteSeriesDialogProps) {
+  const open = series !== undefined;
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !isDeleting) onCancel();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this recurring series?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the{" "}
+            <span className="font-medium text-foreground">
+              {series ? formatSeriesRule(series.rule) : ""}
+            </span>{" "}
+            series and all of its future sessions. Past sessions are kept. This
+            can&apos;t be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            disabled={isDeleting}
+            className={cn(buttonVariants({ variant: "destructive" }))}
+          >
+            {isDeleting ? "Deleting…" : "Delete series"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/ui/dashboard/recurrence-fields.tsx
+++ b/src/components/ui/dashboard/recurrence-fields.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { DateTime } from "ts-luxon";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/components/lib/utils";
+import {
+  Frequency,
+  MAX_INTERVAL,
+  MAX_OCCURRENCES,
+  RecurrenceEnd,
+  WEEKDAYS_ORDERED,
+  Weekday,
+  frequencyLabel,
+  frequencySupportsWeekdays,
+  weekdayLabel,
+} from "@/types/recurrence";
+
+export interface RecurrenceFieldsProps {
+  frequency: Frequency;
+  onFrequencyChange: (frequency: Frequency) => void;
+  interval: number;
+  onIntervalChange: (interval: number) => void;
+  byWeekdays: Weekday[];
+  onByWeekdaysChange: (weekdays: Weekday[]) => void;
+  end: RecurrenceEnd;
+  onEndChange: (end: RecurrenceEnd) => void;
+  startWeekday: Weekday | null;
+  startDate: DateTime | null;
+  timezone: string;
+  disabled?: boolean;
+  error?: string | null;
+}
+
+export function RecurrenceFields({
+  frequency,
+  onFrequencyChange,
+  interval,
+  onIntervalChange,
+  byWeekdays,
+  onByWeekdaysChange,
+  end,
+  onEndChange,
+  startWeekday,
+  startDate,
+  timezone,
+  disabled = false,
+  error = null,
+}: RecurrenceFieldsProps) {
+  const defaultUntilDate = (): string => {
+    const anchor = startDate ?? DateTime.now().setZone(timezone);
+    return anchor.plus({ weeks: 4 }).toFormat("yyyy-MM-dd");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-2">
+          <Label htmlFor="recurrence-frequency">Frequency</Label>
+          <Select
+            value={frequency}
+            onValueChange={(v) => onFrequencyChange(v as Frequency)}
+            disabled={disabled}
+          >
+            <SelectTrigger id="recurrence-frequency">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {Object.values(Frequency).map((f) => (
+                <SelectItem key={f} value={f}>
+                  {frequencyLabel(f)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="recurrence-interval">Every</Label>
+          <Input
+            id="recurrence-interval"
+            type="number"
+            min={1}
+            max={MAX_INTERVAL}
+            value={interval}
+            onChange={(e) => {
+              const next = parseInt(e.target.value, 10);
+              onIntervalChange(Number.isFinite(next) && next >= 1 ? next : 1);
+            }}
+            disabled={disabled}
+          />
+        </div>
+      </div>
+
+      {frequencySupportsWeekdays(frequency) && (
+        <div className="space-y-2">
+          <Label>On these days</Label>
+          <ToggleGroup
+            type="multiple"
+            value={byWeekdays}
+            onValueChange={(v) => onByWeekdaysChange(v as Weekday[])}
+            disabled={disabled}
+            className="justify-start flex-wrap"
+          >
+            {WEEKDAYS_ORDERED.map((d) => (
+              <ToggleGroupItem
+                key={d}
+                value={d}
+                aria-label={weekdayLabel(d)}
+                className="w-10"
+              >
+                {weekdayLabel(d).slice(0, 1)}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          {startWeekday && (
+            <p className="text-xs text-muted-foreground">
+              Your first session is on a {weekdayLabel(startWeekday)}, which
+              must stay selected.
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label>Ends</Label>
+        <RadioGroup
+          value={end.kind}
+          onValueChange={(v) =>
+            onEndChange(
+              v === "count"
+                ? { kind: "count", count: end.kind === "count" ? end.count : 4 }
+                : {
+                    kind: "until",
+                    until:
+                      end.kind === "until" && end.until
+                        ? end.until
+                        : defaultUntilDate(),
+                  }
+            )
+          }
+          disabled={disabled}
+        >
+          <div className="flex items-center gap-3">
+            <RadioGroupItem id="end-count" value="count" />
+            <Label htmlFor="end-count" className="cursor-pointer">
+              After
+            </Label>
+            <Input
+              type="number"
+              min={1}
+              max={MAX_OCCURRENCES}
+              value={end.kind === "count" ? end.count : ""}
+              onChange={(e) => {
+                const next = parseInt(e.target.value, 10);
+                onEndChange({
+                  kind: "count",
+                  count: Number.isFinite(next) && next >= 1 ? next : 1,
+                });
+              }}
+              disabled={disabled || end.kind !== "count"}
+              className="w-20"
+            />
+            <span className="text-sm text-muted-foreground">occurrences</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <RadioGroupItem id="end-until" value="until" />
+            <Label htmlFor="end-until" className="cursor-pointer">
+              On
+            </Label>
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={disabled || end.kind !== "until"}
+                  className={cn(
+                    "h-9 gap-2 font-normal",
+                    end.kind === "until" && end.until
+                      ? ""
+                      : "text-muted-foreground"
+                  )}
+                >
+                  <CalendarIcon className="h-4 w-4" />
+                  {end.kind === "until" && end.until
+                    ? DateTime.fromISO(end.until).toLocaleString(
+                        DateTime.DATE_MED
+                      )
+                    : "Pick a date"}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="start">
+                <Calendar
+                  mode="single"
+                  selected={
+                    end.kind === "until" && end.until
+                      ? new Date(`${end.until}T00:00:00`)
+                      : undefined
+                  }
+                  onSelect={(date) =>
+                    onEndChange({
+                      kind: "until",
+                      until: date
+                        ? DateTime.fromJSDate(date).toFormat("yyyy-MM-dd")
+                        : "",
+                    })
+                  }
+                />
+              </PopoverContent>
+            </Popover>
+          </div>
+        </RadioGroup>
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -30,6 +30,7 @@ import {
   Recurrence,
   Weekday,
   recurrenceToPayload,
+  untilDateToUtcDateTime,
   validateRecurrence,
   weekdayFromLuxon,
 } from "@/types/recurrence";
@@ -180,6 +181,9 @@ function RescheduleSeriesForm({
       byWeekdays,
       end
     );
+    if (recurrence.until) {
+      recurrence.until = untilDateToUtcDateTime(recurrence.until, userTimezone);
+    }
     const payload: CreateRecurringSessionRequest = {
       coaching_relationship_id: series.coaching_relationship_id,
       start_at: utcDateTime,

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -23,7 +23,6 @@ import { getBrowserTimezone } from "@/lib/timezone-utils";
 import { EntityApiError } from "@/types/entity-api-error";
 import {
   CoachingSessionSeries,
-  formatSeriesRule,
   seriesRecurrenceToEnd,
 } from "@/types/coaching-session-series";
 import {
@@ -61,8 +60,6 @@ export function RescheduleSeriesDialog({
           </DialogDescription>
         </DialogHeader>
         {series && (
-          // Key by id so the form re-seeds from scratch when a different
-          // series is opened.
           <RescheduleSeriesForm
             key={series.id}
             series={series}
@@ -264,7 +261,7 @@ function RescheduleSeriesForm({
 
       <Button type="submit" disabled={!canSubmit} className="justify-self-start">
         {isSubmitting && <Spinner className="mr-2" />}
-        Reschedule {formatSeriesRule(series.rule)}
+        Reschedule sessions
       </Button>
     </form>
   );

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -85,8 +85,8 @@ function RescheduleSeriesForm({
   onRescheduled,
 }: RescheduleSeriesFormProps) {
   const { userSession } = useAuthStore((state) => state);
-  const { update } = useCoachingSessionSeriesMutation();
   const userTimezone = userSession?.timezone || getBrowserTimezone();
+  const { update } = useCoachingSessionSeriesMutation(userTimezone);
 
   // The stored start is a naive UTC ISO string; interpret as UTC, then show
   // it in the user's timezone for editing (mirrors the create/edit form).

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useMemo, useState, type FormEvent } from "react";
+import { DateTime } from "ts-luxon";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Spinner } from "@/components/ui/spinner";
+import { CoachingSessionDurationInput } from "@/components/ui/coaching-sessions/coaching-session-duration-input";
+import { RecurrenceFields } from "@/components/ui/dashboard/recurrence-fields";
+import { useRecurrenceState } from "@/lib/hooks/use-recurrence-state";
+import { useCoachingSessionSeriesMutation } from "@/lib/api/coaching-session-series";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { getBrowserTimezone } from "@/lib/timezone-utils";
+import { EntityApiError } from "@/types/entity-api-error";
+import {
+  CoachingSessionSeries,
+  formatSeriesRule,
+  seriesRecurrenceToEnd,
+} from "@/types/coaching-session-series";
+import {
+  CreateRecurringSessionRequest,
+  Recurrence,
+  Weekday,
+  recurrenceToPayload,
+  validateRecurrence,
+  weekdayFromLuxon,
+} from "@/types/recurrence";
+import { validateDurationMinutes } from "@/types/coaching-session-duration";
+
+export interface RescheduleSeriesDialogProps {
+  series: CoachingSessionSeries | null;
+  onClose: () => void;
+  onRescheduled?: () => void;
+}
+
+export function RescheduleSeriesDialog({
+  series,
+  onClose,
+  onRescheduled,
+}: RescheduleSeriesDialogProps) {
+  return (
+    <Dialog
+      open={series !== null}
+      onOpenChange={(next) => !next && onClose()}
+    >
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Reschedule recurring series</DialogTitle>
+          <DialogDescription>
+            Replaces the rule and re-materializes future sessions. Past sessions
+            are kept.
+          </DialogDescription>
+        </DialogHeader>
+        {series && (
+          // Key by id so the form re-seeds from scratch when a different
+          // series is opened.
+          <RescheduleSeriesForm
+            key={series.id}
+            series={series}
+            onClose={onClose}
+            onRescheduled={onRescheduled}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface RescheduleSeriesFormProps {
+  series: CoachingSessionSeries;
+  onClose: () => void;
+  onRescheduled?: () => void;
+}
+
+function RescheduleSeriesForm({
+  series,
+  onClose,
+  onRescheduled,
+}: RescheduleSeriesFormProps) {
+  const { userSession } = useAuthStore((state) => state);
+  const { update } = useCoachingSessionSeriesMutation();
+  const userTimezone = userSession?.timezone || getBrowserTimezone();
+
+  // The stored start is a naive UTC ISO string; interpret as UTC, then show
+  // it in the user's timezone for editing (mirrors the create/edit form).
+  const startLocal = DateTime.fromISO(series.rule.start_at, {
+    zone: "utc",
+  }).setZone(userTimezone);
+
+  const [sessionDate, setSessionDate] = useState<Date | undefined>(
+    startLocal.toJSDate()
+  );
+  const [sessionTime, setSessionTime] = useState<string>(
+    startLocal.toFormat("HH:mm")
+  );
+  const [durationMinutes, setDurationMinutes] = useState<number>(
+    series.rule.duration_minutes
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const startWeekday = useMemo<Weekday | null>(() => {
+    if (!sessionDate) return null;
+    const local = DateTime.fromJSDate(sessionDate).setZone(userTimezone);
+    return weekdayFromLuxon(local.weekday);
+  }, [sessionDate, userTimezone]);
+
+  const {
+    frequency,
+    setFrequency,
+    interval,
+    setInterval,
+    byWeekdays,
+    setByWeekdays,
+    end,
+    setEnd,
+  } = useRecurrenceState({
+    enabled: true,
+    startWeekday,
+    timezone: userTimezone,
+    init: {
+      frequency: series.rule.recurrence.frequency,
+      interval: series.rule.recurrence.interval,
+      byWeekdays: series.rule.recurrence.by_weekdays ?? [],
+      end: seriesRecurrenceToEnd(series.rule.recurrence),
+    },
+  });
+
+  const recurrenceError = useMemo<string | null>(() => {
+    const start = sessionDate
+      ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
+      : null;
+    return validateRecurrence({
+      frequency,
+      interval,
+      byWeekdays,
+      end,
+      start,
+      startWeekday,
+      timezone: userTimezone,
+    });
+  }, [
+    interval,
+    end,
+    frequency,
+    byWeekdays,
+    startWeekday,
+    sessionDate,
+    userTimezone,
+  ]);
+
+  const canSubmit =
+    !!sessionDate &&
+    !!sessionTime &&
+    !isSubmitting &&
+    !recurrenceError &&
+    validateDurationMinutes(durationMinutes).isOk();
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isSubmitting || !sessionDate || !sessionTime) return;
+
+    setIsSubmitting(true);
+
+    const [hours, minutes] = sessionTime.split(":").map(Number);
+    const utcDateTime = DateTime.fromJSDate(sessionDate)
+      .setZone(userTimezone)
+      .set({ hour: hours, minute: minutes })
+      .toUTC()
+      .toFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    const recurrence: Recurrence = recurrenceToPayload(
+      frequency,
+      interval,
+      byWeekdays,
+      end
+    );
+    const payload: CreateRecurringSessionRequest = {
+      coaching_relationship_id: series.coaching_relationship_id,
+      start_at: utcDateTime,
+      recurrence,
+      duration_minutes: durationMinutes,
+    };
+
+    try {
+      await update(series.id, payload);
+      toast.success("Series rescheduled. Future sessions were updated.");
+      onRescheduled?.();
+      onClose();
+    } catch (error) {
+      const message =
+        error instanceof EntityApiError && error.status === 422
+          ? "Couldn't reschedule the series. Please review the form and try again."
+          : "Failed to reschedule the series. Please try again.";
+      toast.error(message);
+      console.error("Failed to reschedule coaching session series:", error);
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-6">
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="reschedule-date">First session date</Label>
+          <Calendar
+            mode="single"
+            selected={sessionDate}
+            onSelect={(date) => setSessionDate(date)}
+          />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          <div className="space-y-2">
+            <Label htmlFor="reschedule-time">First session time</Label>
+            <input
+              type="time"
+              id="reschedule-time"
+              value={sessionTime}
+              onChange={(e) => setSessionTime(e.target.value)}
+              className="w-full border rounded p-2"
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="reschedule-duration">Duration</Label>
+            <CoachingSessionDurationInput
+              id="reschedule-duration"
+              value={durationMinutes}
+              onChange={setDurationMinutes}
+              disabled={isSubmitting}
+            />
+          </div>
+        </div>
+      </div>
+
+      <RecurrenceFields
+        frequency={frequency}
+        onFrequencyChange={setFrequency}
+        interval={interval}
+        onIntervalChange={setInterval}
+        byWeekdays={byWeekdays}
+        onByWeekdaysChange={setByWeekdays}
+        end={end}
+        onEndChange={setEnd}
+        startWeekday={startWeekday}
+        startDate={
+          sessionDate
+            ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
+            : null
+        }
+        timezone={userTimezone}
+        disabled={isSubmitting}
+        error={recurrenceError}
+      />
+
+      <Button type="submit" disabled={!canSubmit} className="justify-self-start">
+        {isSubmitting && <Spinner className="mr-2" />}
+        Reschedule {formatSeriesRule(series.rule)}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -52,7 +52,7 @@ export function RescheduleSeriesDialog({
       open={series !== null}
       onOpenChange={(next) => !next && onClose()}
     >
-      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-lg">
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-3xl">
         <DialogHeader>
           <DialogTitle>Reschedule recurring series</DialogTitle>
           <DialogDescription>
@@ -208,16 +208,20 @@ function RescheduleSeriesForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="grid gap-6">
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-6 sm:grid-cols-2 sm:items-start"
+    >
+      <div className="space-y-2">
+        <Label htmlFor="reschedule-date">First session date</Label>
+        <Calendar
+          mode="single"
+          selected={sessionDate}
+          onSelect={(date) => setSessionDate(date)}
+        />
+      </div>
+
       <div className="space-y-4">
-        <div className="space-y-2">
-          <Label htmlFor="reschedule-date">First session date</Label>
-          <Calendar
-            mode="single"
-            selected={sessionDate}
-            onSelect={(date) => setSessionDate(date)}
-          />
-        </div>
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-2">
             <Label htmlFor="reschedule-time">First session time</Label>
@@ -241,29 +245,33 @@ function RescheduleSeriesForm({
             />
           </div>
         </div>
+
+        <RecurrenceFields
+          frequency={frequency}
+          onFrequencyChange={setFrequency}
+          interval={interval}
+          onIntervalChange={setInterval}
+          byWeekdays={byWeekdays}
+          onByWeekdaysChange={setByWeekdays}
+          end={end}
+          onEndChange={setEnd}
+          startWeekday={startWeekday}
+          startDate={
+            sessionDate
+              ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
+              : null
+          }
+          timezone={userTimezone}
+          disabled={isSubmitting}
+          error={recurrenceError}
+        />
       </div>
 
-      <RecurrenceFields
-        frequency={frequency}
-        onFrequencyChange={setFrequency}
-        interval={interval}
-        onIntervalChange={setInterval}
-        byWeekdays={byWeekdays}
-        onByWeekdaysChange={setByWeekdays}
-        end={end}
-        onEndChange={setEnd}
-        startWeekday={startWeekday}
-        startDate={
-          sessionDate
-            ? DateTime.fromJSDate(sessionDate).setZone(userTimezone)
-            : null
-        }
-        timezone={userTimezone}
-        disabled={isSubmitting}
-        error={recurrenceError}
-      />
-
-      <Button type="submit" disabled={!canSubmit} className="justify-self-start">
+      <Button
+        type="submit"
+        disabled={!canSubmit}
+        className="justify-self-start sm:col-span-2"
+      >
         {isSubmitting && <Spinner className="mr-2" />}
         Reschedule sessions
       </Button>

--- a/src/components/ui/dashboard/series-detail-dialog.tsx
+++ b/src/components/ui/dashboard/series-detail-dialog.tsx
@@ -28,15 +28,8 @@ export function SeriesDetailDialog({
   userTimezone,
   onClose,
 }: SeriesDetailDialogProps) {
-  const { series: detail, isLoading, isError } = useCoachingSessionSeries(
-    series?.id ?? "",
-    userTimezone
-  );
-  const open = series !== null;
-  const sessions = detail.coaching_sessions;
-
   return (
-    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+    <Dialog open={series !== null} onOpenChange={(next) => !next && onClose()}>
       <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>Recurring session series</DialogTitle>
@@ -44,43 +37,83 @@ export function SeriesDetailDialog({
             {series ? formatSeriesRule(series.rule) : ""}
           </DialogDescription>
         </DialogHeader>
-
-        {isLoading ? (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Spinner /> Loading sessions…
-          </div>
-        ) : isError ? (
-          <p className="text-sm text-destructive">
-            Couldn&apos;t load the series&apos; sessions. Please try again.
-          </p>
-        ) : sessions.length === 0 ? (
-          <p className="text-sm text-muted-foreground">
-            This series has no sessions.
-          </p>
-        ) : (
-          <ul className="divide-y divide-border">
-            {sessions.map((session) => {
-              const dt = DateTime.fromISO(session.date, { zone: "utc" }).setZone(
-                userTimezone
-              );
-              const past = isPastSession(session);
-              return (
-                <li
-                  key={session.id}
-                  className="flex items-center justify-between gap-2 py-2.5"
-                >
-                  <span className="text-sm tabular-nums">
-                    {formatDateWithTime(dt, "·")}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {past ? "Past" : "Upcoming"}
-                  </span>
-                </li>
-              );
-            })}
-          </ul>
+        {series && (
+          <SeriesDetailSessions
+            key={series.id}
+            seriesId={series.id}
+            userTimezone={userTimezone}
+          />
         )}
       </DialogContent>
     </Dialog>
+  );
+}
+
+interface SeriesDetailSessionsProps {
+  seriesId: string;
+  userTimezone: string;
+}
+
+/**
+ * Loads and renders the materialized sessions for a series. Rendered only when
+ * the dialog is open (guarded by the parent), so the fetch hook always receives
+ * a real id rather than an empty-string sentinel.
+ */
+function SeriesDetailSessions({
+  seriesId,
+  userTimezone,
+}: SeriesDetailSessionsProps) {
+  const { series: detail, isLoading, isError } = useCoachingSessionSeries(
+    seriesId,
+    userTimezone
+  );
+  const sessions = detail.coaching_sessions;
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner /> Loading sessions…
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn&apos;t load the series&apos; sessions. Please try again.
+      </p>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        This series has no sessions.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="divide-y divide-border">
+      {sessions.map((session) => {
+        const dt = DateTime.fromISO(session.date, { zone: "utc" }).setZone(
+          userTimezone
+        );
+        const past = isPastSession(session);
+        return (
+          <li
+            key={session.id}
+            className="flex items-center justify-between gap-2 py-2.5"
+          >
+            <span className="text-sm tabular-nums">
+              {formatDateWithTime(dt, "·")}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {past ? "Past" : "Upcoming"}
+            </span>
+          </li>
+        );
+      })}
+    </ul>
   );
 }

--- a/src/components/ui/dashboard/series-detail-dialog.tsx
+++ b/src/components/ui/dashboard/series-detail-dialog.tsx
@@ -29,7 +29,8 @@ export function SeriesDetailDialog({
   onClose,
 }: SeriesDetailDialogProps) {
   const { series: detail, isLoading, isError } = useCoachingSessionSeries(
-    series?.id ?? ""
+    series?.id ?? "",
+    userTimezone
   );
   const open = series !== null;
   const sessions = detail.coaching_sessions;

--- a/src/components/ui/dashboard/series-detail-dialog.tsx
+++ b/src/components/ui/dashboard/series-detail-dialog.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { DateTime } from "ts-luxon";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Spinner } from "@/components/ui/spinner";
+import { useCoachingSessionSeries } from "@/lib/api/coaching-session-series";
+import { formatDateWithTime } from "@/lib/utils/date";
+import {
+  CoachingSessionSeries,
+  formatSeriesRule,
+} from "@/types/coaching-session-series";
+import { isPastSession } from "@/types/coaching-session";
+
+export interface SeriesDetailDialogProps {
+  series: CoachingSessionSeries | null;
+  userTimezone: string;
+  onClose: () => void;
+}
+
+export function SeriesDetailDialog({
+  series,
+  userTimezone,
+  onClose,
+}: SeriesDetailDialogProps) {
+  const { series: detail, isLoading, isError } = useCoachingSessionSeries(
+    series?.id ?? ""
+  );
+  const open = series !== null;
+  const sessions = detail.coaching_sessions;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="max-h-[90dvh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Recurring session series</DialogTitle>
+          <DialogDescription>
+            {series ? formatSeriesRule(series.rule) : ""}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Spinner /> Loading sessions…
+          </div>
+        ) : isError ? (
+          <p className="text-sm text-destructive">
+            Couldn&apos;t load the series&apos; sessions. Please try again.
+          </p>
+        ) : sessions.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            This series has no sessions.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {sessions.map((session) => {
+              const dt = DateTime.fromISO(session.date, { zone: "utc" }).setZone(
+                userTimezone
+              );
+              const past = isPastSession(session);
+              return (
+                <li
+                  key={session.id}
+                  className="flex items-center justify-between gap-2 py-2.5"
+                >
+                  <span className="text-sm tabular-nums">
+                    {formatDateWithTime(dt, "·")}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {past ? "Past" : "Upcoming"}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/api/coaching-session-series.ts
+++ b/src/lib/api/coaching-session-series.ts
@@ -30,35 +30,42 @@ export const CoachingSessionSeriesApi = {
    *
    * @param relationshipId Relationship whose series to fetch; null returns [].
    */
-  list: (relationshipId: Id | null): Promise<CoachingSessionSeries[]> => {
+  list: (
+    relationshipId: Id | null,
+    timezone: string
+  ): Promise<CoachingSessionSeries[]> => {
     if (!relationshipId) return Promise.resolve([]);
     return EntityApi.listFn<CoachingSessionSeriesRaw, CoachingSessionSeries>(
       COACHING_SESSION_SERIES_BASEURL,
       { params: { coaching_relationship_id: relationshipId } },
-      parseCoachingSessionSeries
+      (raw) => parseCoachingSessionSeries(raw, timezone)
     );
   },
 
   /**
    * Reads one series together with its materialized sessions, date-sorted.
    */
-  get: (id: Id): Promise<CoachingSessionSeriesWithSessions> =>
+  get: (
+    id: Id,
+    timezone: string
+  ): Promise<CoachingSessionSeriesWithSessions> =>
     EntityApi.getFn<CoachingSessionSeriesWithSessionsRaw>(
       `${COACHING_SESSION_SERIES_BASEURL}/${id}`
-    ).then(parseCoachingSessionSeriesWithSessions),
+    ).then((raw) => parseCoachingSessionSeriesWithSessions(raw, timezone)),
 
   /**
    * Creates a series and materializes its sessions in one transaction.
    * Returns the series with every created session; the first equals `start_at`.
    */
   create: (
-    payload: CreateRecurringSessionRequest
+    payload: CreateRecurringSessionRequest,
+    timezone: string
   ): Promise<CoachingSessionSeriesWithSessions> =>
     EntityApi.createFn<
       CreateRecurringSessionRequest,
       CoachingSessionSeriesWithSessionsRaw
-    >(COACHING_SESSION_SERIES_BASEURL, payload).then(
-      parseCoachingSessionSeriesWithSessions
+    >(COACHING_SESSION_SERIES_BASEURL, payload).then((raw) =>
+      parseCoachingSessionSeriesWithSessions(raw, timezone)
     ),
 
   /**
@@ -67,13 +74,14 @@ export const CoachingSessionSeriesApi = {
    */
   update: (
     id: Id,
-    payload: CreateRecurringSessionRequest
+    payload: CreateRecurringSessionRequest,
+    timezone: string
   ): Promise<CoachingSessionSeriesWithSessions> =>
     EntityApi.updateFn<
       CreateRecurringSessionRequest,
       CoachingSessionSeriesWithSessionsRaw
-    >(`${COACHING_SESSION_SERIES_BASEURL}/${id}`, payload).then(
-      parseCoachingSessionSeriesWithSessions
+    >(`${COACHING_SESSION_SERIES_BASEURL}/${id}`, payload).then((raw) =>
+      parseCoachingSessionSeriesWithSessions(raw, timezone)
     ),
 
   /**
@@ -92,7 +100,10 @@ export const CoachingSessionSeriesApi = {
  *
  * @returns { series, isLoading, isError, refresh }
  */
-export const useCoachingSessionSeriesList = (relationshipId: Id | null) => {
+export const useCoachingSessionSeriesList = (
+  relationshipId: Id | null,
+  timezone: string
+) => {
   const params = relationshipId
     ? { coaching_relationship_id: relationshipId }
     : undefined;
@@ -100,7 +111,7 @@ export const useCoachingSessionSeriesList = (relationshipId: Id | null) => {
   const { entities, isLoading, isError, refresh } =
     EntityApi.useEntityList<CoachingSessionSeries>(
       COACHING_SESSION_SERIES_BASEURL,
-      () => CoachingSessionSeriesApi.list(relationshipId),
+      () => CoachingSessionSeriesApi.list(relationshipId, timezone),
       params
     );
 
@@ -113,13 +124,13 @@ export const useCoachingSessionSeriesList = (relationshipId: Id | null) => {
  *
  * @returns { series, isLoading, isError, refresh }
  */
-export const useCoachingSessionSeries = (id: Id) => {
+export const useCoachingSessionSeries = (id: Id, timezone: string) => {
   const url = id ? `${COACHING_SESSION_SERIES_BASEURL}/${id}` : null;
 
   const { entity, isLoading, isError, refresh } =
     EntityApi.useEntity<CoachingSessionSeriesWithSessions>(
       url,
-      () => CoachingSessionSeriesApi.get(id),
+      () => CoachingSessionSeriesApi.get(id, timezone),
       defaultCoachingSessionSeriesWithSessions()
     );
 
@@ -134,13 +145,14 @@ export const useCoachingSessionSeries = (id: Id) => {
  * reschedule re-materializes and a delete drops future sessions, callers
  * displaying `coaching_sessions` lists must `refresh()` those separately.
  */
-export const useCoachingSessionSeriesMutation = () => {
+export const useCoachingSessionSeriesMutation = (timezone: string) => {
   return EntityApi.useEntityMutation<
     CreateRecurringSessionRequest,
     CoachingSessionSeries
   >(COACHING_SESSION_SERIES_BASEURL, {
-    create: CoachingSessionSeriesApi.create,
-    update: CoachingSessionSeriesApi.update,
+    create: (payload) => CoachingSessionSeriesApi.create(payload, timezone),
+    update: (id, payload) =>
+      CoachingSessionSeriesApi.update(id, payload, timezone),
     delete: CoachingSessionSeriesApi.delete,
   });
 };

--- a/src/lib/api/coaching-session-series.ts
+++ b/src/lib/api/coaching-session-series.ts
@@ -6,8 +6,8 @@ import { CreateRecurringSessionRequest } from "@/types/recurrence";
 import {
   CoachingSessionSeries,
   CoachingSessionSeriesWithSessions,
-  RawCoachingSessionSeries,
-  RawCoachingSessionSeriesWithSessions,
+  CoachingSessionSeriesRaw,
+  CoachingSessionSeriesWithSessionsRaw,
   defaultCoachingSessionSeriesWithSessions,
   parseCoachingSessionSeries,
   parseCoachingSessionSeriesWithSessions,
@@ -31,7 +31,7 @@ export const CoachingSessionSeriesApi = {
    */
   list: (relationshipId: Id | null): Promise<CoachingSessionSeries[]> => {
     if (!relationshipId) return Promise.resolve([]);
-    return EntityApi.listFn<RawCoachingSessionSeries, CoachingSessionSeries>(
+    return EntityApi.listFn<CoachingSessionSeriesRaw, CoachingSessionSeries>(
       COACHING_SESSION_SERIES_BASEURL,
       { params: { coaching_relationship_id: relationshipId } },
       parseCoachingSessionSeries
@@ -42,7 +42,7 @@ export const CoachingSessionSeriesApi = {
    * Reads one series together with its materialized sessions, date-sorted.
    */
   get: (id: Id): Promise<CoachingSessionSeriesWithSessions> =>
-    EntityApi.getFn<RawCoachingSessionSeriesWithSessions>(
+    EntityApi.getFn<CoachingSessionSeriesWithSessionsRaw>(
       `${COACHING_SESSION_SERIES_BASEURL}/${id}`
     ).then(parseCoachingSessionSeriesWithSessions),
 
@@ -55,7 +55,7 @@ export const CoachingSessionSeriesApi = {
   ): Promise<CoachingSessionSeriesWithSessions> =>
     EntityApi.createFn<
       CreateRecurringSessionRequest,
-      RawCoachingSessionSeriesWithSessions
+      CoachingSessionSeriesWithSessionsRaw
     >(COACHING_SESSION_SERIES_BASEURL, payload).then(
       parseCoachingSessionSeriesWithSessions
     ),
@@ -70,7 +70,7 @@ export const CoachingSessionSeriesApi = {
   ): Promise<CoachingSessionSeriesWithSessions> =>
     EntityApi.updateFn<
       CreateRecurringSessionRequest,
-      RawCoachingSessionSeriesWithSessions
+      CoachingSessionSeriesWithSessionsRaw
     >(`${COACHING_SESSION_SERIES_BASEURL}/${id}`, payload).then(
       parseCoachingSessionSeriesWithSessions
     ),
@@ -79,7 +79,7 @@ export const CoachingSessionSeriesApi = {
    * Deletes a series and its future sessions; past sessions survive.
    */
   delete: (id: Id): Promise<CoachingSessionSeries> =>
-    EntityApi.deleteFn<null, RawCoachingSessionSeries>(
+    EntityApi.deleteFn<null, CoachingSessionSeriesRaw>(
       `${COACHING_SESSION_SERIES_BASEURL}/${id}`
     ).then(parseCoachingSessionSeries),
 };

--- a/src/lib/api/coaching-session-series.ts
+++ b/src/lib/api/coaching-session-series.ts
@@ -1,0 +1,143 @@
+// Interacts with the coaching_session_series endpoints.
+
+import { siteConfig } from "@/site.config";
+import { Id } from "@/types/general";
+import { CreateRecurringSessionRequest } from "@/types/recurrence";
+import {
+  CoachingSessionSeries,
+  CoachingSessionSeriesWithSessions,
+  RawCoachingSessionSeries,
+  RawCoachingSessionSeriesWithSessions,
+  defaultCoachingSessionSeriesWithSessions,
+  parseCoachingSessionSeries,
+  parseCoachingSessionSeriesWithSessions,
+} from "@/types/coaching-session-series";
+import { EntityApi } from "./entity-api";
+
+const COACHING_SESSION_SERIES_BASEURL: string = `${siteConfig.env.backendServiceURL}/coaching_session_series`;
+
+/**
+ * API client for coaching session series operations.
+ *
+ * Mirrors the CoachingSessionApi pattern: thin wrappers over the generic
+ * EntityApi helpers, with the wire `rule` normalized to domain types at the
+ * fetch edge via the `parse*` functions.
+ */
+export const CoachingSessionSeriesApi = {
+  /**
+   * Lists series for a coaching relationship (metadata only — no sessions).
+   *
+   * @param relationshipId Relationship whose series to fetch; null returns [].
+   */
+  list: (relationshipId: Id | null): Promise<CoachingSessionSeries[]> => {
+    if (!relationshipId) return Promise.resolve([]);
+    return EntityApi.listFn<RawCoachingSessionSeries, CoachingSessionSeries>(
+      COACHING_SESSION_SERIES_BASEURL,
+      { params: { coaching_relationship_id: relationshipId } },
+      parseCoachingSessionSeries
+    );
+  },
+
+  /**
+   * Reads one series together with its materialized sessions, date-sorted.
+   */
+  get: (id: Id): Promise<CoachingSessionSeriesWithSessions> =>
+    EntityApi.getFn<RawCoachingSessionSeriesWithSessions>(
+      `${COACHING_SESSION_SERIES_BASEURL}/${id}`
+    ).then(parseCoachingSessionSeriesWithSessions),
+
+  /**
+   * Creates a series and materializes its sessions in one transaction.
+   * Returns the series with every created session; the first equals `start_at`.
+   */
+  create: (
+    payload: CreateRecurringSessionRequest
+  ): Promise<CoachingSessionSeriesWithSessions> =>
+    EntityApi.createFn<
+      CreateRecurringSessionRequest,
+      RawCoachingSessionSeriesWithSessions
+    >(COACHING_SESSION_SERIES_BASEURL, payload).then(
+      parseCoachingSessionSeriesWithSessions
+    ),
+
+  /**
+   * Reschedules a series: replaces the rule and re-materializes future
+   * sessions. Past sessions are untouched. Returns the series with its sessions.
+   */
+  update: (
+    id: Id,
+    payload: CreateRecurringSessionRequest
+  ): Promise<CoachingSessionSeriesWithSessions> =>
+    EntityApi.updateFn<
+      CreateRecurringSessionRequest,
+      RawCoachingSessionSeriesWithSessions
+    >(`${COACHING_SESSION_SERIES_BASEURL}/${id}`, payload).then(
+      parseCoachingSessionSeriesWithSessions
+    ),
+
+  /**
+   * Deletes a series and its future sessions; past sessions survive.
+   */
+  delete: (id: Id): Promise<CoachingSessionSeries> =>
+    EntityApi.deleteFn<null, RawCoachingSessionSeries>(
+      `${COACHING_SESSION_SERIES_BASEURL}/${id}`
+    ).then(parseCoachingSessionSeries),
+};
+
+/**
+ * Fetches the list of series for a relationship (metadata only).
+ *
+ * @returns { series, isLoading, isError, refresh }
+ */
+export const useCoachingSessionSeriesList = (relationshipId: Id | null) => {
+  const params = relationshipId
+    ? { coaching_relationship_id: relationshipId }
+    : undefined;
+
+  const { entities, isLoading, isError, refresh } =
+    EntityApi.useEntityList<CoachingSessionSeries>(
+      COACHING_SESSION_SERIES_BASEURL,
+      () => CoachingSessionSeriesApi.list(relationshipId),
+      params
+    );
+
+  return { series: entities, isLoading, isError, refresh };
+};
+
+/**
+ * Fetches a single series with its materialized sessions. Passing a falsy id
+ * disables the fetch and yields the default empty series.
+ *
+ * @returns { series, isLoading, isError, refresh }
+ */
+export const useCoachingSessionSeries = (id: Id) => {
+  const url = id ? `${COACHING_SESSION_SERIES_BASEURL}/${id}` : null;
+
+  const { entity, isLoading, isError, refresh } =
+    EntityApi.useEntity<CoachingSessionSeriesWithSessions>(
+      url,
+      () => CoachingSessionSeriesApi.get(id),
+      defaultCoachingSessionSeriesWithSessions()
+    );
+
+  return { series: entity, isLoading, isError, refresh };
+};
+
+/**
+ * Mutation hook for series create/reschedule/delete with loading + error state
+ * and automatic invalidation of series-list cache keys.
+ *
+ * Note: this only invalidates `coaching_session_series` keys. Because a
+ * reschedule re-materializes and a delete drops future sessions, callers
+ * displaying `coaching_sessions` lists must `refresh()` those separately.
+ */
+export const useCoachingSessionSeriesMutation = () => {
+  return EntityApi.useEntityMutation<
+    CreateRecurringSessionRequest,
+    CoachingSessionSeries
+  >(COACHING_SESSION_SERIES_BASEURL, {
+    create: CoachingSessionSeriesApi.create,
+    update: CoachingSessionSeriesApi.update,
+    delete: CoachingSessionSeriesApi.delete,
+  });
+};

--- a/src/lib/api/coaching-session-series.ts
+++ b/src/lib/api/coaching-session-series.ts
@@ -8,6 +8,7 @@ import {
   CoachingSessionSeriesWithSessions,
   CoachingSessionSeriesRaw,
   CoachingSessionSeriesWithSessionsRaw,
+  defaultCoachingSessionSeries,
   defaultCoachingSessionSeriesWithSessions,
   parseCoachingSessionSeries,
   parseCoachingSessionSeriesWithSessions,
@@ -78,10 +79,12 @@ export const CoachingSessionSeriesApi = {
   /**
    * Deletes a series and its future sessions; past sessions survive.
    */
-  delete: (id: Id): Promise<CoachingSessionSeries> =>
-    EntityApi.deleteFn<null, CoachingSessionSeriesRaw>(
+  delete: async (id: Id): Promise<CoachingSessionSeries> => {
+    await EntityApi.deleteFn<null, void>(
       `${COACHING_SESSION_SERIES_BASEURL}/${id}`
-    ).then(parseCoachingSessionSeries),
+    );
+    return defaultCoachingSessionSeries();
+  },
 };
 
 /**

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -10,7 +10,6 @@ import {
 } from "@/types/coaching-session";
 import { CoachingSessionCountByMonth } from "@/types/coaching-session-bucket";
 import { ApiSortOrder, CoachingSessionSortField } from "@/types/sorting";
-import { CreateRecurringSessionRequest } from "@/types/recurrence";
 import { EntityApi } from "./entity-api";
 import { USERS_BASEURL } from "./users";
 import { DateTime } from "ts-luxon";
@@ -85,25 +84,6 @@ export const CoachingSessionApi = {
     EntityApi.createFn<CoachingSession, CoachingSession>(
       COACHING_SESSIONS_BASEURL,
       coachingSession
-    ),
-
-  /**
-   * Creates a recurring series of coaching sessions in a single request.
-   *
-   * Hits POST /coaching_sessions/recurring. The backend expands the
-   * recurrence rule and persists every occurrence; the first one always
-   * equals `start_at`. Caller is responsible for satisfying the field
-   * rules — see `@/types/recurrence` and the form-side guards.
-   *
-   * @param payload The CreateRecurringSessionRequest payload
-   * @returns Promise resolving to the array of created CoachingSession objects
-   */
-  createRecurring: async (
-    payload: CreateRecurringSessionRequest
-  ): Promise<CoachingSession[]> =>
-    EntityApi.createFn<CreateRecurringSessionRequest, CoachingSession[]>(
-      `${COACHING_SESSIONS_BASEURL}/recurring`,
-      payload
     ),
 
   createNested: async (): Promise<CoachingSession> => {

--- a/src/lib/hooks/use-recurrence-state.ts
+++ b/src/lib/hooks/use-recurrence-state.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from "react";
+import { DateTime } from "ts-luxon";
+import {
+  Frequency,
+  RecurrenceEnd,
+  Weekday,
+  frequencySupportsWeekdays,
+  weekdayFromLuxon,
+} from "@/types/recurrence";
+
+export interface RecurrenceStateInit {
+  frequency?: Frequency;
+  interval?: number;
+  byWeekdays?: Weekday[];
+  end?: RecurrenceEnd;
+}
+
+export interface UseRecurrenceStateArgs {
+  enabled: boolean;
+  startWeekday: Weekday | null;
+  timezone: string;
+  init?: RecurrenceStateInit;
+}
+
+const DEFAULT_END: RecurrenceEnd = { kind: "count", count: 4 };
+
+/**
+ * Owns the recurrence-rule form state (frequency / interval / weekdays / end)
+ * shared by the create-session form and the series reschedule dialog, plus the
+ * auto-seed effect that keeps the first session's weekday selected.
+ */
+export function useRecurrenceState({
+  enabled,
+  startWeekday,
+  timezone,
+  init,
+}: UseRecurrenceStateArgs) {
+  const [frequency, setFrequency] = useState<Frequency>(
+    init?.frequency ?? Frequency.Weekly
+  );
+  const [interval, setInterval] = useState<number>(init?.interval ?? 1);
+  const [byWeekdays, setByWeekdays] = useState<Weekday[]>(
+    init?.byWeekdays ?? []
+  );
+  const [end, setEnd] = useState<RecurrenceEnd>(init?.end ?? DEFAULT_END);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!frequencySupportsWeekdays(frequency)) return;
+    if (byWeekdays.length !== 0) return;
+    const seed =
+      startWeekday ??
+      weekdayFromLuxon(DateTime.now().setZone(timezone).weekday);
+    // Seed-once-but-overridable: a pure derivation can't express "default to
+    // the start weekday yet let the user deselect it", so this stays an effect.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setByWeekdays([seed]);
+  }, [enabled, frequency, startWeekday, byWeekdays.length, timezone]);
+
+  const reset = useCallback(() => {
+    setFrequency(init?.frequency ?? Frequency.Weekly);
+    setInterval(init?.interval ?? 1);
+    setByWeekdays(init?.byWeekdays ?? []);
+    setEnd(init?.end ?? DEFAULT_END);
+  }, [init]);
+
+  return {
+    frequency,
+    setFrequency,
+    interval,
+    setInterval,
+    byWeekdays,
+    setByWeekdays,
+    end,
+    setEnd,
+    reset,
+  };
+}

--- a/src/types/__tests__/coaching-session-series.test.ts
+++ b/src/types/__tests__/coaching-session-series.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { DateTime } from "ts-luxon";
+import { Frequency, Weekday } from "@/types/recurrence";
+import { defaultCoachingSession } from "@/types/coaching-session";
+import {
+  CoachingSessionSeriesRaw,
+  CoachingSessionSeriesWithSessionsRaw,
+  defaultCoachingSessionSeries,
+  defaultCoachingSessionSeriesWithSessions,
+  isCoachingSessionSeries,
+  parseCoachingSessionSeries,
+  parseCoachingSessionSeriesWithSessions,
+} from "@/types/coaching-session-series";
+
+// A count-based weekly rule, matching the backend wire shape where the unused
+// end-condition (`until` here) is serialized as explicit null, not omitted.
+function rawSeries(
+  overrides?: Partial<CoachingSessionSeriesRaw>
+): CoachingSessionSeriesRaw {
+  return {
+    id: "series-1",
+    coaching_relationship_id: "rel-1",
+    created_by_user_id: "user-1",
+    rule: {
+      start_at: "2026-05-15T10:00:00",
+      duration_minutes: 60,
+      recurrence: {
+        frequency: Frequency.Weekly,
+        interval: 1,
+        by_weekdays: [Weekday.Mon, Weekday.Wed],
+        count: 24,
+        until: null,
+      },
+    },
+    created_at: "2026-05-01T08:00:00+00:00",
+    updated_at: "2026-05-02T09:30:00+00:00",
+    ...overrides,
+  };
+}
+
+describe("parseCoachingSessionSeries", () => {
+  it("passes scalar fields through unchanged", () => {
+    const result = parseCoachingSessionSeries(rawSeries());
+
+    expect(result.id).toBe("series-1");
+    expect(result.coaching_relationship_id).toBe("rel-1");
+    expect(result.created_by_user_id).toBe("user-1");
+    expect(result.rule.start_at).toBe("2026-05-15T10:00:00");
+    expect(result.rule.duration_minutes).toBe(60);
+    expect(result.rule.recurrence.frequency).toBe(Frequency.Weekly);
+    expect(result.rule.recurrence.interval).toBe(1);
+    expect(result.rule.recurrence.by_weekdays).toEqual([
+      Weekday.Mon,
+      Weekday.Wed,
+    ]);
+  });
+
+  it("lifts a present count to Some and a null until to None", () => {
+    const result = parseCoachingSessionSeries(rawSeries());
+
+    expect(result.rule.recurrence.count.some).toBe(true);
+    expect(result.rule.recurrence.count.some && result.rule.recurrence.count.val).toBe(24);
+    expect(result.rule.recurrence.until.none).toBe(true);
+  });
+
+  it("lifts a present until to Some and a null count to None", () => {
+    const result = parseCoachingSessionSeries(
+      rawSeries({
+        rule: {
+          start_at: "2026-05-15T10:00:00",
+          duration_minutes: 45,
+          recurrence: {
+            frequency: Frequency.Weekly,
+            interval: 2,
+            by_weekdays: [Weekday.Mon],
+            count: null,
+            until: "2026-08-15",
+          },
+        },
+      })
+    );
+
+    expect(result.rule.recurrence.count.none).toBe(true);
+    expect(result.rule.recurrence.until.some).toBe(true);
+    expect(
+      result.rule.recurrence.until.some && result.rule.recurrence.until.val
+    ).toBe("2026-08-15");
+  });
+
+  it("omits by_weekdays when absent rather than emitting undefined", () => {
+    const raw = rawSeries();
+    delete raw.rule.recurrence.by_weekdays;
+
+    const result = parseCoachingSessionSeries(raw);
+
+    expect("by_weekdays" in result.rule.recurrence).toBe(false);
+  });
+
+  it("parses created_at/updated_at ISO strings into valid DateTimes", () => {
+    const result = parseCoachingSessionSeries(rawSeries());
+
+    expect(DateTime.isDateTime(result.created_at)).toBe(true);
+    expect(result.created_at.isValid).toBe(true);
+    expect(result.created_at.toUTC().toISO()).toBe(
+      DateTime.fromISO("2026-05-01T08:00:00+00:00").toUTC().toISO()
+    );
+    expect(result.updated_at.isValid).toBe(true);
+  });
+});
+
+describe("parseCoachingSessionSeriesWithSessions", () => {
+  it("includes the materialized sessions alongside the parsed series", () => {
+    const sessions = [
+      { ...defaultCoachingSession(), id: "cs-1" },
+      { ...defaultCoachingSession(), id: "cs-2" },
+    ];
+    const raw: CoachingSessionSeriesWithSessionsRaw = {
+      ...rawSeries(),
+      coaching_sessions: sessions,
+    };
+
+    const result = parseCoachingSessionSeriesWithSessions(raw);
+
+    expect(result.id).toBe("series-1");
+    expect(result.rule.recurrence.count.some).toBe(true);
+    expect(result.coaching_sessions).toHaveLength(2);
+    expect(result.coaching_sessions.map((s) => s.id)).toEqual(["cs-1", "cs-2"]);
+  });
+});
+
+describe("isCoachingSessionSeries", () => {
+  it("accepts a parsed series", () => {
+    expect(isCoachingSessionSeries(parseCoachingSessionSeries(rawSeries()))).toBe(
+      true
+    );
+  });
+
+  it("rejects non-objects and shapes missing required keys", () => {
+    expect(isCoachingSessionSeries(null)).toBe(false);
+    expect(isCoachingSessionSeries("series")).toBe(false);
+    expect(isCoachingSessionSeries({ id: "x" })).toBe(false);
+  });
+});
+
+describe("defaults", () => {
+  it("produces a None/None recurrence with no sessions", () => {
+    const base = defaultCoachingSessionSeries();
+    expect(base.rule.recurrence.count.none).toBe(true);
+    expect(base.rule.recurrence.until.none).toBe(true);
+
+    expect(defaultCoachingSessionSeriesWithSessions().coaching_sessions).toEqual(
+      []
+    );
+  });
+});

--- a/src/types/__tests__/coaching-session-series.test.ts
+++ b/src/types/__tests__/coaching-session-series.test.ts
@@ -91,6 +91,16 @@ describe("parseCoachingSessionSeries", () => {
     ).toBe("2026-08-15");
   });
 
+  it("treats an omitted (not just null) count/until as None", () => {
+    const raw = rawSeries();
+    // Backend may omit the unused end-condition entirely rather than send null.
+    delete raw.rule.recurrence.until;
+    const result = parseCoachingSessionSeries(raw);
+
+    expect(result.rule.recurrence.until.none).toBe(true);
+    expect(result.rule.recurrence.count.some).toBe(true);
+  });
+
   it("omits by_weekdays when absent rather than emitting undefined", () => {
     const raw = rawSeries();
     delete raw.rule.recurrence.by_weekdays;
@@ -119,8 +129,8 @@ describe("parseCoachingSessionSeriesWithSessions", () => {
       { ...defaultCoachingSession(), id: "cs-2" },
     ];
     const raw: CoachingSessionSeriesWithSessionsRaw = {
-      ...rawSeries(),
-      coaching_sessions: sessions,
+      series: rawSeries(),
+      sessions,
     };
 
     const result = parseCoachingSessionSeriesWithSessions(raw);

--- a/src/types/__tests__/coaching-session-series.test.ts
+++ b/src/types/__tests__/coaching-session-series.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { DateTime } from "ts-luxon";
 import { Frequency, Weekday } from "@/types/recurrence";
+import { Some, None } from "@/types/option";
 import { defaultCoachingSession } from "@/types/coaching-session";
 import {
   CoachingSessionSeriesRaw,
   CoachingSessionSeriesWithSessionsRaw,
+  SeriesRule,
   defaultCoachingSessionSeries,
   defaultCoachingSessionSeriesWithSessions,
+  formatSeriesRule,
   isCoachingSessionSeries,
   parseCoachingSessionSeries,
   parseCoachingSessionSeriesWithSessions,
@@ -151,5 +154,52 @@ describe("defaults", () => {
     expect(defaultCoachingSessionSeriesWithSessions().coaching_sessions).toEqual(
       []
     );
+  });
+});
+
+describe("formatSeriesRule", () => {
+  function rule(overrides: Partial<SeriesRule["recurrence"]>): SeriesRule {
+    return {
+      start_at: "2026-05-15T10:00:00",
+      duration_minutes: 60,
+      recurrence: {
+        frequency: Frequency.Weekly,
+        interval: 1,
+        count: Some(24),
+        until: None,
+        ...overrides,
+      },
+    };
+  }
+
+  it("summarizes a weekly count-based rule with weekdays", () => {
+    expect(
+      formatSeriesRule(rule({ by_weekdays: [Weekday.Mon, Weekday.Wed] }))
+    ).toBe("Weekly on Mon, Wed · 24 sessions");
+  });
+
+  it("summarizes an until-based rule with a formatted date", () => {
+    expect(
+      formatSeriesRule(
+        rule({
+          frequency: Frequency.Biweekly,
+          by_weekdays: [Weekday.Mon],
+          count: None,
+          until: Some("2026-08-15"),
+        })
+      )
+    ).toBe("Bi-weekly on Mon · until Aug 15, 2026");
+  });
+
+  it("uses 'Every N <unit>' phrasing when interval > 1 and singularizes one session", () => {
+    expect(
+      formatSeriesRule(rule({ frequency: Frequency.Daily, interval: 2, count: Some(1) }))
+    ).toBe("Every 2 days · 1 session");
+  });
+
+  it("omits the weekday clause when there are no weekdays", () => {
+    expect(
+      formatSeriesRule(rule({ frequency: Frequency.Monthly, count: Some(6) }))
+    ).toBe("Monthly · 6 sessions");
   });
 });

--- a/src/types/__tests__/coaching-session-series.test.ts
+++ b/src/types/__tests__/coaching-session-series.test.ts
@@ -13,6 +13,7 @@ import {
   isCoachingSessionSeries,
   parseCoachingSessionSeries,
   parseCoachingSessionSeriesWithSessions,
+  seriesRecurrenceToEnd,
 } from "@/types/coaching-session-series";
 
 // A count-based weekly rule, matching the backend wire shape where the unused
@@ -201,5 +202,30 @@ describe("formatSeriesRule", () => {
     expect(
       formatSeriesRule(rule({ frequency: Frequency.Monthly, count: Some(6) }))
     ).toBe("Monthly · 6 sessions");
+  });
+});
+
+describe("seriesRecurrenceToEnd", () => {
+  const base = {
+    frequency: Frequency.Weekly,
+    interval: 1,
+  };
+
+  it("maps a count-based recurrence to a count end", () => {
+    expect(
+      seriesRecurrenceToEnd({ ...base, count: Some(12), until: None })
+    ).toEqual({ kind: "count", count: 12 });
+  });
+
+  it("maps an until-based recurrence to an until end", () => {
+    expect(
+      seriesRecurrenceToEnd({ ...base, count: None, until: Some("2026-08-15") })
+    ).toEqual({ kind: "until", until: "2026-08-15" });
+  });
+
+  it("falls back to a 4-occurrence count when neither bound is set", () => {
+    expect(
+      seriesRecurrenceToEnd({ ...base, count: None, until: None })
+    ).toEqual({ kind: "count", count: 4 });
   });
 });

--- a/src/types/__tests__/coaching-session-series.test.ts
+++ b/src/types/__tests__/coaching-session-series.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { DateTime } from "ts-luxon";
-import { Frequency, Weekday } from "@/types/recurrence";
+import {
+  Frequency,
+  Weekday,
+  untilDateToUtcDateTime,
+} from "@/types/recurrence";
 import { Some, None } from "@/types/option";
 import { defaultCoachingSession } from "@/types/coaching-session";
 import {
@@ -42,9 +46,14 @@ function rawSeries(
   };
 }
 
+// Most fixtures carry a bare-date or null `until`, which the parser leaves
+// untouched regardless of zone; a concrete zone only matters for the datetime
+// round-trip test below.
+const TZ = "America/New_York";
+
 describe("parseCoachingSessionSeries", () => {
   it("passes scalar fields through unchanged", () => {
-    const result = parseCoachingSessionSeries(rawSeries());
+    const result = parseCoachingSessionSeries(rawSeries(), TZ);
 
     expect(result.id).toBe("series-1");
     expect(result.coaching_relationship_id).toBe("rel-1");
@@ -60,7 +69,7 @@ describe("parseCoachingSessionSeries", () => {
   });
 
   it("lifts a present count to Some and a null until to None", () => {
-    const result = parseCoachingSessionSeries(rawSeries());
+    const result = parseCoachingSessionSeries(rawSeries(), TZ);
 
     expect(result.rule.recurrence.count.some).toBe(true);
     expect(result.rule.recurrence.count.some && result.rule.recurrence.count.val).toBe(24);
@@ -81,7 +90,8 @@ describe("parseCoachingSessionSeries", () => {
             until: "2026-08-15",
           },
         },
-      })
+      }),
+      TZ
     );
 
     expect(result.rule.recurrence.count.none).toBe(true);
@@ -91,11 +101,41 @@ describe("parseCoachingSessionSeries", () => {
     ).toBe("2026-08-15");
   });
 
+  it("round-trips a datetime until back to the picked local date (no day drift)", () => {
+    // What the form sends for an end date of Jan 31 in a negative-offset zone:
+    // end-of-day local crosses midnight UTC, so the stored value is Feb 1 UTC.
+    const stored = untilDateToUtcDateTime("2027-01-31", TZ);
+    expect(stored).toBe("2027-02-01T04:59:59");
+
+    const result = parseCoachingSessionSeries(
+      rawSeries({
+        rule: {
+          start_at: "2027-01-10T10:00:00",
+          duration_minutes: 60,
+          recurrence: {
+            frequency: Frequency.Weekly,
+            interval: 1,
+            by_weekdays: [Weekday.Sun],
+            count: null,
+            until: stored,
+          },
+        },
+      }),
+      TZ
+    );
+
+    // Naively slicing `stored` would yield "2027-02-01" — a day late. The
+    // parser must shift back into the user's zone first.
+    expect(
+      result.rule.recurrence.until.some && result.rule.recurrence.until.val
+    ).toBe("2027-01-31");
+  });
+
   it("treats an omitted (not just null) count/until as None", () => {
     const raw = rawSeries();
     // Backend may omit the unused end-condition entirely rather than send null.
     delete raw.rule.recurrence.until;
-    const result = parseCoachingSessionSeries(raw);
+    const result = parseCoachingSessionSeries(raw, TZ);
 
     expect(result.rule.recurrence.until.none).toBe(true);
     expect(result.rule.recurrence.count.some).toBe(true);
@@ -105,13 +145,13 @@ describe("parseCoachingSessionSeries", () => {
     const raw = rawSeries();
     delete raw.rule.recurrence.by_weekdays;
 
-    const result = parseCoachingSessionSeries(raw);
+    const result = parseCoachingSessionSeries(raw, TZ);
 
     expect("by_weekdays" in result.rule.recurrence).toBe(false);
   });
 
   it("parses created_at/updated_at ISO strings into valid DateTimes", () => {
-    const result = parseCoachingSessionSeries(rawSeries());
+    const result = parseCoachingSessionSeries(rawSeries(), TZ);
 
     expect(DateTime.isDateTime(result.created_at)).toBe(true);
     expect(result.created_at.isValid).toBe(true);
@@ -133,7 +173,7 @@ describe("parseCoachingSessionSeriesWithSessions", () => {
       sessions,
     };
 
-    const result = parseCoachingSessionSeriesWithSessions(raw);
+    const result = parseCoachingSessionSeriesWithSessions(raw, TZ);
 
     expect(result.id).toBe("series-1");
     expect(result.rule.recurrence.count.some).toBe(true);
@@ -144,7 +184,7 @@ describe("parseCoachingSessionSeriesWithSessions", () => {
 
 describe("isCoachingSessionSeries", () => {
   it("accepts a parsed series", () => {
-    expect(isCoachingSessionSeries(parseCoachingSessionSeries(rawSeries()))).toBe(
+    expect(isCoachingSessionSeries(parseCoachingSessionSeries(rawSeries(), TZ))).toBe(
       true
     );
   });

--- a/src/types/__tests__/recurrence.test.ts
+++ b/src/types/__tests__/recurrence.test.ts
@@ -9,6 +9,7 @@ import {
   frequencyLabel,
   frequencySupportsWeekdays,
   recurrenceToPayload,
+  untilDateToUtcDateTime,
   validateRecurrence,
   weekdayFromLuxon,
   weekdayLabel,
@@ -186,6 +187,28 @@ describe("recurrenceToPayload", () => {
         until: "2026-12-31",
       }).frequency
     ).toBe(Frequency.Monthly);
+  });
+});
+
+describe("untilDateToUtcDateTime", () => {
+  it("anchors to end-of-day UTC when the zone is UTC", () => {
+    expect(untilDateToUtcDateTime("2027-01-31", "UTC")).toBe(
+      "2027-01-31T23:59:59"
+    );
+  });
+
+  it("converts end-of-day in a positive-offset zone to UTC (same day)", () => {
+    // 2027-01-31T23:59:59.999+05:30 → 18:29:59 UTC.
+    expect(untilDateToUtcDateTime("2027-01-31", "Asia/Kolkata")).toBe(
+      "2027-01-31T18:29:59"
+    );
+  });
+
+  it("rolls into the next UTC day for a negative-offset zone", () => {
+    // 2027-01-31T23:59:59.999-05:00 (EST) → 2027-02-01T04:59:59 UTC.
+    expect(untilDateToUtcDateTime("2027-01-31", "America/New_York")).toBe(
+      "2027-02-01T04:59:59"
+    );
   });
 });
 

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -1,6 +1,11 @@
 import { DateTime } from "ts-luxon";
 import { Id } from "@/types/general";
-import { Frequency, Weekday } from "@/types/recurrence";
+import {
+  Frequency,
+  Weekday,
+  frequencyLabel,
+  weekdayLabel,
+} from "@/types/recurrence";
 import { type Option, Some, None } from "@/types/option";
 import { CoachingSession } from "@/types/coaching-session";
 import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
@@ -141,4 +146,49 @@ export function isCoachingSessionSeries(
     typeof object.rule === "object" &&
     object.rule !== null
   );
+}
+
+function frequencyPhrase(frequency: Frequency, interval: number): string {
+  if (interval <= 1) {
+    return frequencyLabel(frequency);
+  }
+  switch (frequency) {
+    case Frequency.Daily:
+      return `Every ${interval} days`;
+    case Frequency.Weekly:
+      return `Every ${interval} weeks`;
+    case Frequency.Biweekly:
+      return `Every ${interval * 2} weeks`;
+    case Frequency.Monthly:
+      return `Every ${interval} months`;
+    default: {
+      const _exhaustive: never = frequency;
+      throw new Error(`Unhandled frequency: ${_exhaustive}`);
+    }
+  }
+}
+
+/**
+ * Renders a series' recurrence rule as a single human-readable line, e.g.
+ * "Weekly on Mon, Wed · 24 sessions" or "Bi-weekly on Mon · until Aug 15, 2026".
+ */
+export function formatSeriesRule(rule: SeriesRule): string {
+  const { recurrence } = rule;
+  const base = frequencyPhrase(recurrence.frequency, recurrence.interval);
+  const onDays =
+    recurrence.by_weekdays && recurrence.by_weekdays.length > 0
+      ? ` on ${recurrence.by_weekdays.map(weekdayLabel).join(", ")}`
+      : "";
+
+  let end: string;
+  if (recurrence.count.some) {
+    const n = recurrence.count.val;
+    end = `${n} session${n === 1 ? "" : "s"}`;
+  } else if (recurrence.until.some) {
+    end = `until ${DateTime.fromISO(recurrence.until.val).toFormat("LLL d, yyyy")}`;
+  } else {
+    end = "no end date";
+  }
+
+  return `${base}${onDays} · ${end}`;
 }

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -5,7 +5,7 @@ import { type Option, Some, None } from "@/types/option";
 import { CoachingSession } from "@/types/coaching-session";
 import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 
-interface RawSeriesRecurrence {
+interface SeriesRecurrenceRaw {
   frequency: Frequency;
   interval: number;
   by_weekdays?: Weekday[];
@@ -13,23 +13,23 @@ interface RawSeriesRecurrence {
   until: string | null;
 }
 
-interface RawSeriesRule {
+interface SeriesRuleRaw {
   start_at: string;
-  recurrence: RawSeriesRecurrence;
+  recurrence: SeriesRecurrenceRaw;
   duration_minutes: number;
 }
 
-export interface RawCoachingSessionSeries {
+export interface CoachingSessionSeriesRaw {
   id: Id;
   coaching_relationship_id: Id;
-  rule: RawSeriesRule;
+  rule: SeriesRuleRaw;
   created_by_user_id: Id;
   created_at: string;
   updated_at: string;
 }
 
-export interface RawCoachingSessionSeriesWithSessions
-  extends RawCoachingSessionSeries {
+export interface CoachingSessionSeriesWithSessionsRaw
+  extends CoachingSessionSeriesRaw {
   coaching_sessions: CoachingSession[];
 }
 
@@ -64,7 +64,7 @@ export interface CoachingSessionSeriesWithSessions extends CoachingSessionSeries
   coaching_sessions: CoachingSession[];
 }
 
-function parseSeriesRule(raw: RawSeriesRule): SeriesRule {
+function parseSeriesRule(raw: SeriesRuleRaw): SeriesRule {
   return {
     start_at: raw.start_at,
     duration_minutes: raw.duration_minutes,
@@ -81,7 +81,7 @@ function parseSeriesRule(raw: RawSeriesRule): SeriesRule {
 }
 
 export function parseCoachingSessionSeries(
-  raw: RawCoachingSessionSeries
+  raw: CoachingSessionSeriesRaw
 ): CoachingSessionSeries {
   return {
     id: raw.id,
@@ -94,7 +94,7 @@ export function parseCoachingSessionSeries(
 }
 
 export function parseCoachingSessionSeriesWithSessions(
-  raw: RawCoachingSessionSeriesWithSessions
+  raw: CoachingSessionSeriesWithSessionsRaw
 ): CoachingSessionSeriesWithSessions {
   return {
     ...parseCoachingSessionSeries(raw),

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -1,0 +1,144 @@
+import { DateTime } from "ts-luxon";
+import { Id } from "@/types/general";
+import { Frequency, Weekday } from "@/types/recurrence";
+import { type Option, Some, None } from "@/types/option";
+import { CoachingSession } from "@/types/coaching-session";
+import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
+
+interface RawSeriesRecurrence {
+  frequency: Frequency;
+  interval: number;
+  by_weekdays?: Weekday[];
+  count: number | null;
+  until: string | null;
+}
+
+interface RawSeriesRule {
+  start_at: string;
+  recurrence: RawSeriesRecurrence;
+  duration_minutes: number;
+}
+
+export interface RawCoachingSessionSeries {
+  id: Id;
+  coaching_relationship_id: Id;
+  rule: RawSeriesRule;
+  created_by_user_id: Id;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RawCoachingSessionSeriesWithSessions
+  extends RawCoachingSessionSeries {
+  coaching_sessions: CoachingSession[];
+}
+
+// ─── Domain shapes ───────────────────────────────────────────────────
+
+export interface SeriesRecurrence {
+  frequency: Frequency;
+  interval: number;
+  by_weekdays?: Weekday[];
+  count: Option<number>;
+  until: Option<string>;
+}
+
+export interface SeriesRule {
+  start_at: string;
+  recurrence: SeriesRecurrence;
+  duration_minutes: number;
+}
+
+export interface CoachingSessionSeries {
+  id: Id;
+  coaching_relationship_id: Id;
+  rule: SeriesRule;
+  created_by_user_id: Id;
+  created_at: DateTime;
+  updated_at: DateTime;
+}
+
+// POST /coaching_session_series and GET /coaching_session_series/:id both
+// return the series together with its materialized sessions, date-sorted.
+export interface CoachingSessionSeriesWithSessions extends CoachingSessionSeries {
+  coaching_sessions: CoachingSession[];
+}
+
+function parseSeriesRule(raw: RawSeriesRule): SeriesRule {
+  return {
+    start_at: raw.start_at,
+    duration_minutes: raw.duration_minutes,
+    recurrence: {
+      frequency: raw.recurrence.frequency,
+      interval: raw.recurrence.interval,
+      ...(raw.recurrence.by_weekdays
+        ? { by_weekdays: raw.recurrence.by_weekdays }
+        : {}),
+      count: raw.recurrence.count !== null ? Some(raw.recurrence.count) : None,
+      until: raw.recurrence.until !== null ? Some(raw.recurrence.until) : None,
+    },
+  };
+}
+
+export function parseCoachingSessionSeries(
+  raw: RawCoachingSessionSeries
+): CoachingSessionSeries {
+  return {
+    id: raw.id,
+    coaching_relationship_id: raw.coaching_relationship_id,
+    created_by_user_id: raw.created_by_user_id,
+    rule: parseSeriesRule(raw.rule),
+    created_at: DateTime.fromISO(raw.created_at),
+    updated_at: DateTime.fromISO(raw.updated_at),
+  };
+}
+
+export function parseCoachingSessionSeriesWithSessions(
+  raw: RawCoachingSessionSeriesWithSessions
+): CoachingSessionSeriesWithSessions {
+  return {
+    ...parseCoachingSessionSeries(raw),
+    coaching_sessions: raw.coaching_sessions,
+  };
+}
+
+export function defaultCoachingSessionSeries(): CoachingSessionSeries {
+  const now = DateTime.now();
+  return {
+    id: "",
+    coaching_relationship_id: "",
+    created_by_user_id: "",
+    rule: {
+      start_at: "",
+      duration_minutes: FALLBACK_DURATION_MINUTES,
+      recurrence: {
+        frequency: Frequency.Weekly,
+        interval: 1,
+        count: None,
+        until: None,
+      },
+    },
+    created_at: now,
+    updated_at: now,
+  };
+}
+
+export function defaultCoachingSessionSeriesWithSessions(): CoachingSessionSeriesWithSessions {
+  return { ...defaultCoachingSessionSeries(), coaching_sessions: [] };
+}
+
+export function isCoachingSessionSeries(
+  value: unknown
+): value is CoachingSessionSeries {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const object = value as Record<string, unknown>;
+  return (
+    typeof object.id === "string" &&
+    typeof object.coaching_relationship_id === "string" &&
+    typeof object.created_by_user_id === "string" &&
+    typeof object.rule === "object" &&
+    object.rule !== null
+  );
+}

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -14,9 +14,9 @@ import { FALLBACK_DURATION_MINUTES } from "@/types/coaching-session-duration";
 interface SeriesRecurrenceRaw {
   frequency: Frequency;
   interval: number;
-  by_weekdays?: Weekday[];
-  count: number | null;
-  until: string | null;
+  by_weekdays?: Weekday[] | null;
+  count?: number | null;
+  until?: string | null;
 }
 
 interface SeriesRuleRaw {
@@ -34,9 +34,9 @@ export interface CoachingSessionSeriesRaw {
   updated_at: string;
 }
 
-export interface CoachingSessionSeriesWithSessionsRaw
-  extends CoachingSessionSeriesRaw {
-  coaching_sessions: CoachingSession[];
+export interface CoachingSessionSeriesWithSessionsRaw {
+  series: CoachingSessionSeriesRaw;
+  sessions: CoachingSession[];
 }
 
 // ─── Domain shapes ───────────────────────────────────────────────────
@@ -71,17 +71,25 @@ export interface CoachingSessionSeriesWithSessions extends CoachingSessionSeries
 }
 
 function parseSeriesRule(raw: SeriesRuleRaw): SeriesRule {
+  const { recurrence } = raw;
+  // count/until are one-of, and the absent one may be null or omitted — treat
+  // both as None. `?? null` collapses undefined so the !== null guard covers
+  // both cases.
+  const count = recurrence.count ?? null;
+  const until = recurrence.until ?? null;
   return {
     start_at: raw.start_at,
     duration_minutes: raw.duration_minutes,
     recurrence: {
-      frequency: raw.recurrence.frequency,
-      interval: raw.recurrence.interval,
-      ...(raw.recurrence.by_weekdays
-        ? { by_weekdays: raw.recurrence.by_weekdays }
+      frequency: recurrence.frequency,
+      interval: recurrence.interval,
+      ...(recurrence.by_weekdays
+        ? { by_weekdays: recurrence.by_weekdays }
         : {}),
-      count: raw.recurrence.count !== null ? Some(raw.recurrence.count) : None,
-      until: raw.recurrence.until !== null ? Some(raw.recurrence.until) : None,
+      count: count !== null ? Some(count) : None,
+      // `until` is a date in the domain (the form's end-picker); keep only the
+      // date part in case the backend serializes it as a datetime.
+      until: until !== null ? Some(until.slice(0, 10)) : None,
     },
   };
 }
@@ -103,8 +111,8 @@ export function parseCoachingSessionSeriesWithSessions(
   raw: CoachingSessionSeriesWithSessionsRaw
 ): CoachingSessionSeriesWithSessions {
   return {
-    ...parseCoachingSessionSeries(raw),
-    coaching_sessions: raw.coaching_sessions,
+    ...parseCoachingSessionSeries(raw.series),
+    coaching_sessions: raw.sessions,
   };
 }
 

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -2,6 +2,7 @@ import { DateTime } from "ts-luxon";
 import { Id } from "@/types/general";
 import {
   Frequency,
+  RecurrenceEnd,
   Weekday,
   frequencyLabel,
   weekdayLabel,
@@ -166,6 +167,18 @@ function frequencyPhrase(frequency: Frequency, interval: number): string {
       throw new Error(`Unhandled frequency: ${_exhaustive}`);
     }
   }
+}
+
+export function seriesRecurrenceToEnd(
+  recurrence: SeriesRecurrence
+): RecurrenceEnd {
+  if (recurrence.count.some) {
+    return { kind: "count", count: recurrence.count.val };
+  }
+  if (recurrence.until.some) {
+    return { kind: "until", until: recurrence.until.val };
+  }
+  return { kind: "count", count: 4 };
 }
 
 /**

--- a/src/types/coaching-session-series.ts
+++ b/src/types/coaching-session-series.ts
@@ -5,6 +5,7 @@ import {
   RecurrenceEnd,
   Weekday,
   frequencyLabel,
+  utcDateTimeToUntilDate,
   weekdayLabel,
 } from "@/types/recurrence";
 import { type Option, Some, None } from "@/types/option";
@@ -70,7 +71,7 @@ export interface CoachingSessionSeriesWithSessions extends CoachingSessionSeries
   coaching_sessions: CoachingSession[];
 }
 
-function parseSeriesRule(raw: SeriesRuleRaw): SeriesRule {
+function parseSeriesRule(raw: SeriesRuleRaw, timezone: string): SeriesRule {
   const { recurrence } = raw;
   // count/until are one-of, and the absent one may be null or omitted — treat
   // both as None. `?? null` collapses undefined so the !== null guard covers
@@ -87,31 +88,34 @@ function parseSeriesRule(raw: SeriesRuleRaw): SeriesRule {
         ? { by_weekdays: recurrence.by_weekdays }
         : {}),
       count: count !== null ? Some(count) : None,
-      // `until` is a date in the domain (the form's end-picker); keep only the
-      // date part in case the backend serializes it as a datetime.
-      until: until !== null ? Some(until.slice(0, 10)) : None,
+      // `until` is a date in the domain (the form's end-picker). The backend
+      // stores it as a naive-UTC end-of-day datetime, so convert it back to the
+      // user's local date — inverting `untilDateToUtcDateTime`.
+      until: until !== null ? Some(utcDateTimeToUntilDate(until, timezone)) : None,
     },
   };
 }
 
 export function parseCoachingSessionSeries(
-  raw: CoachingSessionSeriesRaw
+  raw: CoachingSessionSeriesRaw,
+  timezone: string
 ): CoachingSessionSeries {
   return {
     id: raw.id,
     coaching_relationship_id: raw.coaching_relationship_id,
     created_by_user_id: raw.created_by_user_id,
-    rule: parseSeriesRule(raw.rule),
+    rule: parseSeriesRule(raw.rule, timezone),
     created_at: DateTime.fromISO(raw.created_at),
     updated_at: DateTime.fromISO(raw.updated_at),
   };
 }
 
 export function parseCoachingSessionSeriesWithSessions(
-  raw: CoachingSessionSeriesWithSessionsRaw
+  raw: CoachingSessionSeriesWithSessionsRaw,
+  timezone: string
 ): CoachingSessionSeriesWithSessions {
   return {
-    ...parseCoachingSessionSeries(raw.series),
+    ...parseCoachingSessionSeries(raw.series, timezone),
     coaching_sessions: raw.sessions,
   };
 }

--- a/src/types/coaching-session.ts
+++ b/src/types/coaching-session.ts
@@ -18,6 +18,7 @@ export interface CoachingSession {
   duration_minutes: number;
   meeting_url?: string;
   provider?: Provider;
+  coaching_session_series_id?: Id;
   created_at: DateTime;
   updated_at: DateTime;
 }

--- a/src/types/recurrence.ts
+++ b/src/types/recurrence.ts
@@ -139,6 +139,22 @@ export function recurrenceToPayload(
   return recurrence;
 }
 
+/**
+ * Serializes the form's date-only `until` (yyyy-MM-dd, in the user's wall
+ * clock) as a UTC-naive datetime — the backend wants the same datetime shape
+ * as `start_at`, not a bare date. Anchored to end-of-day so occurrences on the
+ * final day are still included.
+ */
+export function untilDateToUtcDateTime(
+  untilDate: string,
+  timezone: string
+): string {
+  return DateTime.fromISO(untilDate, { zone: timezone })
+    .endOf("day")
+    .toUTC()
+    .toFormat("yyyy-MM-dd'T'HH:mm:ss");
+}
+
 // Backend caps the expanded series. Mirroring them here so callers can
 // surface inline guidance before submission instead of waiting for a 422.
 export const MAX_OCCURRENCES = 365;

--- a/src/types/recurrence.ts
+++ b/src/types/recurrence.ts
@@ -155,6 +155,27 @@ export function untilDateToUtcDateTime(
     .toFormat("yyyy-MM-dd'T'HH:mm:ss");
 }
 
+/**
+ * Inverse of `untilDateToUtcDateTime`: turns the stored `until` back into the
+ * form's date-only `until` (yyyy-MM-dd) in the user's wall clock. The backend
+ * stores it as a naive-UTC end-of-day datetime, so naively slicing the first
+ * 10 chars would read the UTC date — a day ahead of what the user picked in any
+ * negative-offset zone. Re-interpret as UTC, shift into the user's zone, then
+ * take the date. A value the backend already serialized as a bare date is
+ * returned unchanged.
+ */
+export function utcDateTimeToUntilDate(
+  until: string,
+  timezone: string
+): string {
+  if (!until.includes("T")) {
+    return until.slice(0, 10);
+  }
+  return DateTime.fromISO(until, { zone: "utc" })
+    .setZone(timezone)
+    .toFormat("yyyy-MM-dd");
+}
+
 // Backend caps the expanded series. Mirroring them here so callers can
 // surface inline guidance before submission instead of waiting for a 422.
 export const MAX_OCCURRENCES = 365;


### PR DESCRIPTION
## Description
Consume the backend's new first-class **coaching session series** entity for recurring sessions. Replaces the removed `POST /coaching_sessions/recurring` route with the `/coaching_session_series` endpoints and adds dashboard UI to list, view, reschedule, and delete a series.

#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* **Types & API** - `CoachingSessionSeries` types with a parse-at-the-edge layer (wire `{ series, sessions }` envelope domain types; nullable `count`/`until` normalized to `Option<T>`), plus `CoachingSessionSeriesApi` (list/get/create/update/delete) and SWR hooks.
* **Create** - migrated the recurring-session form from `CoachingSessionApi.createRecurring` to `POST /coaching_session_series`; removed the dead wrapper.
* **List / View / Reschedule / Delete** - new `CoachingSeriesCard` on the dashboard (scoped to the sessions-card relationship filter), a `SeriesDetailDialog` (`GET /:id`), a coach-only `RescheduleSeriesDialog` (`PUT`), and a `DeleteSeriesDialog` (`DELETE`, 204).
* **Refactor** - extracted the recurrence sub-form into a reusable `RecurrenceFields` component + `useRecurrenceState` hook, shared by the create form and reschedule dialog.
* **Fixes** - send `until` as a UTC datetime (not a bare date) to satisfy the backend deserializer; refresh the series list after the create/edit dialog closes; `coaching_session_series_id` added to `CoachingSession`.

### Screenshots / Videos Showing UI Changes (if applicable)
* The dashboard **"Recurring sessions"** card (populated + empty/"select a relationship" states). 
<img width="1211" height="172" alt="Screenshot 2026-06-12 at 7 01 17 AM" src="https://github.com/user-attachments/assets/5fbf3bf1-2d5c-406b-b3d5-63faa2683790" />

* The series **kebab menu** (View sessions / Reschedule / Delete). 
<img width="1238" height="176" alt="Screenshot 2026-06-12 at 7 04 04 AM" src="https://github.com/user-attachments/assets/b15650bd-1b66-4bda-9b91-f379b3c14945" />

* The **Reschedule dialog**. 
<img width="647" height="489" alt="Screenshot 2026-06-12 at 7 05 13 AM" src="https://github.com/user-attachments/assets/e5643fd4-07f9-4b88-8a45-d40754b2f613" />

* The **Delete** confirmation and **View sessions** dialog.
<img width="443" height="173" alt="Screenshot 2026-06-12 at 7 07 27 AM" src="https://github.com/user-attachments/assets/cef0a0b8-05cd-4cd4-8e65-e98fea9042ab" />

<img width="437" height="241" alt="Screenshot 2026-06-12 at 7 06 37 AM" src="https://github.com/user-attachments/assets/00b39183-2c3f-46e5-85c1-fcf3e77e1199" />

### Testing Strategy
* **Unit tests** (Vitest): response parsing & null/omitted-field normalization, `formatSeriesRule`, `seriesRecurrenceToEnd`, `untilDateToUtcDateTime` (UTC / +offset / -offset rollover), and the dashboard-container dialog-close -> refresh contract.
* **Manual**: pick a relationship in the sessions-card filter → create a recurring series → it appears in the card; open **View sessions**; **Reschedule** (incl. an `until`-based rule) and confirm future sessions update; **Delete** and confirm it disappears (past sessions retained).

### Concerns
The work here would need to be deployed together with this [backend PR](https://github.com/refactor-group/refactor-platform-rs/pull/356)