### PR TITLE
Distinguish 403 Forbidden from generic errors in UI

### DIFF
--- a/__tests__/app/organizations/members/members-page.test.tsx
+++ b/__tests__/app/organizations/members/members-page.test.tsx
@@ -1,7 +1,39 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import { isAdminOrSuperAdmin, Role } from '@/types/user';
 import type { UserRoleState } from '@/types/user';
 import { shouldDenyMembersPageAccess } from '@/app/organizations/[id]/members/access-control';
+import MembersPage from '@/app/organizations/[id]/members/page';
+import { EntityApiError } from '@/types/entity-api-error';
+import { useCurrentOrganization } from '@/lib/hooks/use-current-organization';
+import { useCurrentUserRole } from '@/lib/hooks/use-current-user-role';
+import { useCoachingRelationshipList } from '@/lib/api/coaching-relationships';
+import { useUserList } from '@/lib/api/organizations/users';
+
+// Data hooks the members page reads — mocked so the render tests below can drive
+// the page into its 403 (ForbiddenError) and generic-error branches. next/navigation
+// is already mocked globally in the test setup.
+vi.mock('@/lib/hooks/use-current-organization', () => ({
+  useCurrentOrganization: vi.fn(),
+}));
+vi.mock('@/lib/hooks/use-current-user-role', () => ({
+  useCurrentUserRole: vi.fn(),
+}));
+vi.mock('@/lib/api/coaching-relationships', () => ({
+  useCoachingRelationshipList: vi.fn(),
+}));
+vi.mock('@/lib/api/organizations/users', () => ({
+  useUserList: vi.fn(),
+}));
+vi.mock('@/lib/providers/auth-store-provider', () => ({
+  useAuthStore: vi.fn(() => ({ userSession: { id: 'user-1' } })),
+  AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+// The success path renders MemberContainer; stub it so these tests stay focused
+// on the page-level error branches (it is never reached in the 403/error cases).
+vi.mock('@/components/ui/members/member-container', () => ({
+  MemberContainer: () => <div data-testid="member-container" />,
+}));
 
 /**
  * Test Suite: Members Page Access Control
@@ -167,5 +199,96 @@ describe('Members Page Access Control Logic', () => {
         expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState)).toBe(true);
       });
     });
+  });
+});
+
+/**
+ * Test Suite: Members Page — page-level 403 rendering
+ *
+ * Mirrors the ActionsPageContainer 403 render test. When either the relationships
+ * or users fetch returns a 403, the page should short-circuit to <ForbiddenError>
+ * (title + shared "view" permission message) rather than the generic error state.
+ * This locks in the second page-level 403 path called out in review.
+ */
+describe('MembersPage - page-level error rendering', () => {
+  const adminRoleState: UserRoleState = {
+    status: 'success',
+    role: Role.Admin,
+    hasAccess: true,
+  };
+
+  // React 19's `use()` unwraps a thenable synchronously when it is already tagged
+  // fulfilled, so the page renders without needing a Suspense boundary in the test.
+  function resolvedParams(id: string) {
+    const params = Promise.resolve({ id }) as Promise<{ id: string }> & {
+      status?: string;
+      value?: { id: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { id };
+    return params;
+  }
+
+  // A real EntityApiError carrying a 403, so the page's real isForbiddenError
+  // (instanceof + status check) narrows correctly.
+  function forbiddenError(): EntityApiError {
+    return new EntityApiError('GET', '/organizations/org-1/users', {
+      isAxiosError: true,
+      response: { status: 403, statusText: 'Forbidden', data: {} },
+    } as never);
+  }
+
+  function mockLists(relationshipsError: unknown, usersError: unknown) {
+    vi.mocked(useCoachingRelationshipList).mockReturnValue({
+      relationships: [],
+      isLoading: false,
+      isError: relationshipsError,
+      refresh: vi.fn(),
+    } as never);
+    vi.mocked(useUserList).mockReturnValue({
+      users: [],
+      isLoading: false,
+      isError: usersError,
+      refresh: vi.fn(),
+    } as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCurrentOrganization).mockReturnValue({
+      currentOrganizationId: 'org-1',
+      setCurrentOrganizationId: vi.fn(),
+    } as never);
+    vi.mocked(useCurrentUserRole).mockReturnValue(adminRoleState);
+  });
+
+  it('renders ForbiddenError when the users fetch returns 403', () => {
+    mockLists(false, forbiddenError());
+
+    render(<MembersPage params={resolvedParams('org-1')} />);
+
+    expect(screen.getByText('Members Access Denied')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You don't have permission to view this organization's members."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders ForbiddenError when the relationships fetch returns 403', () => {
+    mockLists(forbiddenError(), false);
+
+    render(<MembersPage params={resolvedParams('org-1')} />);
+
+    expect(screen.getByText('Members Access Denied')).toBeInTheDocument();
+  });
+
+  it('renders the generic error state for a non-403 fetch failure', () => {
+    mockLists(false, new Error('boom'));
+
+    render(<MembersPage params={resolvedParams('org-1')} />);
+
+    expect(screen.getByText('Error loading members')).toBeInTheDocument();
+    expect(screen.queryByText('Members Access Denied')).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/members/add-member-dialog.test.tsx
+++ b/__tests__/components/members/add-member-dialog.test.tsx
@@ -72,6 +72,22 @@ describe("AddMemberDialog write-freeze handling", () => {
     );
   });
 
+  it("shows the permission-denied message on a 403", async () => {
+    mockCreateNested.mockRejectedValueOnce(apiError(403, { error: "forbidden" }));
+    render(
+      <AddMemberDialog open onOpenChange={vi.fn()} onMemberAdded={vi.fn()} />
+    );
+
+    fillForm();
+    fireEvent.click(screen.getByRole("button", { name: "Create Member" }));
+
+    await waitFor(() =>
+      expect(mockToastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      )
+    );
+  });
+
   it("falls back to the generic message for other errors", async () => {
     mockCreateNested.mockRejectedValueOnce(new Error("network"));
     render(

--- a/__tests__/components/members/member-card.test.tsx
+++ b/__tests__/components/members/member-card.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemberCard } from "@/components/ui/members/member-card";
+import { EntityApiError } from "@/types/entity-api-error";
+import { Role, type UserRoleState } from "@/types/user";
+import { toast } from "sonner";
+import { createMockUser } from "../../test-utils";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+}));
+
+const mockAuthStore = vi.fn();
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector(mockAuthStore()),
+}));
+
+const mockResendInvite = vi.fn();
+const mockDeleteNested = vi.fn();
+vi.mock("@/lib/api/organizations/users", () => ({
+  UserApi: { resendInvite: (...a: unknown[]) => mockResendInvite(...a) },
+  useUserMutation: () => ({ error: undefined, deleteNested: mockDeleteNested }),
+}));
+
+const mockCreateRelationship = vi.fn();
+vi.mock("@/lib/api/coaching-relationships", () => ({
+  useCoachingRelationshipMutation: () => ({
+    createNested: mockCreateRelationship,
+  }),
+}));
+
+// Role derivation is pure and covered elsewhere; stub it so the card renders
+// without needing full relationship fixtures.
+vi.mock("@/lib/utils/user-roles", () => ({
+  getUserDisplayRoles: () => [],
+  getUserCoaches: () => [],
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const adminRole: UserRoleState = {
+  status: "success",
+  role: Role.Admin,
+  hasAccess: true,
+};
+
+// A real EntityApiError carrying the given status/body, so the card's real
+// isForbiddenError / organizationArchivedMessage helpers behave as in prod.
+function apiError(status: number, data: unknown = {}): EntityApiError {
+  const axiosLike = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Error", data },
+  });
+  return new EntityApiError("POST", "/api", axiosLike);
+}
+
+function renderCard(userOverrides = {}, users = undefined as unknown) {
+  const cardUser = createMockUser({
+    id: "user-1",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    invite_status: null,
+    ...userOverrides,
+  });
+  const otherUser = createMockUser({
+    id: "user-2",
+    first_name: "Bob",
+    last_name: "Jones",
+  });
+  render(
+    <MemberCard
+      user={cardUser}
+      currentUserId="me"
+      userRelationships={[]}
+      onRefresh={vi.fn()}
+      users={(users as never) ?? [cardUser, otherUser]}
+      currentUserRoleState={adminRole}
+    />
+  );
+}
+
+// Drives the "Assign Coach" flow: open the row menu, pick Assign Coach, choose a
+// member in the dialog's Select, then submit. Leaves the createRelationship
+// rejection to the caller.
+async function submitAssignCoach(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button")); // row actions menu (icon-only)
+  await user.click(await screen.findByText("Assign Coach")); // menu item → opens dialog
+  await user.click(screen.getByRole("combobox")); // open member Select
+  await user.click(await screen.findByText("Bob Jones")); // choose assignee
+  await user.click(screen.getByRole("button", { name: /assign as coach/i }));
+}
+
+// ── Test setup ────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mockAuthStore.mockReturnValue({
+    isACoach: true,
+    userSession: { id: "me" },
+  });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MemberCard – resend invite error handling", () => {
+  it("shows the permission-denied toast on a 403", async () => {
+    mockResendInvite.mockRejectedValueOnce(apiError(403));
+    const user = userEvent.setup();
+    renderCard({ invite_status: "expired" });
+
+    await user.click(screen.getByRole("button", { name: /resend/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      )
+    );
+  });
+
+  it("falls back to the generic message for other errors", async () => {
+    mockResendInvite.mockRejectedValueOnce(new Error("boom"));
+    const user = userEvent.setup();
+    renderCard({ invite_status: "expired" });
+
+    await user.click(screen.getByRole("button", { name: /resend/i }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Failed to resend invitation")
+    );
+  });
+});
+
+describe("MemberCard – assign relationship error handling", () => {
+  it("surfaces the backend message when the org is archived", async () => {
+    mockCreateRelationship.mockRejectedValueOnce(
+      apiError(409, {
+        error: "organization_archived",
+        message: "This organization is archived and cannot accept new changes.",
+      })
+    );
+    const user = userEvent.setup();
+    renderCard();
+
+    await submitAssignCoach(user);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "This organization is archived and cannot accept new changes."
+      )
+    );
+  });
+
+  it("shows the permission-denied toast on a 403", async () => {
+    mockCreateRelationship.mockRejectedValueOnce(apiError(403));
+    const user = userEvent.setup();
+    renderCard();
+
+    await submitAssignCoach(user);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      )
+    );
+  });
+
+  it("falls back to the generic assign message for other errors", async () => {
+    mockCreateRelationship.mockRejectedValueOnce(new Error("boom"));
+    const user = userEvent.setup();
+    renderCard();
+
+    await submitAssignCoach(user);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Error assigning Coach")
+    );
+  });
+});

