### PR TITLE
In-place cache patch for agreement_* SSE events

### DIFF
--- a/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
+++ b/__tests__/lib/hooks/use-sse-cache-invalidation.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { matchesEndpoint } from "@/lib/hooks/use-sse-cache-invalidation";
+import {
+  matchesEndpoint,
+  upsertAgreementInList,
+  removeAgreementFromList,
+} from "@/lib/hooks/use-sse-cache-invalidation";
+import type { Agreement } from "@/types/agreement";
+import { DateTime } from "ts-luxon";
+
+const makeAgreement = (id: string, body: string): Agreement => ({
+  id,
+  coaching_session_id: "s-1",
+  body,
+  user_id: "u-1",
+  created_at: DateTime.now(),
+  updated_at: DateTime.now(),
+});
 
 /**
  * Test Suite: matchesEndpoint
@@ -64,5 +79,58 @@ describe("matchesEndpoint", () => {
       matchesEndpoint(`${BASE}/coaching_sessions/s-1/topics?x=1`, BASE, "/topics"),
     ).toBe(true);
     expect(matchesEndpoint(`${BASE}/topics_archive`, BASE, "/topics")).toBe(false);
+  });
+});
+
+/**
+ * Test Suite: agreement in-place cache patching
+ * Story: "Apply a fine-grained agreement_* SSE entity to a cached list without a
+ * refetch — append on create, replace on update, remove on delete."
+ */
+describe("upsertAgreementInList", () => {
+  it("appends a new agreement (create)", () => {
+    const list = [makeAgreement("a-1", "first")];
+    const next = upsertAgreementInList(list, makeAgreement("a-2", "second"));
+    expect(next.map((a) => a.id)).toEqual(["a-1", "a-2"]);
+  });
+
+  it("replaces an existing agreement in place (update), preserving position", () => {
+    const list = [makeAgreement("a-1", "first"), makeAgreement("a-2", "second")];
+    const next = upsertAgreementInList(list, makeAgreement("a-1", "edited"));
+    expect(next.map((a) => a.id)).toEqual(["a-1", "a-2"]);
+    expect(next[0].body).toBe("edited");
+  });
+
+  it("does not mutate the input array", () => {
+    const list = [makeAgreement("a-1", "first")];
+    const snapshot = [...list];
+    upsertAgreementInList(list, makeAgreement("a-2", "second"));
+    expect(list).toEqual(snapshot);
+  });
+
+  it("handles an empty starting list", () => {
+    const next = upsertAgreementInList([], makeAgreement("a-1", "first"));
+    expect(next.map((a) => a.id)).toEqual(["a-1"]);
+  });
+});
+
+describe("removeAgreementFromList", () => {
+  it("removes the agreement with the matching id", () => {
+    const list = [makeAgreement("a-1", "first"), makeAgreement("a-2", "second")];
+    const next = removeAgreementFromList(list, "a-1");
+    expect(next.map((a) => a.id)).toEqual(["a-2"]);
+  });
+
+  it("is a no-op when the id is absent", () => {
+    const list = [makeAgreement("a-1", "first")];
+    const next = removeAgreementFromList(list, "a-999");
+    expect(next.map((a) => a.id)).toEqual(["a-1"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const list = [makeAgreement("a-1", "first"), makeAgreement("a-2", "second")];
+    const snapshot = [...list];
+    removeAgreementFromList(list, "a-1");
+    expect(list).toEqual(snapshot);
   });
 });

--- a/src/lib/hooks/use-sse-cache-invalidation.ts
+++ b/src/lib/hooks/use-sse-cache-invalidation.ts
@@ -107,13 +107,8 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
     console.log(`[SSE] Revalidated session-scoped goal caches after ${eventName}`);
   }, [mutate, baseUrl]);
 
-  /**
-   * Agreement list caches are keyed by tuple `[`${baseUrl}/agreements`, params]`
-   * where `params.coaching_session_id` scopes the list. The SSE event is
-   * relationship-scoped (envelope carries `coaching_relationship_id`), but the
-   * payload `agreement` carries its own `coaching_session_id`, so we route the
-   * in-place patch by the entity, not the envelope.
-   */
+  // Route the patch by the payload entity's coaching_session_id, not the
+  // relationship-scoped envelope, since the list cache is session-keyed.
   const agreementsUrl = `${baseUrl}/agreements`;
 
   const isAgreementListKey = useCallback(
@@ -122,9 +117,8 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
     [agreementsUrl],
   );
 
