### PR TITLE
Make Action.due_by nullable to fix dashboard crash

### DIFF
--- a/__tests__/components/action-filtering.test.tsx
+++ b/__tests__/components/action-filtering.test.tsx
@@ -571,15 +571,17 @@ describe("Action Filtering", () => {
       const overdueCount = actions.filter(
         (a) =>
           a.action.status !== ItemStatus.Completed &&
-          isActionOverdue(a.action.due_by, today)
+          a.action.due_by.some &&
+          isActionOverdue(a.action.due_by.val, today)
       ).length;
       expect(overdueCount).toBe(2);
 
       // Due today should NOT be overdue
       const dueTodayOverdue = actions.filter(
         (a) =>
-          a.action.due_by.hasSame(today, "day") &&
-          isActionOverdue(a.action.due_by, today)
+          a.action.due_by.some &&
+          a.action.due_by.val.hasSame(today, "day") &&
+          isActionOverdue(a.action.due_by.val, today)
       ).length;
       expect(dueTodayOverdue).toBe(0);
     });

--- a/__tests__/components/action-filtering.test.tsx
+++ b/__tests__/components/action-filtering.test.tsx
@@ -1001,4 +1001,71 @@ describe("Action Filtering", () => {
       expect(results).toHaveLength(0);
     });
   });
+
+  /**
+   * These tests verify the production filterActionsByStatus function with the
+   * DueSoon filter. This filter shows incomplete actions assigned to the user
+   * that are due on or before the next session for their relationship.
+   *
+   * An action with no due date (due_by is None) has no date to compare against
+   * the next session, so it is intentionally excluded from DueSoon.
+   */
+  describe("due soon filter (production)", () => {
+    const createSessionMap = (sessionId: string, relationshipId: string) => {
+      const map = new Map<string, EnrichedCoachingSession>();
+      map.set(sessionId, {
+        id: sessionId,
+        coaching_relationship_id: relationshipId,
+        date: REFERENCE_DATE.toISO() ?? "",
+      } as EnrichedCoachingSession);
+      return map;
+    };
+
+    const createNextSessionMap = (relationshipId: string, date: DateTime) => {
+      const map = new Map<string, EnrichedCoachingSession>();
+      map.set(relationshipId, {
+        id: generateTestUUID(),
+        coaching_relationship_id: relationshipId,
+        date: date.toISO() ?? "",
+      } as EnrichedCoachingSession);
+      return map;
+    };
+
+    it("includes actions due before the next session but excludes undated actions", () => {
+      const sessionMap = createSessionMap(
+        TEST_SESSION_IDS.SESSION_1,
+        TEST_RELATIONSHIP_IDS.PRIMARY
+      );
+      const nextSessionMap = createNextSessionMap(
+        TEST_RELATIONSHIP_IDS.PRIMARY,
+        REFERENCE_DATE.plus({ days: 7 })
+      );
+
+      const dated = createMockAction({
+        id: generateTestUUID(),
+        coachingSessionId: TEST_SESSION_IDS.SESSION_1,
+        dueBy: REFERENCE_DATE.plus({ days: 2 }),
+        status: ItemStatus.NotStarted,
+        assigneeIds: [TEST_USER_IDS.CURRENT_USER],
+      });
+      const undated = createMockAction({
+        id: generateTestUUID(),
+        coachingSessionId: TEST_SESSION_IDS.SESSION_1,
+        dueBy: null,
+        status: ItemStatus.NotStarted,
+        assigneeIds: [TEST_USER_IDS.CURRENT_USER],
+      });
+
+      const results = filterActionsByStatus(
+        [dated, undated],
+        AssignedActionsFilter.DueSoon,
+        TEST_USER_IDS.CURRENT_USER,
+        sessionMap,
+        nextSessionMap,
+        new Map() // lastSessionByRelationship not used for DueSoon
+      );
+
+      expect(results.map((a) => a.id)).toEqual([dated.id]);
+    });
+  });
 });

--- a/__tests__/components/ui/actions/actions-page-container.test.tsx
+++ b/__tests__/components/ui/actions/actions-page-container.test.tsx
@@ -6,7 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { DateTime } from "ts-luxon";
 import { toast } from "sonner";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import type { AssignedActionWithContext } from "@/types/assigned-actions";
 import { siteConfig } from "@/site.config";
 import { EntityApiError } from "@/lib/api/entity-api";
