### PR TITLE
Live title sync via coaching_session_title_updated SSE

### DIFF
--- a/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
+++ b/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
@@ -99,4 +99,18 @@ describe("matchesEndpoint", () => {
       matchesEndpoint(`${BASE}/coaching_sessions/s-1/goals`, BASE, "/coaching_sessions"),
     ).toBe(true);
   });
+
+  // The raw matcher still matches the month count caches; the title listener
+  // (invalidateCoachingSessionTitle) excludes them separately, since a rename
+  // can't change a count. This documents that the exclusion lives in the
+  // listener, not in matchesEndpoint.
+  it("matchesEndpoint still matches the count caches (exclusion is in the title listener)", () => {
+    expect(
+      matchesEndpoint(
+        `${BASE}/users/u-1/coaching_sessions/counts`,
+        BASE,
+        "/coaching_sessions",
+      ),
+    ).toBe(true);
+  });
 });

--- a/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
+++ b/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
@@ -65,4 +65,38 @@ describe("matchesEndpoint", () => {
     ).toBe(true);
     expect(matchesEndpoint(`${BASE}/topics_archive`, BASE, "/topics")).toBe(false);
   });
+
+  // coaching_session_title_updated invalidates the /coaching_sessions segment so a
+  // title rename by either participant refreshes both the single read and the
+  // enriched list reads that surface display_title.
+  it("matches the coaching session reads for coaching_session_title_updated", () => {
+    expect(
+      matchesEndpoint(`${BASE}/coaching_sessions/s-1`, BASE, "/coaching_sessions"),
+    ).toBe(true);
+    expect(
+      matchesEndpoint(`${BASE}/users/u-1/coaching_sessions`, BASE, "/coaching_sessions"),
+    ).toBe(true);
+    expect(
+      matchesEndpoint(
+        `${BASE}/coaching_sessions?coaching_relationship_id=r-1`,
+        BASE,
+        "/coaching_sessions",
+      ),
+    ).toBe(true);
+    expect(
+      matchesEndpoint(`${BASE}/coaching_sessions_archive`, BASE, "/coaching_sessions"),
+    ).toBe(false);
+  });
+
+  // Intentional over-match: invalidating /coaching_sessions also revalidates
+  // session subresource caches (topics/goals/...). Harmless extra refetches on an
+  // infrequent title edit; documented so it is a tested property, not a surprise.
+  it("also matches session subresource caches (intentional, coarse)", () => {
+    expect(
+      matchesEndpoint(`${BASE}/coaching_sessions/s-1/topics`, BASE, "/coaching_sessions"),
+    ).toBe(true);
+    expect(
+      matchesEndpoint(`${BASE}/coaching_sessions/s-1/goals`, BASE, "/coaching_sessions"),
+    ).toBe(true);
+  });
 });

--- a/src/lib/hooks/use-sse-cache-invalidation.ts
+++ b/src/lib/hooks/use-sse-cache-invalidation.ts
@@ -151,4 +151,14 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
   useSSEEventHandler(eventSource, 'topics_changed', () => {
     invalidateEndpoint('/topics', 'topics_changed');
   });
+
+  // COACHING SESSION TITLE EVENTS - Invalidate the coaching session caches.
+  // Coarse-by-design (parity with topics_changed): the event carries no title,
+  // so we refetch. The /coaching_sessions segment covers both the single-session
+  // read (/coaching_sessions/{id}) and the enriched list reads
+  // (/users/{id}/coaching_sessions, /coaching_sessions?coaching_relationship_id=)
+  // that surface display_title.
+  useSSEEventHandler(eventSource, 'coaching_session_title_updated', () => {
+    invalidateEndpoint('/coaching_sessions', 'coaching_session_title_updated');
+  });
 }