-  // Upsert the agreement into its session's cached list without a refetch. The
-  // payload entity and the cached entities share the same raw (untransformed)
-  // shape, so it drops in directly. Replace-in-place on update, append on create.
+  // Payload entity shares the cached entities' raw (untransformed) shape, so it
+  // drops in directly. Skip caches with no loaded list to avoid a partial write.
   const upsertAgreement = useCallback(
     (agreement: Agreement, eventName: string) => {
       mutate(
@@ -132,7 +126,7 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
           isAgreementListKey(key) &&
           key[1]?.coaching_session_id === agreement.coaching_session_id,
         (current: Agreement[] | undefined) =>
-          upsertAgreementInList(current ?? [], agreement),
+          current ? upsertAgreementInList(current, agreement) : current,
         { revalidate: false },
       );
       console.log(`[SSE] Patched agreement ${agreement.id} in cache after ${eventName}`);
@@ -140,8 +134,7 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
     [mutate, isAgreementListKey],
   );
 
-  // Remove the agreement by id. The delete payload carries no session id, so we
-  // scan every agreement-list cache and drop the matching row (ids are unique).
+  // Delete payload carries no session id, so scan every list cache (ids are unique).
   const removeAgreement = useCallback(
     (agreementId: Id, eventName: string) => {
       mutate(

--- a/src/lib/hooks/use-sse-cache-invalidation.ts
+++ b/src/lib/hooks/use-sse-cache-invalidation.ts
@@ -3,6 +3,8 @@
 import { useCallback } from 'react';
 import { useSWRConfig } from 'swr';
 import { siteConfig } from '@/site.config';
+import type { Agreement } from '@/types/agreement';
+import type { Id } from '@/types/general';
 import { useSSEEventHandler } from './use-sse-event-handler';
 
 /**
@@ -27,6 +29,30 @@ export function matchesEndpoint(
   if (!url.startsWith(baseUrl)) return false;
   const pattern = new RegExp(`${endpointPath}(/|\\?|$)`);
   return pattern.test(url);
+}
+
+/**
+ * Upsert an agreement into a cached list: replace in place if its id is already
+ * present (an update), otherwise append (a create). Returns a new array; never
+ * mutates the input.
+ */
+export function upsertAgreementInList(
+  list: Agreement[],
+  agreement: Agreement,
+): Agreement[] {
+  const idx = list.findIndex((a) => a.id === agreement.id);
+  if (idx === -1) return [...list, agreement];
+  const next = [...list];
+  next[idx] = agreement;
+  return next;
+}
+
+/** Remove an agreement from a cached list by id. Returns a new array. */
+export function removeAgreementFromList(
+  list: Agreement[],
+  agreementId: Id,
+): Agreement[] {
+  return list.filter((a) => a.id !== agreementId);
 }
 
 export function useSSECacheInvalidation(eventSource: EventSource | null) {
@@ -81,6 +107,54 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
     console.log(`[SSE] Revalidated session-scoped goal caches after ${eventName}`);
   }, [mutate, baseUrl]);
 
+  /**
+   * Agreement list caches are keyed by tuple `[`${baseUrl}/agreements`, params]`
+   * where `params.coaching_session_id` scopes the list. The SSE event is
+   * relationship-scoped (envelope carries `coaching_relationship_id`), but the
+   * payload `agreement` carries its own `coaching_session_id`, so we route the
+   * in-place patch by the entity, not the envelope.
+   */
+  const agreementsUrl = `${baseUrl}/agreements`;
+
+  const isAgreementListKey = useCallback(
+    (key: unknown): key is [string, { coaching_session_id?: Id }] =>
+      Array.isArray(key) && typeof key[0] === 'string' && key[0] === agreementsUrl,
+    [agreementsUrl],
+  );
+
+  // Upsert the agreement into its session's cached list without a refetch. The
+  // payload entity and the cached entities share the same raw (untransformed)
+  // shape, so it drops in directly. Replace-in-place on update, append on create.
+  const upsertAgreement = useCallback(
+    (agreement: Agreement, eventName: string) => {
+      mutate(
+        (key) =>
+          isAgreementListKey(key) &&
+          key[1]?.coaching_session_id === agreement.coaching_session_id,
+        (current: Agreement[] | undefined) =>
+          upsertAgreementInList(current ?? [], agreement),
+        { revalidate: false },
+      );
+      console.log(`[SSE] Patched agreement ${agreement.id} in cache after ${eventName}`);
+    },
+    [mutate, isAgreementListKey],
+  );
+
+  // Remove the agreement by id. The delete payload carries no session id, so we
+  // scan every agreement-list cache and drop the matching row (ids are unique).
+  const removeAgreement = useCallback(
+    (agreementId: Id, eventName: string) => {
+      mutate(
+        (key) => isAgreementListKey(key),
+        (current: Agreement[] | undefined) =>
+          current ? removeAgreementFromList(current, agreementId) : current,
+        { revalidate: false },
+      );
+      console.log(`[SSE] Removed agreement ${agreementId} from cache after ${eventName}`);
+    },
+    [mutate, isAgreementListKey],
+  );
+
   // ACTION EVENTS - Invalidate only /actions endpoint
   useSSEEventHandler(eventSource, 'action_created', () => {
     invalidateEndpoint('/actions', 'action_created');
@@ -94,17 +168,19 @@ export function useSSECacheInvalidation(eventSource: EventSource | null) {
     invalidateEndpoint('/actions', 'action_deleted');
   });
 
-  // AGREEMENT EVENTS - Invalidate only /agreements endpoint
-  useSSEEventHandler(eventSource, 'agreement_created', () => {
-    invalidateEndpoint('/agreements', 'agreement_created');
+  // AGREEMENT EVENTS - Fine-grained: patch the session's cached list in place
+  // from the entity in the payload (no refetch). Relationship-scoped on the wire,
+  // but routed to the right session cache via the entity's coaching_session_id.
+  useSSEEventHandler(eventSource, 'agreement_created', (event) => {
+    upsertAgreement(event.data.agreement, 'agreement_created');
   });
 
-  useSSEEventHandler(eventSource, 'agreement_updated', () => {
-    invalidateEndpoint('/agreements', 'agreement_updated');
+  useSSEEventHandler(eventSource, 'agreement_updated', (event) => {
+    upsertAgreement(event.data.agreement, 'agreement_updated');
   });
 
-  useSSEEventHandler(eventSource, 'agreement_deleted', () => {
-    invalidateEndpoint('/agreements', 'agreement_deleted');
+  useSSEEventHandler(eventSource, 'agreement_deleted', (event) => {
+    removeAgreement(event.data.agreement_id, 'agreement_deleted');
   });
 
   // GOAL EVENTS - Invalidate /goals and session-scoped goal caches (join table)

--- a/src/types/sse-events.ts
+++ b/src/types/sse-events.ts
@@ -38,12 +38,12 @@ export type ActionDeletedEvent = BaseSSEEvent<
   }
 >;
 
-// ==================== AGREEMENT EVENTS (relationship-scoped) ====================
+// ==================== AGREEMENT EVENTS (session-scoped) ====================
 
 export type AgreementCreatedEvent = BaseSSEEvent<
   'agreement_created',
   {
-    coaching_relationship_id: Id;
+    coaching_session_id: Id;
     agreement: Agreement;
   }
 >;
@@ -51,7 +51,7 @@ export type AgreementCreatedEvent = BaseSSEEvent<
 export type AgreementUpdatedEvent = BaseSSEEvent<
   'agreement_updated',
   {
-    coaching_relationship_id: Id;
+    coaching_session_id: Id;
     agreement: Agreement;
   }
 >;
@@ -59,7 +59,7 @@ export type AgreementUpdatedEvent = BaseSSEEvent<
 export type AgreementDeletedEvent = BaseSSEEvent<
   'agreement_deleted',
   {
-    coaching_relationship_id: Id;
+    coaching_session_id: Id;
     agreement_id: Id;
   }
 >;


### PR DESCRIPTION
## Description
Upgrade the `agreement_*` SSE listeners from coarse refetch to **fine-grained in-place cache patching**, consuming the `agreement` entity carried in the payload (per the `agreement_sse` contract). Mirrors the backend's `feat/agreement-sse` branch. No refetch round-trip on an agreement create/update/delete by the other participant.

### Changes
* `agreement_created` / `agreement_updated` upsert the payload entity into the session's cached agreement list (replace-in-place on update, append on create).
* `agreement_deleted` removes by id.
* **Scope routing:** the SSE envelope is relationship-scoped (`coaching_relationship_id`), but the FE agreement list cache is keyed per `coaching_session_id`. create/update route via the payload entity's own `coaching_session_id`; delete carries no session id, so it scans the agreement-list caches and removes by unique id.
* Extracted pure helpers `upsertAgreementInList` / `removeAgreementFromList` with unit tests.

### Testing Strategy
* `npx tsc --noEmit` clean; `vitest` for `use-sse-cache-invalidation.test.ts` green (16 passed).
* Live two-connection check (pending BE deploy of `feat/agreement-sse`): two browsers on the same coaching session, create/edit/delete an agreement from one, confirm the other's list patches without a refetch.

### Concerns
* The payload entity and the list cache share the same raw (untransformed) shape — `transformEntityDates` runs at render, not in cache — so the entity drops in directly. Verified against `entity-api` list-key/transform handling.
* No client-side re-sort after upsert: new/updated rows append or hold position; the next natural refetch reconciles canonical order. Agreement lists are small and change infrequently, so order drift is negligible. Flag if a strict server order is required and I'll re-sort by the list's sort params.