@@ -141,7 +141,7 @@ function makeCtx(
       user_id: "user-1",
       status,
       status_changed_at: now,
-      due_by: now.plus({ days: 7 }),
+      due_by: Some(now.plus({ days: 7 })),
       created_at: now,
       updated_at: now,
       assignee_ids: ["user-1"],

--- a/__tests__/components/ui/actions/kanban-action-card.test.tsx
+++ b/__tests__/components/ui/actions/kanban-action-card.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import type { AssignedActionWithContext } from "@/types/assigned-actions";
 import { KanbanActionCard } from "@/components/ui/actions/kanban-action-card";
 import { TestProviders } from "@/test-utils/providers";
@@ -37,7 +37,7 @@ function makeCtx(
       user_id: "user-1",
       status,
       status_changed_at: now,
-      due_by: now.plus({ days: 7 }),
+      due_by: Some(now.plus({ days: 7 })),
       created_at: now,
       updated_at: now,
       assignee_ids: ["user-1"],

--- a/__tests__/components/ui/actions/kanban-board.test.tsx
+++ b/__tests__/components/ui/actions/kanban-board.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import { StatusVisibility } from "@/types/assigned-actions";
 import type { AssignedActionWithContext } from "@/types/assigned-actions";
 import { KanbanBoard } from "@/components/ui/actions/kanban-board";
@@ -46,7 +46,7 @@ function makeAction(
       user_id: "user-1",
       status,
       status_changed_at: now,
-      due_by: now.plus({ days: 7 }),
+      due_by: Some(now.plus({ days: 7 })),
       created_at: now,
       updated_at: now,
       assignee_ids: ["user-1"],

--- a/__tests__/components/ui/actions/kanban-column.test.tsx
+++ b/__tests__/components/ui/actions/kanban-column.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import type { AssignedActionWithContext } from "@/types/assigned-actions";
 import { KanbanColumn } from "@/components/ui/actions/kanban-column";
 import { TestProviders } from "@/test-utils/providers";
@@ -44,7 +44,7 @@ function makeAction(
       user_id: "user-1",
       status,
       status_changed_at: now,
-      due_by: now.plus({ days: 7 }),
+      due_by: Some(now.plus({ days: 7 })),
       created_at: now,
       updated_at: now,
       assignee_ids: ["user-1"],

--- a/__tests__/components/ui/actions/use-optimistic-status.test.ts
+++ b/__tests__/components/ui/actions/use-optimistic-status.test.ts
@@ -3,6 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
 import type { AssignedActionWithContext } from "@/types/assigned-actions";
+import { Some } from "@/types/option";
 import { useOptimisticStatus } from "@/components/ui/actions/use-optimistic-status";
 
 const now = DateTime.now();
@@ -19,7 +20,7 @@ function makeCtx(
       user_id: "user-1",
       status,
       status_changed_at: now,
-      due_by: now.plus({ days: 7 }),
+      due_by: Some(now.plus({ days: 7 })),
       created_at: now,
       updated_at: now,
       assignee_ids: [],

--- a/__tests__/components/ui/actions/utils.test.ts
+++ b/__tests__/components/ui/actions/utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import {
   StatusVisibility,
   TimeRange,
@@ -28,7 +28,7 @@ function makeAction(
   overrides: Partial<{
     id: string;
     status: ItemStatus;
-    due_by: DateTime;
+    due_by: DateTime | null;
     created_at: DateTime;
     relationshipId: string;
   }> = {}
@@ -43,7 +43,10 @@ function makeAction(
       user_id: "user-1",
       status: overrides.status ?? ItemStatus.NotStarted,
       status_changed_at: now,
-      due_by: overrides.due_by ?? now.plus({ days: 7 }),
+      due_by:
+        overrides.due_by === null
+          ? None
+          : Some(overrides.due_by ?? now.plus({ days: 7 })),
       created_at: overrides.created_at ?? now,
       updated_at: now,
       assignee_ids: ["user-1"],
@@ -132,7 +135,7 @@ function makePlainAction(
     user_id: "user-1",
     status: overrides.status ?? ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: ["user-1"],
@@ -302,6 +305,20 @@ describe("applyTimeFilter", () => {
     const result = applyTimeFilter(actions, TimeRange.Last30Days);
 
     expect(result).toHaveLength(1);
+  });
+
+  it("keeps undated actions in every range (no due date to filter against)", () => {
+    const actions = [
+      makeAction({ id: "undated", due_by: null }),
+      makeAction({ id: "recent", due_by: DateTime.now() }),
+      makeAction({ id: "old", due_by: DateTime.now().minus({ days: 200 }) }),
+    ];
+
+    const bounded = applyTimeFilter(actions, TimeRange.Last30Days);
+    expect(bounded.map((a) => a.action.id)).toEqual(["undated", "recent"]);
+
+    const all = applyTimeFilter(actions, TimeRange.AllTime);
+    expect(all.map((a) => a.action.id)).toEqual(["undated", "recent", "old"]);
   });
 
   it("returns empty array for empty input", () => {

--- a/__tests__/components/ui/coaching-sessions/action-card-compact.test.tsx
+++ b/__tests__/components/ui/coaching-sessions/action-card-compact.test.tsx
@@ -176,7 +176,7 @@ describe("CompactActionCard", () => {
         <Wrapper>
           <CompactActionCard
             {...baseProps({
-              action: createMockAction({ due_by: dueDate }),
+              action: createMockAction({ due_by: Some(dueDate) }),
             })}
           />
         </Wrapper>
@@ -193,7 +193,7 @@ describe("CompactActionCard", () => {
         <Wrapper>
           <CompactActionCard
             {...baseProps({
-              action: createMockAction({ due_by: pastDate }),
+              action: createMockAction({ due_by: Some(pastDate) }),
             })}
           />
         </Wrapper>
@@ -413,7 +413,7 @@ describe("CompactActionCard", () => {
         <Wrapper>
           <CompactActionCard
             {...baseProps({
-              action: createMockAction({ id: "", body: "", due_by: initialDueBy }),
+              action: createMockAction({ id: "", body: "", due_by: Some(initialDueBy) }),
               initialEditing: true,
               onBodyChange,
               onDueDateChange,

--- a/__tests__/components/ui/dashboard/upcoming-session-card.test.tsx
+++ b/__tests__/components/ui/dashboard/upcoming-session-card.test.tsx
@@ -8,7 +8,7 @@ import {
 import type { EnrichedCoachingSession, CoachingSession } from "@/types/coaching-session";
 import type { Action } from "@/types/action";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 
 /**
  * Test Suite: UpcomingSessionCard
@@ -94,7 +94,13 @@ function setRelationshipSessionList(sessions: CoachingSession[] = []) {
   });
 }
 
-function makeAction(overrides: Partial<Action> & { coaching_session_id: string; due_by: DateTime }): Action {
+function makeAction({
+  due_by,
+  ...overrides
+}: Partial<Omit<Action, "due_by">> & {
+  coaching_session_id: string;
+  due_by: DateTime | null;
+}): Action {
   return {
     id: overrides.id ?? `action-${Math.random()}`,
     coaching_session_id: overrides.coaching_session_id,
@@ -103,7 +109,7 @@ function makeAction(overrides: Partial<Action> & { coaching_session_id: string; 
     user_id: "coach-1",
     status: ItemStatus.NotStarted,
     status_changed_at: DateTime.now(),
-    due_by: overrides.due_by,
+    due_by: due_by ? Some(due_by) : None,
     created_at: DateTime.now(),
     updated_at: DateTime.now(),
     assignee_ids: ["coach-1"],

--- a/__tests__/lib/hooks/use-all-actions-with-context.test.ts
+++ b/__tests__/lib/hooks/use-all-actions-with-context.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { DateTime } from "ts-luxon";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import {
   AssignmentFilter,
   CoachViewMode,
@@ -104,7 +104,7 @@ function makeTestAction(overrides: Partial<Action> = {}): Action {
     user_id: "user-1",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: ["user-1"],
@@ -278,7 +278,7 @@ describe("useAllActionsWithContext", () => {
 
   it("sets isOverdue when due_by is in the past", () => {
     mockActions = [
-      makeTestAction({ due_by: now.minus({ days: 5 }) }),
+      makeTestAction({ due_by: Some(now.minus({ days: 5 })) }),
     ];
     mockSessions = [makeTestSession()];
 

--- a/__tests__/lib/hooks/use-panel-actions.test.ts
+++ b/__tests__/lib/hooks/use-panel-actions.test.ts
@@ -77,7 +77,7 @@ function makeAction(overrides: Partial<Action> = {}): Action {
     user_id: "user-1",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: [],
@@ -248,7 +248,8 @@ describe("handleCreate — goal linking", () => {
 
     expect(mockCreate).toHaveBeenCalledOnce();
     const created = mockCreate.mock.calls[0][0] as Action;
-    expect(created.due_by.toISO()).toBe(picked.toISO());
+    expect(created.due_by.some).toBe(true);
+    expect(created.due_by.some && created.due_by.val.toISO()).toBe(picked.toISO());
   });
 
   it("falls back to now()+7 days when dueBy is omitted", async () => {
@@ -261,11 +262,13 @@ describe("handleCreate — goal linking", () => {
 
     const after = DateTime.now();
     const created = mockCreate.mock.calls[0][0] as Action;
+    expect(created.due_by.some).toBe(true);
+    if (!created.due_by.some) throw new Error("expected a due date");
     // due_by should fall in [before+7d, after+7d] (a few-ms window).
-    expect(created.due_by.toMillis()).toBeGreaterThanOrEqual(
+    expect(created.due_by.val.toMillis()).toBeGreaterThanOrEqual(
       before.plus({ days: 7 }).toMillis()
     );
-    expect(created.due_by.toMillis()).toBeLessThanOrEqual(
+    expect(created.due_by.val.toMillis()).toBeLessThanOrEqual(
       after.plus({ days: 7 }).toMillis()
     );
   });

--- a/__tests__/lib/utils/assigned-actions.test.ts
+++ b/__tests__/lib/utils/assigned-actions.test.ts
@@ -42,7 +42,7 @@ function makeAction(overrides: Partial<Action> = {}): Action {
     user_id: "user-1",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: [],

--- a/__tests__/lib/utils/select-review-actions-for-session.test.ts
+++ b/__tests__/lib/utils/select-review-actions-for-session.test.ts
@@ -4,9 +4,16 @@ import { selectReviewActionsForSession } from "@/lib/utils/select-review-actions
 import type { Action } from "@/types/action";
 import type { CoachingSession } from "@/types/coaching-session";
 import { ItemStatus } from "@/types/general";
-import { Some } from "@/types/option";
+import { Some, None } from "@/types/option";
 
-function makeAction(overrides: Partial<Action> & { id: string; coaching_session_id: string; due_by: DateTime }): Action {
+function makeAction({
+  due_by,
+  ...overrides
+}: Partial<Omit<Action, "due_by">> & {
+  id: string;
+  coaching_session_id: string;
+  due_by: DateTime | null;
+}): Action {
   return {
     id: overrides.id,
     coaching_session_id: overrides.coaching_session_id,
@@ -14,7 +21,7 @@ function makeAction(overrides: Partial<Action> & { id: string; coaching_session_
     body: "An action",
     goal_id: Some("goal-1"),
     status: ItemStatus.NotStarted,
-    due_by: overrides.due_by,
+    due_by: due_by ? Some(due_by) : None,
     assignee_ids: [],
     created_at: DateTime.now(),
     updated_at: DateTime.now(),

--- a/__tests__/test-utils.ts
+++ b/__tests__/test-utils.ts
@@ -5,7 +5,7 @@ import { CoachingSession, EnrichedCoachingSession } from "@/types/coaching-sessi
 import { CoachingRelationshipWithUserNames } from "@/types/coaching_relationship";
 import { Goal } from "@/types/goal";
 import { ItemStatus } from "@/types/general";
-import { None } from "@/types/option";
+import { Some, None } from "@/types/option";
 import { Organization } from "@/types/organization";
 import { User } from "@/types/user";
 import { OAuthConnection } from "@/types/oauth-connection";
@@ -198,7 +198,7 @@ export function createMockAction(overrides?: Partial<Action>): Action {
     user_id: "user-1",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: ["user-1"],

--- a/__tests__/types/action-serialization.test.ts
+++ b/__tests__/types/action-serialization.test.ts
@@ -20,7 +20,7 @@ function makeAction(goalId: Action["goal_id"]): Action {
     user_id: "user-1",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now.plus({ days: 7 }),
+    due_by: Some(now.plus({ days: 7 })),
     created_at: now,
     updated_at: now,
     assignee_ids: ["user-1"],
@@ -56,8 +56,8 @@ describe("serializeAction", () => {
     expect(wire.user_id).toBe(action.user_id);
     expect(wire.status).toBe(action.status);
     expect(wire.assignee_ids).toEqual(action.assignee_ids);
-    // DateTime instances should be the same references
-    expect(wire.due_by).toBe(action.due_by);
+    // due_by is unwrapped from Option to a raw DateTime on the wire
+    expect(wire.due_by).toBe(action.due_by.some ? action.due_by.val : null);
     expect(wire.created_at).toBe(action.created_at);
   });
 });
@@ -130,6 +130,34 @@ describe("transformAction", () => {
     expect(action.goal_id.none).toBe(true);
   });
 
+  it("wraps a null due_by as None", () => {
+    const raw = {
+      id: "action-1",
+      coaching_session_id: "session-1",
+      goal_id: null,
+      body: "Test",
+      user_id: "user-1",
+      status: "NotStarted",
+      status_changed_at: "2026-03-30T12:00:00Z",
+      due_by: null,
+      created_at: "2026-03-30T12:00:00Z",
+      updated_at: "2026-03-30T12:00:00Z",
+      assignee_ids: [],
+    };
+
+    const action = transformAction(raw);
+
+    expect(action.due_by.some).toBe(false);
+    expect(action.due_by.none).toBe(true);
+  });
+
+  it("serializes a None due_by back to null", () => {
+    const action = makeAction(None);
+    action.due_by = None;
+
+    expect(serializeAction(action).due_by).toBeNull();
+  });
+
   it("transforms date strings into DateTime instances", () => {
     const raw = {
       id: "action-1",
@@ -147,7 +175,7 @@ describe("transformAction", () => {
 
     const action = transformAction(raw);
 
-    expect(DateTime.isDateTime(action.due_by)).toBe(true);
+    expect(action.due_by.some && DateTime.isDateTime(action.due_by.val)).toBe(true);
     expect(DateTime.isDateTime(action.created_at)).toBe(true);
     expect(DateTime.isDateTime(action.updated_at)).toBe(true);
   });

--- a/__tests__/types/action.test.ts
+++ b/__tests__/types/action.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { isAction, sortActionArray, sortByPositionMap, sortByDateField } from '@/types/action'
 import { SortOrder } from '@/types/sorting'
 import { ItemStatus } from '@/types/general'
-import { None } from '@/types/option'
+import { Some, None } from '@/types/option'
 import { DateTime } from 'ts-luxon'
 import type { Action } from '@/types/action'
 
@@ -14,7 +14,7 @@ const makeAction = (id: string, createdAt: string, updatedAt: string): Action =>
   body: `Action ${id}`,
   status: ItemStatus.NotStarted,
   status_changed_at: DateTime.now(),
-  due_by: DateTime.now(),
+  due_by: Some(DateTime.now()),
   created_at: DateTime.fromISO(createdAt),
   updated_at: DateTime.fromISO(updatedAt),
   assignee_ids: [],
@@ -93,9 +93,9 @@ describe('sortActionArray', () => {
     it('should produce stable order when primary sort field values are equal', () => {
       const sameDueBy = DateTime.fromISO('2026-02-10')
       const tiedActions = [
-        { ...makeAction('zzz', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
-        { ...makeAction('aaa', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
-        { ...makeAction('mmm', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
+        { ...makeAction('zzz', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
+        { ...makeAction('aaa', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
+        { ...makeAction('mmm', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
       ]
 
       const sorted = sortActionArray(tiedActions, SortOrder.Desc, 'due_by')
@@ -105,21 +105,40 @@ describe('sortActionArray', () => {
 
     it('should maintain primary sort order when values differ', () => {
       const distinctActions = [
-        { ...makeAction('b', '2026-02-02', '2026-02-10'), due_by: DateTime.fromISO('2026-02-05') },
-        { ...makeAction('a', '2026-02-01', '2026-02-12'), due_by: DateTime.fromISO('2026-02-10') },
-        { ...makeAction('c', '2026-02-03', '2026-02-08'), due_by: DateTime.fromISO('2026-02-01') },
+        { ...makeAction('b', '2026-02-02', '2026-02-10'), due_by: Some(DateTime.fromISO('2026-02-05')) },
+        { ...makeAction('a', '2026-02-01', '2026-02-12'), due_by: Some(DateTime.fromISO('2026-02-10')) },
+        { ...makeAction('c', '2026-02-03', '2026-02-08'), due_by: Some(DateTime.fromISO('2026-02-01')) },
       ]
 
       const sorted = sortActionArray(distinctActions, SortOrder.Desc, 'due_by')
       expect(sorted.map((a) => a.id)).toEqual(['a', 'b', 'c'])
     })
 
+    it('sorts undated (None due_by) actions last without throwing, in both directions', () => {
+      const dated = { ...makeAction('dated', '2026-02-01', '2026-02-10'), due_by: Some(DateTime.fromISO('2026-02-05')) }
+      const undated = { ...makeAction('undated', '2026-02-01', '2026-02-10'), due_by: None }
+
+      const asc = sortActionArray([undated, dated], SortOrder.Asc, 'due_by')
+      expect(asc.map((a) => a.id)).toEqual(['dated', 'undated'])
+
+      const desc = sortActionArray([undated, dated], SortOrder.Desc, 'due_by')
+      expect(desc.map((a) => a.id)).toEqual(['dated', 'undated'])
+    })
+
+    it('breaks ties between two undated actions by id', () => {
+      const a = { ...makeAction('zzz', '2026-02-01', '2026-02-10'), due_by: None }
+      const b = { ...makeAction('aaa', '2026-02-01', '2026-02-10'), due_by: None }
+
+      const sorted = sortActionArray([a, b], SortOrder.Desc, 'due_by')
+      expect(sorted.map((x) => x.id)).toEqual(['aaa', 'zzz'])
+    })
+
     it('should be idempotent — sorting twice yields the same order', () => {
       const sameDueBy = DateTime.fromISO('2026-02-10')
       const tiedActions = [
-        { ...makeAction('c', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
-        { ...makeAction('a', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
-        { ...makeAction('b', '2026-02-01', '2026-02-10'), due_by: sameDueBy },
+        { ...makeAction('c', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
+        { ...makeAction('a', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
+        { ...makeAction('b', '2026-02-01', '2026-02-10'), due_by: Some(sameDueBy) },
       ]
 
       const first = sortActionArray(tiedActions, SortOrder.Asc, 'due_by')

--- a/__tests__/utils/action-test-utils.ts
+++ b/__tests__/utils/action-test-utils.ts
@@ -19,6 +19,7 @@ import type {
 import type { CoachingRelationshipWithUserNames } from "@/types/coaching-relationship";
 import type { EnrichedCoachingSession } from "@/types/coaching-session";
 import { ItemStatus } from "@/types/general";
+import { Some, None } from "@/types/option";
 
 // ============================================================================
 // UUID Generator
@@ -99,7 +100,8 @@ export interface MockActionOptions {
   userId?: string;
   body?: string;
   status?: ItemStatus;
-  dueBy: DateTime;
+  /** Pass null for an action with no due date. */
+  dueBy: DateTime | null;
   createdAt?: DateTime;
   statusChangedAt?: DateTime;
   assigneeIds?: string[];
@@ -120,7 +122,7 @@ export function createMockAction(options: MockActionOptions): Action {
     body: options.body ?? "Test action",
     status: options.status ?? ItemStatus.NotStarted,
     status_changed_at: options.statusChangedAt ?? now,
-    due_by: options.dueBy,
+    due_by: options.dueBy ? Some(options.dueBy) : None,
     created_at: options.createdAt ?? now.minus({ days: 7 }),
     updated_at: now,
     assignee_ids: options.assigneeIds ?? [TEST_USER_IDS.CURRENT_USER],

--- a/src/components/ui/actions/actions-page-container.tsx
+++ b/src/components/ui/actions/actions-page-container.tsx
@@ -227,7 +227,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
       if (!ctx) return;
 
       try {
-        await updateAction(id, { ...ctx.action, due_by: newDueBy });
+        await updateAction(id, { ...ctx.action, due_by: Some(newDueBy) });
         refresh();
       } catch (err) {
         if (err instanceof EntityApiError && err.isNetworkError()) {

--- a/src/components/ui/actions/utils.ts
+++ b/src/components/ui/actions/utils.ts
@@ -83,7 +83,11 @@ export function groupByStatus<T>(
   return result;
 }
 
-/** Apply a time range filter on due date */
+/**
+ * Apply a time range filter on due date. Undated actions have no date to
+ * compare against, so they pass every range rather than disappearing from the
+ * default view.
+ */
 export function applyTimeFilter(
   actions: AssignedActionWithContext[],
   range: TimeRange
@@ -94,7 +98,9 @@ export function applyTimeFilter(
   const daysBack = range === TimeRange.Last30Days ? 30 : 90;
   const cutoff = now.minus({ days: daysBack });
 
-  return actions.filter((ctx) => ctx.action.due_by >= cutoff);
+  return actions.filter(
+    (ctx) => ctx.action.due_by.none || ctx.action.due_by.val >= cutoff
+  );
 }
 
 /**

--- a/src/components/ui/coaching-sessions/action-card-compact.tsx
+++ b/src/components/ui/coaching-sessions/action-card-compact.tsx
@@ -26,7 +26,7 @@ import type { Action } from "@/types/action";
 import type { Goal } from "@/types/goal";
 import { useLinkedGoalDisplay } from "@/lib/hooks/use-linked-goal-display";
 import { ItemStatus, Id } from "@/types/general";
-import { type Option, None } from "@/types/option";
+import { type Option, Some, None } from "@/types/option";
 import type { NoteField } from "@/types/note-selection";
 import { useFieldPrefill } from "@/lib/hooks/use-field-prefill";
 import { cn } from "@/components/lib/utils";
@@ -118,9 +118,11 @@ export function CompactActionCard({
   const [localAssigneeIds, setLocalAssigneeIds] = useState<Id[]>(
     action.assignee_ids ?? []
   );
-  const [localDueBy, setLocalDueBy] = useState<DateTime>(action.due_by);
+  const [localDueBy, setLocalDueBy] = useState<DateTime>(
+    action.due_by.some ? action.due_by.val : DateTime.now().plus({ days: 7 })
+  );
   const displayedAction = useMemo(
-    () => (initialEditing ? { ...action, due_by: localDueBy } : action),
+    () => (initialEditing ? { ...action, due_by: Some(localDueBy) } : action),
     [initialEditing, action, localDueBy]
   );
   const assigneeIds = useMemo(
@@ -321,12 +323,12 @@ function ActionFooter({
   locale,
 }: {
   resolvedAssignees: { initials: string; name: string }[];
-  dueBy: DateTime;
+  dueBy: Option<DateTime>;
   locale: string;
 }) {
-  const formattedDate = dueBy
-    .setLocale(locale)
-    .toLocaleString(DateTime.DATE_MED);
+  const formattedDate = dueBy.some
+    ? dueBy.val.setLocale(locale).toLocaleString(DateTime.DATE_MED)
+    : "No due date";
 
   return (
     <div className="flex items-center justify-between text-[11px] text-muted-foreground">
@@ -355,7 +357,7 @@ function ActionFooter({
             </span>
           </TooltipTrigger>
           <TooltipContent side="bottom" className="text-xs">
-            Due {formattedDate}
+            {dueBy.some ? `Due ${formattedDate}` : formattedDate}
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
@@ -390,9 +392,9 @@ function ActionBackView({
   onEdit: () => void;
   onDelete?: () => void;
 }) {
-  const formattedDate = action.due_by
-    .setLocale(locale)
-    .toLocaleString(DateTime.DATE_MED);
+  const formattedDate = action.due_by.some
+    ? action.due_by.val.setLocale(locale).toLocaleString(DateTime.DATE_MED)
+    : null;
 
   const formattedSessionDate = sourceSessionDate
     ?.setLocale(locale)
@@ -402,7 +404,7 @@ function ActionBackView({
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-[11px] font-bold">
-          Due: {formattedDate}
+          {formattedDate ? `Due: ${formattedDate}` : "No due date"}
         </span>
         <button
           type="button"
@@ -597,7 +599,11 @@ function ActionEditForm({
         <div className="flex items-center justify-between">
           <span className="text-[11px] text-muted-foreground">Due date</span>
           <DueDatePicker
-            value={action.due_by}
+            value={
+              action.due_by.some
+                ? action.due_by.val
+                : DateTime.now().plus({ days: 7 })
+            }
             onChange={onDueDateChange}
             locale={locale}
             variant="button"

--- a/src/components/ui/coaching-sessions/action-section-content.tsx
+++ b/src/components/ui/coaching-sessions/action-section-content.tsx
@@ -8,7 +8,7 @@ import type { Action } from "@/types/action";
 import type { Goal } from "@/types/goal";
 import type { Id } from "@/types/general";
 import type { ItemStatus } from "@/types/general";
-import { type Option, None } from "@/types/option";
+import { type Option, Some, None } from "@/types/option";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { DateTime } from "ts-luxon";
 
@@ -156,7 +156,7 @@ export function ActionSectionContent({
   // Seed due_by to +7 days so the picker initially shows the same default
   // that the backend create handler falls back to when none is selected.
   const newActionPlaceholder = useMemo(
-    () => ({ ...defaultAction(), due_by: DateTime.now().plus({ days: 7 }) }),
+    () => ({ ...defaultAction(), due_by: Some(DateTime.now().plus({ days: 7 })) }),
     []
   );
 

--- a/src/components/ui/dashboard/coaching-sessions-hover-detail.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-hover-detail.tsx
@@ -105,7 +105,8 @@ export function SessionHoverDetail({
 function ActionDueRow({ action }: { action: Action }) {
   const isCompleted = action.status === ItemStatus.Completed;
   const dueLabel = useMemo(
-    () => action.due_by.toFormat("MMM d"),
+    () =>
+      action.due_by.some ? `Due ${action.due_by.val.toFormat("MMM d")}` : "No due date",
     [action.due_by]
   );
 
@@ -124,7 +125,7 @@ function ActionDueRow({ action }: { action: Action }) {
         >
           {action.body}
         </p>
-        <p className="text-xs text-muted-foreground mt-0.5">Due {dueLabel}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{dueLabel}</p>
       </div>
       <ChevronRight className="h-3.5 w-3.5 text-muted-foreground/25 shrink-0" />
     </Link>

--- a/src/lib/hooks/use-panel-actions.ts
+++ b/src/lib/hooks/use-panel-actions.ts
@@ -239,7 +239,7 @@ function useActionCrud(
           body,
           goal_id: goalId ? Some(goalId) : None,
           status: ItemStatus.NotStarted,
-          due_by: dueBy ?? DateTime.now().plus({ days: 7 }),
+          due_by: Some(dueBy ?? DateTime.now().plus({ days: 7 })),
           assignee_ids: assigneeIds ?? [],
         };
         await create(newAction);
@@ -283,7 +283,7 @@ function useActionCrud(
 
   const handleDueDateChange = useCallback(
     (id: Id, newDueBy: DateTime) =>
-      updateField(id, { due_by: newDueBy }, "Failed to update due date"),
+      updateField(id, { due_by: Some(newDueBy) }, "Failed to update due date"),
     [updateField]
   );
 

--- a/src/lib/utils/assigned-actions.ts
+++ b/src/lib/utils/assigned-actions.ts
@@ -90,8 +90,9 @@ function isDueBeforeNextSession(
   );
   if (!nextSession) return true; // Include if no next session scheduled
 
+  if (action.due_by.none) return false;
   const nextSessionDate = DateTime.fromISO(nextSession.date);
-  return action.due_by <= nextSessionDate;
+  return action.due_by.val <= nextSessionDate;
 }
 
 /** Checks if action was completed since the last session for its relationship */
@@ -250,8 +251,9 @@ export function addContextToAction(
 
   // Compare dates only (not times) to avoid marking items due today as overdue
   const today = DateTime.now().startOf("day");
-  const dueDate = action.due_by.startOf("day");
-  const isOverdue = dueDate < today;
+  const isOverdue = action.due_by.some
+    ? action.due_by.val.startOf("day") < today
+    : false;
 
   return {
     action,
@@ -302,8 +304,14 @@ export function sortActionsByDueDate(
     // Overdue actions first
     if (a.isOverdue && !b.isOverdue) return -1;
     if (!a.isOverdue && b.isOverdue) return 1;
-    // Then by due date
-    return a.action.due_by.toMillis() - b.action.due_by.toMillis();
+    // Then by due date; undated actions sort last.
+    const aMillis = a.action.due_by.some ? a.action.due_by.val.toMillis() : null;
+    const bMillis = b.action.due_by.some ? b.action.due_by.val.toMillis() : null;
+    if (aMillis === null || bMillis === null) {
+      if (aMillis === bMillis) return 0;
+      return aMillis === null ? 1 : -1;
+    }
+    return aMillis - bMillis;
   });
 }
 

--- a/src/lib/utils/session.ts
+++ b/src/lib/utils/session.ts
@@ -384,7 +384,8 @@ export function filterReviewActions(
     if (a.coaching_session_id === currentSessionId) return false;
     if (stickyIds?.has(a.id)) return true;
 
-    const dueBy = a.due_by;
+    if (a.due_by.none) return false;
+    const dueBy = a.due_by.val;
     if (dueBy > endOfCurrentDate) return false;
     if (!startOfPrevDate || dueBy >= startOfPrevDate) return true;
     return false;

--- a/src/types/action.ts
+++ b/src/types/action.ts
@@ -14,7 +14,8 @@ export interface Action {
   user_id: Id;
   status: ItemStatus;
   status_changed_at: DateTime;
-  due_by: DateTime;
+  /** None when no due date is set. */
+  due_by: Option<DateTime>;
   created_at: DateTime;
   updated_at: DateTime;
   /** User IDs assigned to this action. Frontend resolves names from coach/coachee data. */
@@ -42,7 +43,9 @@ export function isAction(value: unknown): value is Action {
     typeof object.status === "string" &&
     ITEM_STATUS_VALUES.has(object.status as string) &&
     isDateTimeOrString(object.status_changed_at) &&
-    isDateTimeOrString(object.due_by) &&
+    (object.due_by === null ||
+      isOption(object.due_by) ||
+      isDateTimeOrString(object.due_by)) &&
     isDateTimeOrString(object.created_at) &&
     isDateTimeOrString(object.updated_at) &&
     (object.goal_id === undefined ||
@@ -60,6 +63,14 @@ export function isActionArray(value: unknown): value is Action[] {
   return Array.isArray(value) && value.every(isAction);
 }
 
+/** Millis for a sort field, or null when the field is an absent due date. */
+function sortFieldMillis(action: Action, field: ActionSortField): number | null {
+  if (field === "due_by") {
+    return action.due_by.some ? action.due_by.val.toMillis() : null;
+  }
+  return action[field].toMillis();
+}
+
 export function sortActionArray(
   actions: Action[],
   order: SortOrder,
@@ -67,8 +78,13 @@ export function sortActionArray(
 ): Action[] {
   const sorted = [...actions];
   sorted.sort((a, b) => {
-    const aTime = a[field].toMillis();
-    const bTime = b[field].toMillis();
+    const aTime = sortFieldMillis(a, field);
+    const bTime = sortFieldMillis(b, field);
+    // Undated actions sort last regardless of direction.
+    if (aTime === null || bTime === null) {
+      if (aTime === bTime) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+      return aTime === null ? 1 : -1;
+    }
     const primary = order === SortOrder.Asc ? aTime - bTime : bTime - aTime;
     if (primary !== 0) return primary;
     // Deterministic tiebreaker: ascending by id to ensure stable order
@@ -112,8 +128,11 @@ export function sortByDateField<T>(
   return [...items].sort((a, b) => getDate(a).toMillis() - getDate(b).toMillis());
 }
 
-/** Wire shape where Option fields are unwrapped to string | null for JSON. */
-export type ActionWire = Omit<Action, "goal_id"> & { goal_id: Id | null };
+/** Wire shape where Option fields are unwrapped to value | null for JSON. */
+export type ActionWire = Omit<Action, "goal_id" | "due_by"> & {
+  goal_id: Id | null;
+  due_by: DateTime | null;
+};
 
 /**
  * Wire shape of a single item in the batch coachee-actions response.
@@ -143,6 +162,7 @@ export function serializeAction(action: Action): ActionWire {
   return {
     ...action,
     goal_id: action.goal_id.some ? action.goal_id.val : null,
+    due_by: action.due_by.some ? action.due_by.val : null,
   };
 }
 
@@ -155,6 +175,7 @@ export function transformAction(raw: any): Action {
   const dated = transformEntityDates(raw);
   const rawGoalId = dated.goal_id;
   dated.goal_id = typeof rawGoalId === "string" ? Some(rawGoalId) : None;
+  dated.due_by = DateTime.isDateTime(dated.due_by) ? Some(dated.due_by) : None;
   return dated;
 }
 
@@ -168,7 +189,7 @@ export function defaultAction(): Action {
     user_id: "",
     status: ItemStatus.NotStarted,
     status_changed_at: now,
-    due_by: now,
+    due_by: None,
     created_at: now,
     updated_at: now,
     assignee_ids: [],


### PR DESCRIPTION
## Description
The backend returns `null` for `due_by` when an action has no due date, but the field was typed as a non-null `DateTime`. `sortActionArray` called `due_by.toMillis()` unconditionally, throwing `Cannot read properties of null (reading 'toMillis')` and crashing the entire dashboard whenever a user had an upcoming session with an undated action. This was a P1 (also reproducible against production data).

Retyping `due_by` as `Option<DateTime>` (per coding standards: nullable backend fields use `Option<T>`, not `T | null`) forced the compiler to surface every consumer — including two additional latent crashes the issue didn't mention.

#### GitHub Issue: Fixes #427

### Changes
* `Action.due_by` is now `Option<DateTime>`; `sortActionArray` is null-safe (undated actions sort **last**, both directions).
* Boundary transforms updated: `transformAction` wraps to `Some`/`None`, `serializeAction`/`ActionWire` unwrap to `null`, `isAction` accepts null/Option/string, `defaultAction` → `None`.
* All consumers handle `None` and render **"No due date"** (kanban card, session panel footer + back view, dashboard hover row, edit form). The edit picker defaults to +7 days when `None`.
* Fixed two latent unconditional-`toMillis`/`toFormat` crashes (`coaching-sessions-hover-detail.tsx`, action card back view).
* Intentionally divergent `None` handling between the two filters: the dashboard review-window filter (`filterReviewActions`) **excludes** undated (no date ⇒ not "due within [prev, current]"); the `/actions` recency filter (`applyTimeFilter`) **keeps** undated in every range so active work doesn't silently vanish under the default "Last 30 days".

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: an undated action on the `/actions` kanban and in the session Actions panel, both showing the **"No due date"** label.

### Testing Strategy
* `npx tsc --noEmit` clean; `npx vitest run` — **1573 unit tests pass**, including new sad-path coverage for null-`due_by` sorting, filtering, and serialization.
* Manual (Playwright, against a running backend): created a real `due_by: null` action via the API (confirming the backend accepts/returns null — the issue's exact data shape), then verified no crash and correct "No due date" rendering across the dashboard, `/actions` kanban, and the session Actions panel, plus the edit picker defaulting to +7 days. Test action deleted afterward.

### Concerns
The undated-action filter behavior is a deliberate product decision (review window excludes vs. recency filter keeps). If reviewers prefer different semantics for the `/actions` time-range dropdown, that's the spot to revisit.