--- a/src/lib/hooks/use-sse-cache-invalidation.ts
+++ b/src/lib/hooks/use-sse-cache-invalidation.ts
@@ -58,6 +58,30 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
   }, [mutate, baseUrl]);
 
   /**
+   * Invalidates the coaching session caches that surface a title — the single
+   * read (/coaching_sessions/{id}) and the enriched list reads
+   * (/users/{id}/coaching_sessions, /coaching_sessions?coaching_relationship_id=).
+   *
+   * Like invalidateEndpoint('/coaching_sessions', ...) but excludes the month
+   * count caches (/users/{id}/coaching_sessions/counts): a title rename cannot
+   * change a month's session count, so refetching them would be pure waste.
+   */
+  const invalidateCoachingSessionTitle = useCallback((eventName: string) => {
+    mutate(
+      (key) => {
+        const url = typeof key === 'string' ? key : Array.isArray(key) ? key[0] : null;
+        if (typeof url !== 'string') return false;
+        if (url.includes('/coaching_sessions/counts')) return false;
+        return matchesEndpoint(url, baseUrl, '/coaching_sessions');
+      },
+      undefined,
+      // See invalidateEndpoint: don't blank the cache, just revalidate.
+      { revalidate: true, populateCache: false }
+    );
+    console.log(`[SSE] Revalidated /coaching_sessions cache after ${eventName}`);
+  }, [mutate, baseUrl]);
+
+  /**
    * Invalidates session-scoped goal caches: both per-session caches
    * (e.g. /coaching_sessions/{id}/goals) and the batch endpoint cache
    * (e.g. /coaching_sessions/goals?coaching_relationship_id=...).
@@ -154,11 +178,10 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
 
   // COACHING SESSION TITLE EVENTS - Invalidate the coaching session caches.
   // Coarse-by-design (parity with topics_changed): the event carries no title,
-  // so we refetch. The /coaching_sessions segment covers both the single-session
-  // read (/coaching_sessions/{id}) and the enriched list reads
-  // (/users/{id}/coaching_sessions, /coaching_sessions?coaching_relationship_id=)
-  // that surface display_title.
+  // so we refetch the single read and the enriched list reads that surface
+  // display_title. The month count caches are excluded — a rename can't change
+  // a count — so we don't over-match them.
   useSSEEventHandler(eventSource, 'coaching_session_title_updated', () => {
-    invalidateEndpoint('/coaching_sessions', 'coaching_session_title_updated');
+    invalidateCoachingSessionTitle('coaching_session_title_updated');
   });
 }

--- a/src/types/sse-events.ts
+++ b/src/types/sse-events.ts
@@ -137,6 +137,18 @@ export type TranscriptionUpdatedEvent = BaseSSEEvent<
   }
 >;
 
+// ==================== COACHING SESSION TITLE EVENTS (session-scoped) ====================
+
+// Coarse, like topics_changed: carries only the session id. Fires on a title
+// PATCH by either participant. On receipt, refetch the session (single read and
+// the enriched list reads that surface display_title).
+export type CoachingSessionTitleUpdatedEvent = BaseSSEEvent<
+  'coaching_session_title_updated',
+  {
+    coaching_session_id: Id;
+  }
+>;
+
 // ==================== TOPIC EVENTS (session-scoped) ====================
 
 // Coarse, like meeting_recording/transcription: carries only the session id.
@@ -168,4 +180,5 @@ export type SSEEvent =
   | ForceLogoutEvent
   | MeetingRecordingUpdatedEvent
   | TranscriptionUpdatedEvent
-  | TopicsChangedEvent;
+  | TopicsChangedEvent
+  | CoachingSessionTitleUpdatedEvent;


### PR DESCRIPTION
## Description
Wire the frontend listener for the backend's new `coaching_session_title_updated` SSE event (`CoachingSessionTitleField` v3), closing the "No SSE" gap from v2. A title rename by either participant now updates the other participant's open view live, instead of waiting for a manual refetch.

### Changes
* Add `CoachingSessionTitleUpdatedEvent` to the `SSEEvent` union (`src/types/sse-events.ts`) — coarse payload, session-scoped.
* Add a `coaching_session_title_updated` listener in `use-sse-cache-invalidation.ts` that invalidates the `/coaching_sessions` cache segment, refreshing both the single-session read and the enriched list/dashboard `display_title` reads in one shot. Mirrors the existing `topics_changed` coarse-refetch pattern.
* Unit tests for the `/coaching_sessions` endpoint matching, including the intentional coarse over-match on session subresources.

### Testing Strategy
* `npx tsc --noEmit` clean; `vitest` for `use-sse-cache-invalidation.test.ts` green (11 passed).
* Live two-connection check (pending BE deploy of `feat/coaching-session-title-sse`): open the same session as coach + coachee in two browsers, rename from one, confirm the other's title and the dashboard `display_title` update without refresh.

### Concerns
* Invalidating `/coaching_sessions` is intentionally coarse — it also revalidates session subresource caches (topics/goals). Harmless extra refetches on an infrequent title edit, consistent with the rest of the SSE invalidation layer; documented and tested.