--- a/__tests__/components/settings/coaching-preferences-section.test.tsx
+++ b/__tests__/components/settings/coaching-preferences-section.test.tsx
@@ -157,6 +157,25 @@ describe("CoachingPreferencesSection", () => {
       );
     });
 
+    it("shows the permission-denied toast on a 403", async () => {
+      mockUpdate.mockRejectedValue(
+        makeApiError(403, { status_code: 403, error: "forbidden" })
+      );
+      render(<CoachingPreferencesSection />);
+
+      const numericInput = screen.getByRole("combobox", { name: /duration in minutes/i });
+      fireEvent.change(numericInput, { target: { value: "45" } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(AUTOSAVE_DEBOUNCE_MS);
+        await Promise.resolve();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+    });
+
     it("shows a generic fallback toast on non-422 errors", async () => {
       mockUpdate.mockRejectedValue(
         makeApiError(503, { status_code: 503, error: "service_unavailable" })

--- a/__tests__/components/ui/actions/actions-page-container.test.tsx
+++ b/__tests__/components/ui/actions/actions-page-container.test.tsx
@@ -117,6 +117,8 @@ vi.mock("@/lib/api/entity-api", () => {
   return {
     EntityApiError,
     PERMISSION_DENIED_MESSAGE: "You don't have permission to perform this action.",
+    viewPermissionDeniedMessage: (resource: string) =>
+      `You don't have permission to view ${resource}.`,
     isForbiddenError: (e: unknown) =>
       e instanceof EntityApiError && e.isForbidden(),
   };

--- a/__tests__/components/ui/actions/actions-page-container.test.tsx
+++ b/__tests__/components/ui/actions/actions-page-container.test.tsx
@@ -86,7 +86,7 @@ vi.mock("@/lib/api/actions", () => ({
 const now = DateTime.now();
 let mockActionsData: AssignedActionWithContext[] = [];
 let mockIsLoading = false;
-let mockIsError = false;
+let mockIsError: unknown = false;
 const mockRefresh = vi.fn();
 
 vi.mock("@/lib/hooks/use-all-actions-with-context", () => ({
@@ -98,18 +98,29 @@ vi.mock("@/lib/hooks/use-all-actions-with-context", () => ({
   }),
 }));
 
-vi.mock("@/lib/api/entity-api", () => ({
-  EntityApiError: class EntityApiError extends Error {
+vi.mock("@/lib/api/entity-api", () => {
+  class EntityApiError extends Error {
     private _networkError: boolean;
-    constructor(message: string, networkError = false) {
+    private _forbidden: boolean;
+    constructor(message: string, networkError = false, forbidden = false) {
       super(message);
       this._networkError = networkError;
+      this._forbidden = forbidden;
     }
     isNetworkError() {
       return this._networkError;
     }
-  },
-}));
+    isForbidden() {
+      return this._forbidden;
+    }
+  }
+  return {
+    EntityApiError,
+    PERMISSION_DENIED_MESSAGE: "You don't have permission to perform this action.",
+    isForbiddenError: (e: unknown) =>
+      e instanceof EntityApiError && e.isForbidden(),
+  };
+});
 
 vi.mock("@/lib/api/goals", () => ({
   useGoal: () => ({ goal: { id: "" }, isLoading: false, isError: undefined, refresh: vi.fn() }),
@@ -251,6 +262,18 @@ describe("ActionsPageContainer", () => {
     expect(
       screen.getByText("Failed to load actions. Please try again later.")
     ).toBeInTheDocument();
+  });
+
+  it("shows ForbiddenError when the data fetch returns 403", () => {
+    mockIsError = new EntityApiError("Forbidden", false, true);
+
+    render(
+      <Wrapper>
+        <ActionsPageContainer locale={siteConfig.locale} />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("Actions Access Denied")).toBeInTheDocument();
   });
 
   it("toggles status visibility to show all 4 columns", async () => {
@@ -554,6 +577,28 @@ describe("ActionsPageContainer", () => {
       await waitFor(() => {
         expect(toast.error).toHaveBeenCalledWith(
           "Failed to delete action."
+        );
+      });
+    });
+
+    it("shows permission toast when delete fails with a 403", async () => {
+      mockDelete.mockRejectedValueOnce(
+        new EntityApiError("Forbidden", false, true)
+      );
+      mockActionsData = [makeCtx("a1", ItemStatus.NotStarted)];
+      const user = userEvent.setup();
+
+      const { container } = render(
+        <Wrapper>
+          <ActionsPageContainer locale={siteConfig.locale} />
+        </Wrapper>
+      );
+
+      await triggerDelete(container, user);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith(
+          "You don't have permission to perform this action."
         );
       });
     });

--- a/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
+++ b/__tests__/components/ui/dashboard/coaching-session-form.test.tsx
@@ -224,6 +224,22 @@ describe("CoachingSessionForm – handleSubmit error handling", () => {
     });
   });
 
+  it("shows the permission-denied toast on a 403", async () => {
+    mockUpdate.mockRejectedValue(makeEntityApiError(403));
+
+    const user = userEvent.setup();
+    renderUpdateForm();
+
+    await user.click(screen.getByRole("button", { name: /update session/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
   it("shows a generic toast for other API errors", async () => {
     mockUpdate.mockRejectedValue(makeEntityApiError(500));
 

--- a/__tests__/components/ui/dashboard/goals-overview-card.test.tsx
+++ b/__tests__/components/ui/dashboard/goals-overview-card.test.tsx
@@ -6,7 +6,18 @@ import { AssigneeScope } from "@/types/assigned-actions";
 import { GoalProgress } from "@/types/goal-progress";
 import type { GoalWithProgress } from "@/types/goal-progress";
 import { ItemStatus } from "@/types/general";
+import { EntityApiError } from "@/types/entity-api-error";
 import { Some, None } from "@/types/option";
+
+// A real EntityApiError carrying the given status, so the card's real
+// isForbiddenError (instanceof + status) narrows correctly.
+function apiError(status: number): EntityApiError {
+  const axiosLike = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Error", data: {} },
+  });
+  return new EntityApiError("GET", "/api/goal_progress", axiosLike);
+}
 
 // ── Hook mocks ─────────────────────────────────────────────────────────
 const mockUseGoalProgressList = vi.fn();
@@ -165,6 +176,25 @@ describe("GoalsOverviewCard", () => {
     expect(
       screen.getByText(/couldn[’']t load active goals\. please refresh/i)
     ).toBeInTheDocument();
+  });
+
+  it("renders the permission-denied message when goal_progress returns 403", () => {
+    setupDefault();
+    mockUseGoalProgressList.mockReturnValue({
+      goalsWithProgress: [],
+      isLoading: false,
+      isError: apiError(403),
+      refresh: vi.fn(),
+    });
+
+    render(<GoalsOverviewCard />);
+    expect(
+      screen.getByText("You don't have permission to perform this action.")
+    ).toBeInTheDocument();
+    // The generic fetch-failure copy must not also appear.
+    expect(
+      screen.queryByText(/couldn[’']t load active goals/i)
+    ).not.toBeInTheDocument();
   });
 
   it("renders the coachee name and the goal count when the user is the coach", () => {

--- a/__tests__/components/ui/dashboard/reschedule-series-dialog.test.tsx
+++ b/__tests__/components/ui/dashboard/reschedule-series-dialog.test.tsx
@@ -150,6 +150,27 @@ describe("RescheduleSeriesDialog - submit path", () => {
     consoleError.mockRestore();
   });
 
+  it("shows the permission-denied toast on a 403 from the backend", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockUpdate.mockRejectedValue(makeEntityApiError(403));
+
+    const { onClose, onRescheduled } = renderDialog();
+
+    submit();
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "You don't have permission to perform this action."
+      );
+    });
+    expect(onRescheduled).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+
+    consoleError.mockRestore();
+  });
+
   it("shows a generic failure toast for non-422 errors", async () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -8,7 +8,7 @@ import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useUserList } from "@/lib/api/organizations/users";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentUserRole } from "@/lib/hooks/use-current-user-role";
-import { Id, isForbiddenError } from "@/types/general";
+import { Id, isForbiddenError, viewPermissionDeniedMessage } from "@/types/general";
 import { ForbiddenError } from "@/components/ui/errors/forbidden-error";
 import { MemberContainer } from "@/components/ui/members/member-container";
 import { PageContainer } from "@/components/ui/page-container";
@@ -64,7 +64,7 @@ export default function MembersPage({
     return (
       <ForbiddenError
         title="Members Access Denied"
-        message="You don't have permission to view this organization's members."
+        message={viewPermissionDeniedMessage("this organization's members")}
       />
     );
   }

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -8,7 +8,8 @@ import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useUserList } from "@/lib/api/organizations/users";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { useCurrentUserRole } from "@/lib/hooks/use-current-user-role";
-import { Id } from "@/types/general";
+import { Id, isForbiddenError } from "@/types/general";
+import { ForbiddenError } from "@/components/ui/errors/forbidden-error";
 import { MemberContainer } from "@/components/ui/members/member-container";
 import { PageContainer } from "@/components/ui/page-container";
 import { shouldDenyMembersPageAccess } from "./access-control";
@@ -58,6 +59,15 @@ export default function MembersPage({
     refreshRelationships();
     refreshUsers();
   };
+
+  if (isForbiddenError(isRelationshipsError) || isForbiddenError(isUsersError)) {
+    return (
+      <ForbiddenError
+        title="Members Access Denied"
+        message="You don't have permission to view this organization's members."
+      />
+    );
+  }
 
   if (isRelationshipsError || isUsersError) {
     return (

--- a/src/components/ui/actions/actions-page-container.tsx
+++ b/src/components/ui/actions/actions-page-container.tsx
@@ -21,7 +21,12 @@ import type { Id, ItemStatus } from "@/types/general";
 import { applyTimeFilter } from "@/components/ui/actions/utils";
 import { ActionsPageHeader } from "@/components/ui/actions/actions-page-header";
 import { KanbanBoard } from "@/components/ui/actions/kanban-board";
-import { EntityApiError, PERMISSION_DENIED_MESSAGE, isForbiddenError } from "@/lib/api/entity-api";
+import {
+  EntityApiError,
+  PERMISSION_DENIED_MESSAGE,
+  viewPermissionDeniedMessage,
+  isForbiddenError,
+} from "@/lib/api/entity-api";
 import { ForbiddenError } from "@/components/ui/errors/forbidden-error";
 import { Skeleton } from "@/components/ui/skeleton";
 
@@ -316,7 +321,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
     return (
       <ForbiddenError
         title="Actions Access Denied"
-        message="You don't have permission to view these actions."
+        message={viewPermissionDeniedMessage("these actions")}
       />
     );
   }

--- a/src/components/ui/actions/actions-page-container.tsx
+++ b/src/components/ui/actions/actions-page-container.tsx
@@ -21,7 +21,8 @@ import type { Id, ItemStatus } from "@/types/general";
 import { applyTimeFilter } from "@/components/ui/actions/utils";
 import { ActionsPageHeader } from "@/components/ui/actions/actions-page-header";
 import { KanbanBoard } from "@/components/ui/actions/kanban-board";
-import { EntityApiError } from "@/lib/api/entity-api";
+import { EntityApiError, PERMISSION_DENIED_MESSAGE, isForbiddenError } from "@/lib/api/entity-api";
+import { ForbiddenError } from "@/components/ui/errors/forbidden-error";
 import { Skeleton } from "@/components/ui/skeleton";
 
 // Default filter values — used for initialization and URL cleanup
@@ -39,6 +40,17 @@ function parseEnum<T extends string>(
   if (!value) return fallback;
   const valid = new Set(Object.values(enumObj));
   return valid.has(value as T) ? (value as T) : fallback;
+}
+
+/** Maps a failed action mutation to a user-facing message. `action` reads as
+ * the verb phrase in "Failed to <action>." (e.g. "update status"). */
+function mutationErrorMessage(err: unknown, action: string): string {
+  if (err instanceof EntityApiError) {
+    if (err.isForbidden()) return PERMISSION_DENIED_MESSAGE;
+    if (err.isNetworkError())
+      return `Failed to ${action}. Connection to service was lost.`;
+  }
+  return `Failed to ${action}.`;
 }
 
 interface ActionsPageContainerProps {
@@ -210,11 +222,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         // No explicit refresh() — the optimistic update already moved the card
         // visually, and SWR will revalidate on its own schedule.
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to update status. Connection to service was lost.");
-        } else {
-          toast.error("Failed to update status.");
-        }
+        toast.error(mutationErrorMessage(err, "update status"));
         throw err; // Re-throw so the board can roll back optimistic updates
       }
     },
@@ -230,11 +238,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         await updateAction(id, { ...ctx.action, due_by: Some(newDueBy) });
         refresh();
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to update due date. Connection to service was lost.");
-        } else {
-          toast.error("Failed to update due date.");
-        }
+        toast.error(mutationErrorMessage(err, "update due date"));
       }
     },
     [actionsWithContext, updateAction, refresh]
@@ -249,11 +253,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         await updateAction(id, { ...ctx.action, assignee_ids: assigneeIds });
         refresh();
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to update assignees. Connection to service was lost.");
-        } else {
-          toast.error("Failed to update assignees.");
-        }
+        toast.error(mutationErrorMessage(err, "update assignees"));
       }
     },
     [actionsWithContext, updateAction, refresh]
@@ -274,11 +274,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         await updateAction(id, updated);
         refresh();
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to update action. Connection to service was lost.");
-        } else {
-          toast.error("Failed to update action.");
-        }
+        toast.error(mutationErrorMessage(err, "update action"));
       }
     },
     [actionsWithContext, updateAction, refresh]
@@ -294,11 +290,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         await updateAction(id, updated);
         refresh();
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to update goal link. Connection to service was lost.");
-        } else {
-          toast.error("Failed to update goal link.");
-        }
+        toast.error(mutationErrorMessage(err, "update goal link"));
       }
     },
     [actionsWithContext, updateAction, refresh]
@@ -310,11 +302,7 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
         await deleteAction(id);
         refresh();
       } catch (err) {
-        if (err instanceof EntityApiError && err.isNetworkError()) {
-          toast.error("Failed to delete action. Connection to service was lost.");
-        } else {
-          toast.error("Failed to delete action.");
-        }
+        toast.error(mutationErrorMessage(err, "delete action"));
       }
     },
     [deleteAction, refresh]
@@ -323,6 +311,15 @@ export function ActionsPageContainer({ locale }: ActionsPageContainerProps) {
   // ---------------------------------------------------------------------------
   // Render
   // ---------------------------------------------------------------------------
+
+  if (isForbiddenError(isError)) {
+    return (
+      <ForbiddenError
+        title="Actions Access Denied"
+        message="You don't have permission to view these actions."
+      />
+    );
+  }
 
   if (isError) {
     return (

--- a/src/components/ui/coaching-relationship-selector.tsx
+++ b/src/components/ui/coaching-relationship-selector.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Id } from "@/types/general";
+import { Id, isForbiddenError } from "@/types/general";
 import { sortRelationshipsByParticipantName } from "@/types/coaching-relationship";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
@@ -37,6 +37,8 @@ function CoachingRelationshipsSelectItems({
     useCoachingRelationshipList(organizationId);
 
   if (isLoading) return <div>Loading...</div>;
+  if (isForbiddenError(isError))
+    return <div>You don&apos;t have permission to view these relationships</div>;
   if (isError) return <div>Error loading coaching relationships</div>;
   if (!relationships?.length) return <div>No coaching relationships found</div>;
 

--- a/src/components/ui/coaching-relationship-selector.tsx
+++ b/src/components/ui/coaching-relationship-selector.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Id, isForbiddenError } from "@/types/general";
+import { Id, isForbiddenError, viewPermissionDeniedMessage } from "@/types/general";
 import { sortRelationshipsByParticipantName } from "@/types/coaching-relationship";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentCoachingRelationship } from "@/lib/hooks/use-current-coaching-relationship";
@@ -38,7 +38,7 @@ function CoachingRelationshipsSelectItems({
 
   if (isLoading) return <div>Loading...</div>;
   if (isForbiddenError(isError))
-    return <div>You don&apos;t have permission to view these relationships</div>;
+    return <div>{viewPermissionDeniedMessage("these relationships")}</div>;
   if (isError) return <div>Error loading coaching relationships</div>;
   if (!relationships?.length) return <div>No coaching relationships found</div>;
 

--- a/src/components/ui/coaching-sessions/coaching-session-title.tsx
+++ b/src/components/ui/coaching-sessions/coaching-session-title.tsx
@@ -28,6 +28,7 @@ import { EditableSessionTitle } from "./editable-session-title";
 import { PresenceIndicator } from "@/components/ui/presence-indicator";
 import { UserPresence } from "@/types/presence";
 import { RelationshipRole } from "@/types/relationship-role";
+import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 
 const CoachingSessionTitle: FC = () => {
   const { userSession } = useAuthStore((state) => state);
@@ -71,7 +72,9 @@ const CoachingSessionTitle: FC = () => {
     } catch (err) {
       console.error("Failed to save session title:", err);
       sonnerToast.error("Failed to save title", {
-        description: "An error occurred while saving the title.",
+        description: isForbiddenError(err)
+          ? PERMISSION_DENIED_MESSAGE
+          : "An error occurred while saving the title.",
       });
     } finally {
       setSave({ kind: "idle" });

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -33,7 +33,7 @@ import { useState, useMemo, useEffect, useRef, useCallback, type FormEvent } fro
 import { useRouter } from "next/navigation";
 import { defaultCoachingSession } from "@/types/coaching-session";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { EntityApiError, PERMISSION_DENIED_MESSAGE } from "@/types/entity-api-error";
+import { EntityApiError, PERMISSION_DENIED_MESSAGE, isForbiddenError } from "@/types/entity-api-error";
 import { toast } from "sonner";
 import { Provider } from "@/types/provider";
 import {
@@ -296,9 +296,7 @@ export default function CoachingSessionForm({
         console.error(`Failed to ${mode} coaching session:`, error);
       } else {
         let message: string;
-        if (error.isForbidden()) {
-          message = PERMISSION_DENIED_MESSAGE;
-        } else if (isDurationValidationError(error)) {
+        if (isDurationValidationError(error)) {
           message = error.data.message;
         } else if (error.isNetworkError()) {
           message = "Could not connect to server. Please check your internet connection.";
@@ -306,6 +304,8 @@ export default function CoachingSessionForm({
           message = "Could not create Google Meet link due to a connection error. Please try again.";
         } else if (error.status === 422) {
           message = `Couldn't ${mode === "update" ? "update" : "create"} ${isRecurring ? "the recurring sessions" : "the session"}. Please review the form and try again.`;
+        } else if (isForbiddenError(error)) {
+          message = PERMISSION_DENIED_MESSAGE;
         } else {
           message = `Failed to ${mode} coaching session. Please try again.`;
         }

--- a/src/components/ui/dashboard/coaching-session-form.tsx
+++ b/src/components/ui/dashboard/coaching-session-form.tsx
@@ -32,7 +32,7 @@ import { useState, useMemo, useEffect, useRef, useCallback, type FormEvent } fro
 import { useRouter } from "next/navigation";
 import { defaultCoachingSession } from "@/types/coaching-session";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { EntityApiError } from "@/types/entity-api-error";
+import { EntityApiError, PERMISSION_DENIED_MESSAGE } from "@/types/entity-api-error";
 import { toast } from "sonner";
 import { Provider } from "@/types/provider";
 import {
@@ -291,7 +291,9 @@ export default function CoachingSessionForm({
         router.push("/settings/integrations");
       } else {
         let message: string;
-        if (isDurationValidationError(error)) {
+        if (error.isForbidden()) {
+          message = PERMISSION_DENIED_MESSAGE;
+        } else if (isDurationValidationError(error)) {
           message = error.data.message;
         } else if (error.isNetworkError()) {
           message = "Could not connect to server. Please check your internet connection.";

--- a/src/components/ui/dashboard/goals-overview-card.tsx
+++ b/src/components/ui/dashboard/goals-overview-card.tsx
@@ -27,7 +27,7 @@ import { GoalProgress } from "@/types/goal-progress";
 import type { GoalWithProgress } from "@/types/goal-progress";
 import { AssigneeScope } from "@/types/assigned-actions";
 import { type Option, Some, None } from "@/types/option";
-import type { Id } from "@/types/general";
+import { type Id, isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 import { ProgressRing } from "@/components/ui/dashboard/progress-ring";
 import { GoalRow } from "@/components/ui/dashboard/goal-row";
 import { GoalsOverviewCardEmpty } from "@/components/ui/dashboard/goals-overview-card-empty";
@@ -112,14 +112,16 @@ function GoalsOverviewCardSkeleton() {
   );
 }
 
-function GoalsOverviewCardError() {
+function GoalsOverviewCardError({
+  message = "Couldn't load active goals. Please refresh.",
+}: {
+  message?: string;
+}) {
   return (
     <Card className="border shadow-none h-full flex flex-col">
       <CardContent className="p-4 sm:p-6 flex flex-col flex-1">
         <div className="flex flex-col items-center justify-center flex-1 text-center py-4">
-          <p className="text-sm text-destructive">
-            Couldn&apos;t load active goals. Please refresh.
-          </p>
+          <p className="text-sm text-destructive">{message}</p>
         </div>
       </CardContent>
     </Card>
@@ -171,7 +173,12 @@ export function GoalsOverviewCard() {
   // Inline error state — matches the UpcomingSessionCard pattern so the
   // dashboard layout stays intact when the backend request fails (network,
   // 404 from a relationship the caller isn't in, 5xx, etc.).
-  if (isError) return <GoalsOverviewCardError />;
+  if (isError)
+    return (
+      <GoalsOverviewCardError
+        message={isForbiddenError(isError) ? PERMISSION_DENIED_MESSAGE : undefined}
+      />
+    );
 
   // Resolve the user's role in this specific session — org-wide isACoach
   // can't disambiguate users who are coach in one relationship and coachee in

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -21,7 +21,11 @@ import { useRecurrenceState } from "@/lib/hooks/use-recurrence-state";
 import { useCoachingSessionSeriesMutation } from "@/lib/api/coaching-session-series";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { EntityApiError, PERMISSION_DENIED_MESSAGE } from "@/types/entity-api-error";
+import {
+  EntityApiError,
+  PERMISSION_DENIED_MESSAGE,
+  isForbiddenError,
+} from "@/types/entity-api-error";
 import {
   CoachingSessionSeries,
   seriesRecurrenceToEnd,
@@ -198,7 +202,7 @@ function RescheduleSeriesForm({
       onClose();
     } catch (error) {
       let message: string;
-      if (error instanceof EntityApiError && error.isForbidden()) {
+      if (isForbiddenError(error)) {
         message = PERMISSION_DENIED_MESSAGE;
       } else if (error instanceof EntityApiError && error.status === 422) {
         message = "Couldn't reschedule the series. Please review the form and try again.";

--- a/src/components/ui/dashboard/reschedule-series-dialog.tsx
+++ b/src/components/ui/dashboard/reschedule-series-dialog.tsx
@@ -21,7 +21,7 @@ import { useRecurrenceState } from "@/lib/hooks/use-recurrence-state";
 import { useCoachingSessionSeriesMutation } from "@/lib/api/coaching-session-series";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { EntityApiError } from "@/types/entity-api-error";
+import { EntityApiError, PERMISSION_DENIED_MESSAGE } from "@/types/entity-api-error";
 import {
   CoachingSessionSeries,
   seriesRecurrenceToEnd,
@@ -197,10 +197,14 @@ function RescheduleSeriesForm({
       onRescheduled?.();
       onClose();
     } catch (error) {
-      const message =
-        error instanceof EntityApiError && error.status === 422
-          ? "Couldn't reschedule the series. Please review the form and try again."
-          : "Failed to reschedule the series. Please try again.";
+      let message: string;
+      if (error instanceof EntityApiError && error.isForbidden()) {
+        message = PERMISSION_DENIED_MESSAGE;
+      } else if (error instanceof EntityApiError && error.status === 422) {
+        message = "Couldn't reschedule the series. Please review the form and try again.";
+      } else {
+        message = "Failed to reschedule the series. Please try again.";
+      }
       toast.error(message);
       console.error("Failed to reschedule coaching session series:", error);
       setIsSubmitting(false);

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -19,6 +19,7 @@ import { NewUser } from "@/types/user";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
+import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 
 interface AddMemberDialogProps {
   open: boolean;
@@ -75,7 +76,9 @@ export function AddMemberDialog({
       onOpenChange(false);
     } catch (error) {
       console.error("Error creating user:", error);
-      toast.error("There was an error adding the member");
+      toast.error(
+        isForbiddenError(error) ? PERMISSION_DENIED_MESSAGE : "There was an error adding the member"
+      );
     }
   };
 

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/select";
 import { CoachingRelationshipWithUserNames } from "@/types/coaching-relationship";
 import { AuthStore } from "@/lib/stores/auth-store";
-import { Id } from "@/types/general";
+import { Id, isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 import {
   InviteStatus,
   User,
@@ -113,7 +113,9 @@ export function MemberCard({
       onRefresh();
     } catch (err) {
       console.error("Error resending invitation:", err);
-      toast.error("Failed to resend invitation");
+      toast.error(
+        isForbiddenError(err) ? PERMISSION_DENIED_MESSAGE : "Failed to resend invitation"
+      );
     }
   };
 
@@ -179,7 +181,9 @@ export function MemberCard({
       setSelectedMember(null);
       setAssignedMember(null);
     } catch (error) {
-      toast.error(`Error assigning ${assignMode}`);
+      toast.error(
+        isForbiddenError(error) ? PERMISSION_DENIED_MESSAGE : `Error assigning ${assignMode}`
+      );
       console.error("Error creating coaching relationship:", error);
     }
   };

--- a/src/components/ui/members/member-profile-container.tsx
+++ b/src/components/ui/members/member-profile-container.tsx
@@ -12,6 +12,7 @@ import { Id } from "@/types/general"
 import { User, NewUserPassword } from "@/types/user"
 import { useUserPasswordMutation } from "@/lib/api/users"
 import { useLogoutUser } from "@/lib/hooks/use-logout-user"
+import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general"
 
 export function MemberProfileContainer({ userId }: { userId: Id }) {
     const { userId: currentUserId, setTimezone } = useAuthStore((state) => state)
@@ -35,7 +36,7 @@ export function MemberProfileContainer({ userId }: { userId: Id }) {
             
             refresh()
         } catch (error) {
-            toast("Error updating profile.")
+            toast(isForbiddenError(error) ? PERMISSION_DENIED_MESSAGE : "Error updating profile.")
             console.error("Error updating profile:", error)
         }
     }
@@ -47,7 +48,7 @@ export function MemberProfileContainer({ userId }: { userId: Id }) {
             // Logout the user when the password is updated
             logoutUser()
         } catch (error) {
-            toast("Error updating password.")
+            toast(isForbiddenError(error) ? PERMISSION_DENIED_MESSAGE : "Error updating password.")
             console.error("Error updating password:", error)
         }
     }

--- a/src/components/ui/settings/coaching-preferences-section.tsx
+++ b/src/components/ui/settings/coaching-preferences-section.tsx
@@ -20,6 +20,10 @@ import {
   isDurationValidationError,
   validateDurationMinutes,
 } from "@/types/coaching-session-duration";
+import {
+  isForbiddenError,
+  PERMISSION_DENIED_MESSAGE,
+} from "@/types/entity-api-error";
 
 const AUTOSAVE_DEBOUNCE_MS = 400;
 
@@ -56,7 +60,9 @@ export const CoachingPreferencesSection: FC = () => {
           });
           refresh();
         } catch (error) {
-          if (isDurationValidationError(error)) {
+          if (isForbiddenError(error)) {
+            toast.error(PERMISSION_DENIED_MESSAGE);
+          } else if (isDurationValidationError(error)) {
             toast.error(error.data.message);
           } else {
             toast.error("Couldn't save preferences. Please try again.");

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -13,6 +13,7 @@ import axios, { type AxiosRequestConfig } from "axios";
 export {
   EntityApiError,
   PERMISSION_DENIED_MESSAGE,
+  viewPermissionDeniedMessage,
   isForbiddenError,
 } from "@/types/general";
 

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -5,7 +5,11 @@ import { sessionGuard } from "@/lib/auth/session-guard";
 import axios, { type AxiosRequestConfig } from "axios";
 
 // Re-export EntityApiError for easy access
-export { EntityApiError } from "@/types/general";
+export {
+  EntityApiError,
+  PERMISSION_DENIED_MESSAGE,
+  isForbiddenError,
+} from "@/types/general";
 
 /** Standard wrapper for all backend API responses. */
 export interface ApiResponse<T> {

--- a/src/types/entity-api-error.ts
+++ b/src/types/entity-api-error.ts
@@ -125,4 +125,28 @@ export class EntityApiError extends Error {
   public isServiceUnavailable(): boolean {
     return this.status === 503;
   }
+
+  /**
+   * Returns true if this error represents a forbidden error (403): the user is
+   * authenticated but lacks permission for the resource. Distinct from 401,
+   * which the session guard handles by logging the user out.
+   */
+  public isForbidden(): boolean {
+    return this.status === 403;
+  }
+}
+
+/**
+ * Default user-facing message for a 403 Forbidden response. Use for permission
+ * failures where the user is authenticated but not allowed to perform the action.
+ */
+export const PERMISSION_DENIED_MESSAGE =
+  "You don't have permission to perform this action.";
+
+/**
+ * Type-safe check for a 403 Forbidden error from an arbitrary thrown value.
+ * Convenience for call sites that don't already narrow to EntityApiError.
+ */
+export function isForbiddenError(error: unknown): boolean {
+  return error instanceof EntityApiError && error.isForbidden();
 }

--- a/src/types/entity-api-error.ts
+++ b/src/types/entity-api-error.ts
@@ -147,6 +147,6 @@ export const PERMISSION_DENIED_MESSAGE =
  * Type-safe check for a 403 Forbidden error from an arbitrary thrown value.
  * Convenience for call sites that don't already narrow to EntityApiError.
  */
-export function isForbiddenError(error: unknown): boolean {
+export function isForbiddenError(error: unknown): error is EntityApiError {
   return error instanceof EntityApiError && error.isForbidden();
 }

--- a/src/types/entity-api-error.ts
+++ b/src/types/entity-api-error.ts
@@ -144,6 +144,14 @@ export const PERMISSION_DENIED_MESSAGE =
   "You don't have permission to perform this action.";
 
 /**
+ * User-facing message for a 403 on a read/view. Keeps the shared prefix and
+ * punctuation in one place while letting each call site name the resource, e.g.
+ * `viewPermissionDeniedMessage("these actions")`.
+ */
+export const viewPermissionDeniedMessage = (resource: string): string =>
+  `You don't have permission to view ${resource}.`;
+
+/**
  * Type-safe check for a 403 Forbidden error from an arbitrary thrown value.
  * Convenience for call sites that don't already narrow to EntityApiError.
  */

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -1,7 +1,11 @@
 import { DateTime } from "ts-luxon";
 
 // Re-export EntityApiError for backward compatibility
-export { EntityApiError } from "./entity-api-error";
+export {
+  EntityApiError,
+  PERMISSION_DENIED_MESSAGE,
+  isForbiddenError,
+} from "./entity-api-error";
 
 // A type alias for each entity's Id field
 export type Id = string;

--- a/src/types/general.ts
+++ b/src/types/general.ts
@@ -4,6 +4,7 @@ import { DateTime } from "ts-luxon";
 export {
   EntityApiError,
   PERMISSION_DENIED_MESSAGE,
+  viewPermissionDeniedMessage,
   isForbiddenError,
 } from "./entity-api-error";
 


### PR DESCRIPTION
## Description
The UI previously collapsed all backend failures into generic error messages, so a 403 Forbidden (user is authenticated but lacks permission) was indistinguishable from a network outage or a 5xx. This change adds a first-class 403 distinction so users see a clear "you don't have permission" message instead of a misleading generic error.

#### GitHub Issue: Closes #https://github.com/refactor-group/refactor-platform-rs/issues/358

### Changes
* Added `isForbidden()` (403 check) to `EntityApiError`, plus a shared `PERMISSION_DENIED_MESSAGE` constant and an `isForbiddenError(error: unknown)` type guard in `src/types/entity-api-error.ts`, re-exported through `@/types/general` and `@/lib/api/entity-api`.
* Page-level 403s now render the `ForbiddenError` component (Actions page, Members page) instead of a generic error block.
* Mutation/action 403s now surface the permission message via toast across the actions board, members (add/resend/assign/profile/password), dashboard (session form, reschedule series, goals overview card), coaching session title, relationship selector, and coaching preferences.
* Refactored the actions container's six duplicated network-error branches into a single `mutationErrorMessage()` helper.
* Added unit tests for the page-level 403 render and the mutation-level 403 toast.

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful captures:
* Actions page showing the **"Actions Access Denied"** `ForbiddenError` screen on a 403 data fetch.
* Members page showing the **"Members Access Denied"** `ForbiddenError` screen.
* A permission-denied toast ("You don't have permission to perform this action.") after a forbidden mutation (e.g. deleting an action).

### Testing Strategy
* `npx vitest run __tests__/components/ui/actions/actions-page-container.test.tsx` — all 18 pass, including the two new 403 cases.
* `npx tsc --noEmit` — clean.
* Manual: as a user without permission, trigger a forbidden read (Actions/Members page → access-denied screen) and a forbidden write (e.g. delete/update an action → permission toast); confirm network/validation/5xx errors still show their existing generic messages.

### Concerns
The backend PR that introduces the 401/403 split is https://github.com/refactor-group/refactor-platform-rs/pull/367
