### PR TITLE
Multi-organization membership

### DIFF
--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -70,7 +70,8 @@ const GRACE = {
 
 function renderDialog(
   currentUserRoleState?: UserRoleState,
-  organizationMembers?: User[]
+  organizationMembers?: User[],
+  canAddExistingMembers = true
 ) {
   render(
     <AddMemberDialog
@@ -80,6 +81,7 @@ function renderDialog(
       productName="Refactor Coach"
       currentUserRoleState={currentUserRoleState}
       organizationMembers={organizationMembers}
+      canAddExistingMembers={canAddExistingMembers}
     />
   );
 }
@@ -445,5 +447,34 @@ describe("AddMemberDialog – attaching an existing member", () => {
     expect(
       screen.getByRole("button", { name: "Add to organization" })
     ).toBeDisabled();
+  });
+});
+
+describe("AddMemberDialog – gating the existing-member tab", () => {
+  it("hides the tab from an admin who administers only one organization", () => {
+    // They would be able to open it and look people up, but every result is
+    // already a member, so the tab can only lead to a conflict.
+    renderDialog(adminRole, [GRACE], false);
+
+    expect(
+      screen.queryByRole("tab", { name: "Add existing member" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText("First Name")).toBeInTheDocument();
+  });
+
+  it("shows the tab when the lookup has candidates to offer", () => {
+    renderDialog(adminRole, [GRACE], true);
+
+    expect(
+      screen.getByRole("tab", { name: "Add existing member" })
+    ).toBeInTheDocument();
+  });
+
+  it("stays hidden for a plain member even when the lookup could offer candidates", () => {
+    renderDialog(memberRole, [GRACE], true);
+
+    expect(
+      screen.queryByRole("tab", { name: "Add existing member" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test-utils/msw-server";
 import { AddMemberDialog } from "@/components/ui/members/add-member-dialog";
-import { Role, type UserRoleState } from "@/types/user";
+import { Role, type User, type UserRoleState } from "@/types/user";
 import { toast } from "sonner";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -20,7 +20,7 @@ vi.mock("@/site.config", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { error: vi.fn(), success: vi.fn() },
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
 vi.mock("@/lib/hooks/use-current-organization", () => ({
@@ -61,13 +61,24 @@ function lookupHandler(matches: typeof ADA | null) {
   });
 }
 
-function renderDialog(currentUserRoleState?: UserRoleState) {
+/** Existing members offered as coach candidates. */
+const GRACE = {
+  id: "user-2",
+  first_name: "Grace",
+  last_name: "Hopper",
+} as unknown as User;
+
+function renderDialog(
+  currentUserRoleState?: UserRoleState,
+  organizationMembers?: User[]
+) {
   render(
     <AddMemberDialog
       open
       onOpenChange={vi.fn()}
       onMemberAdded={vi.fn()}
       currentUserRoleState={currentUserRoleState}
+      organizationMembers={organizationMembers}
     />
   );
 }
@@ -138,6 +149,111 @@ describe("AddMemberDialog – existing member lookup", () => {
     expect(
       screen.getByRole("button", { name: "Add to organization" })
     ).toBeEnabled();
+  });
+});
+
+describe("AddMemberDialog – pre-assigning a coach", () => {
+  /** Captures relationship POSTs. `relationshipFails` makes them 500. */
+  function captureRelationships(relationshipFails = false) {
+    const calls: unknown[] = [];
+    server.use(
+      lookupHandler(ADA),
+      http.post("*/organizations/:organizationId/users/:userId/role", () =>
+        HttpResponse.json({ status_code: 200, data: { id: ADA.id } })
+      ),
+      http.post("*/organizations/:organizationId/users", () =>
+        HttpResponse.json({ status_code: 201, data: { id: "user-new" } })
+      ),
+      http.post(
+        "*/organizations/:organizationId/coaching_relationships",
+        async ({ request }) => {
+          calls.push(await request.json());
+          return relationshipFails
+            ? HttpResponse.json({ error: "boom" }, { status: 500 })
+            : HttpResponse.json({ status_code: 201, data: { id: "rel-1" } });
+        }
+      )
+    );
+    return calls;
+  }
+
+  async function pickCoach(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByLabelText("Coach (optional)"));
+    await user.click(await screen.findByRole("option", { name: "Grace Hopper" }));
+  }
+
+  it("assigns the chosen coach to a newly created member", async () => {
+    const calls = captureRelationships();
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE]);
+
+    await user.type(screen.getByLabelText("First Name"), "Ada");
+    await user.type(screen.getByLabelText("Last Name"), "Lovelace");
+    await user.type(screen.getByLabelText("Display Name"), "Ada");
+    await user.type(screen.getByLabelText("Email"), "new@example.com");
+    await pickCoach(user);
+    await user.click(screen.getByRole("button", { name: "Create Member" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]).toEqual({ coach_id: GRACE.id, coachee_id: "user-new" });
+  });
+
+  it("assigns the chosen coach to an attached existing member", async () => {
+    const calls = captureRelationships();
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE]);
+
+    await findAda(user);
+    await pickCoach(user);
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0]).toEqual({ coach_id: GRACE.id, coachee_id: ADA.id });
+  });
+
+  it("does not create a relationship when no coach is chosen", async () => {
+    const calls = captureRelationships();
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE]);
+
+    await findAda(user);
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(calls).toHaveLength(0);
+  });
+
+  /// The member is already added at this point, so the add must not read as failed.
+  it("still reports the member as added when the coach assignment fails", async () => {
+    captureRelationships(true);
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE]);
+
+    await findAda(user);
+    await pickCoach(user);
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() => expect(toast.warning).toHaveBeenCalled());
+    expect(toast.warning).toHaveBeenCalledWith(
+      expect.stringContaining("Assign one from the member list")
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps the found user off their own coach list", async () => {
+    server.use(lookupHandler(ADA));
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE, ADA as unknown as User]);
+
+    await findAda(user);
+    await user.click(screen.getByLabelText("Coach (optional)"));
+
+    expect(
+      await screen.findByRole("option", { name: "Grace Hopper" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Ada Lovelace" })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test-utils/msw-server";
+import { AddMemberDialog } from "@/components/ui/members/add-member-dialog";
+import { Role, type UserRoleState } from "@/types/user";
+import { toast } from "sonner";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+// A concrete base URL so msw can match the real API calls this dialog makes.
+vi.mock("@/site.config", () => ({
+  siteConfig: {
+    env: {
+      backendServiceURL: "http://localhost:4000",
+      backendApiVersion: "1.0.0-test",
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+}));
+
+vi.mock("@/lib/timezone-utils", () => ({
+  getBrowserTimezone: () => "UTC",
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const adminRole: UserRoleState = {
+  status: "success",
+  role: Role.Admin,
+  hasAccess: true,
+};
+
+const memberRole: UserRoleState = {
+  status: "success",
+  role: Role.User,
+  hasAccess: true,
+};
+
+const ADA = {
+  id: "user-9",
+  first_name: "Ada",
+  last_name: "Lovelace",
+  email: "ada@example.com",
+};
+
+/** Lookup handler that only answers for Ada's exact email. */
+function lookupHandler(matches: typeof ADA | null) {
+  return http.get("*/users", ({ request }) => {
+    const email = new URL(request.url).searchParams.get("email");
+    const found = matches && email === matches.email ? [matches] : [];
+    return HttpResponse.json({ status_code: 200, data: found });
+  });
+}
+
+function renderDialog(currentUserRoleState?: UserRoleState) {
+  render(
+    <AddMemberDialog
+      open
+      onOpenChange={vi.fn()}
+      onMemberAdded={vi.fn()}
+      currentUserRoleState={currentUserRoleState}
+    />
+  );
+}
+
+/** Switches to the "Add existing member" tab, finds Ada, waits for the card. */
+async function findAda(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("tab", { name: "Add existing member" }));
+  await user.type(screen.getByLabelText("Email"), ADA.email);
+  await user.click(screen.getByRole("button", { name: "Find" }));
+  await screen.findByText("Ada Lovelace");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AddMemberDialog – add existing member gating", () => {
+  it("does not offer the existing-member mode to a plain member", () => {
+    renderDialog(memberRole);
+
+    expect(
+      screen.queryByRole("tab", { name: "Add existing member" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Create Member" })
+    ).toBeInTheDocument();
+  });
+
+  it("offers the existing-member mode to an org admin, not only a super admin", () => {
+    renderDialog(adminRole);
+
+    expect(
+      screen.getByRole("tab", { name: "Add existing member" })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("AddMemberDialog – existing member lookup", () => {
+  it("reports no match without hinting at visibility, and keeps the add button disabled", async () => {
+    server.use(lookupHandler(null));
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await user.click(screen.getByRole("tab", { name: "Add existing member" }));
+    await user.type(screen.getByLabelText("Email"), "nobody@example.com");
+    await user.click(screen.getByRole("button", { name: "Find" }));
+
+    expect(
+      await screen.findByText("No user found with that email.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeDisabled();
+  });
+
+  it("shows the returned name and email on a match", async () => {
+    server.use(lookupHandler(ADA));
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+
+    expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(screen.getByText(ADA.email)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeEnabled();
+  });
+});
+
+describe("AddMemberDialog – attaching an existing member", () => {
+  /** Captures every POST to the membership sub-route. */
+  function captureAttach() {
+    const calls: { url: string; body: unknown }[] = [];
+    server.use(
+      lookupHandler(ADA),
+      http.post(
+        "*/organizations/:organizationId/users/:userId/role",
+        async ({ request, params }) => {
+          calls.push({ url: request.url, body: await request.json() });
+          return HttpResponse.json({
+            status_code: 200,
+            data: { id: params.userId },
+          });
+        }
+      )
+    );
+    return calls;
+  }
+
+  it("posts the selected role to the member's /role sub-route", async () => {
+    const calls = captureAttach();
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+    await user.click(screen.getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "Admin" }));
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].url).toBe(
+      `http://localhost:4000/organizations/org-1/users/${ADA.id}/role`
+    );
+    expect(calls[0].body).toEqual({ role: "Admin" });
+  });
+
+  it("defaults to the Member option, which submits the User role", async () => {
+    const calls = captureAttach();
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+    expect(screen.getByRole("combobox")).toHaveTextContent("Member");
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() => expect(calls).toHaveLength(1));
+    expect(calls[0].body).toEqual({ role: "User" });
+  });
+
+  it("surfaces the already-a-member conflict rather than a generic error", async () => {
+    server.use(
+      lookupHandler(ADA),
+      http.post("*/organizations/:organizationId/users/:userId/role", () =>
+        HttpResponse.json(
+          {
+            error: "user_already_in_organization",
+            message: "This user is already a member of this organization.",
+          },
+          { status: 409 }
+        )
+      )
+    );
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+    await user.click(screen.getByRole("button", { name: "Add to organization" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "This user is already a member of this organization."
+      )
+    );
+  });
+});

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -141,6 +141,39 @@ describe("AddMemberDialog – existing member lookup", () => {
   });
 });
 
+describe("AddMemberDialog – discarding a found user", () => {
+  it("clears the found user when Clear is pressed", async () => {
+    server.use(lookupHandler(ADA));
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+    await user.click(screen.getByRole("button", { name: /^Clear / }));
+
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeDisabled();
+    expect(screen.getByLabelText("Email")).toHaveValue("");
+  });
+
+  /// Editing the email must invalidate the match it produced, or the add button
+  /// acts on a stale selection while the field shows a different address.
+  it("discards the found user when the email is edited after finding", async () => {
+    server.use(lookupHandler(ADA));
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await findAda(user);
+    await user.type(screen.getByLabelText("Email"), "x");
+
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeDisabled();
+  });
+});
+
 describe("AddMemberDialog – attaching an existing member", () => {
   /** Captures every POST to the membership sub-route. */
   function captureAttach() {

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -77,6 +77,7 @@ function renderDialog(
       open
       onOpenChange={vi.fn()}
       onMemberAdded={vi.fn()}
+      productName="Refactor Coach"
       currentUserRoleState={currentUserRoleState}
       organizationMembers={organizationMembers}
     />
@@ -390,5 +391,40 @@ describe("AddMemberDialog – attaching an existing member", () => {
         "This user is already a member of this organization."
       )
     );
+  });
+  it("discards a lookup that lands after the email was edited", async () => {
+    // The reply is held open so the email can be edited while it is in flight.
+    let release: () => void = () => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    server.use(
+      http.get("*/users", async ({ request }) => {
+        const email = new URL(request.url).searchParams.get("email");
+        if (email === ADA.email) await held;
+        return HttpResponse.json({
+          status_code: 200,
+          data: email === ADA.email ? [ADA] : [],
+        });
+      })
+    );
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await user.click(screen.getByRole("tab", { name: "Add existing member" }));
+    await user.type(screen.getByLabelText("Email"), ADA.email);
+    await user.click(screen.getByRole("button", { name: "Find" }));
+
+    // Retype before the reply arrives, then let it land.
+    await user.clear(screen.getByLabelText("Email"));
+    await user.type(screen.getByLabelText("Email"), "someone.else@example.com");
+    release();
+
+    // Ada must not reappear: the card belongs to an address the field no longer
+    // shows, and Add would attach her instead of the address on screen.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Add to organization" })).toBeDisabled()
+    );
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
   });
 });

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -267,10 +267,10 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     expect(toast.warning).not.toHaveBeenCalled();
   });
 
-  it("keeps the found user off their own coach list", async () => {
+  it("offers the organization's existing members as coaches", async () => {
     server.use(lookupHandler(ADA));
     const user = userEvent.setup();
-    renderDialog(adminRole, [GRACE, ADA as unknown as User]);
+    renderDialog(adminRole, [GRACE]);
 
     await findAda(user);
     await user.click(screen.getByLabelText("Coach (optional)"));
@@ -278,9 +278,6 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     expect(
       await screen.findByRole("option", { name: "Grace Hopper" })
     ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("option", { name: "Ada Lovelace" })
-    ).not.toBeInTheDocument();
   });
 });
 
@@ -426,5 +423,27 @@ describe("AddMemberDialog – attaching an existing member", () => {
       expect(screen.getByRole("button", { name: "Add to organization" })).toBeDisabled()
     );
     expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+  });
+  it("reports an existing member at lookup time instead of on submit", async () => {
+    server.use(lookupHandler(ADA));
+    const alreadyAMember = {
+      id: ADA.id,
+      first_name: ADA.first_name,
+      last_name: ADA.last_name,
+    } as unknown as User;
+    const user = userEvent.setup();
+    renderDialog(adminRole, [GRACE, alreadyAMember]);
+
+    await user.click(screen.getByRole("tab", { name: "Add existing member" }));
+    await user.type(screen.getByLabelText("Email"), ADA.email);
+    await user.click(screen.getByRole("button", { name: "Find" }));
+
+    await screen.findByText("This user is already a member of this organization.");
+    // No confirmation card, so there is no role or coach to fill in and no
+    // request to send.
+    expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeDisabled();
   });
 });

--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -153,28 +153,41 @@ describe("AddMemberDialog – existing member lookup", () => {
 });
 
 describe("AddMemberDialog – pre-assigning a coach", () => {
-  /** Captures relationship POSTs. `relationshipFails` makes them 500. */
-  function captureRelationships(relationshipFails = false) {
-    const calls: unknown[] = [];
+  /**
+   * Captures the create and attach bodies, plus any relationship POST. The
+   * coach now rides along with the member request, so a relationship POST would
+   * mean the old two-call contract had come back.
+   */
+  function captureAdds(addFails = false) {
+    const created: unknown[] = [];
+    const attached: unknown[] = [];
+    const relationships: unknown[] = [];
     server.use(
       lookupHandler(ADA),
-      http.post("*/organizations/:organizationId/users/:userId/role", () =>
-        HttpResponse.json({ status_code: 200, data: { id: ADA.id } })
+      http.post(
+        "*/organizations/:organizationId/users/:userId/role",
+        async ({ request }) => {
+          attached.push(await request.json());
+          return addFails
+            ? HttpResponse.json({ error: "boom" }, { status: 500 })
+            : HttpResponse.json({ status_code: 200, data: { id: ADA.id } });
+        }
       ),
-      http.post("*/organizations/:organizationId/users", () =>
-        HttpResponse.json({ status_code: 201, data: { id: "user-new" } })
-      ),
+      http.post("*/organizations/:organizationId/users", async ({ request }) => {
+        created.push(await request.json());
+        return addFails
+          ? HttpResponse.json({ error: "boom" }, { status: 500 })
+          : HttpResponse.json({ status_code: 201, data: { id: "user-new" } });
+      }),
       http.post(
         "*/organizations/:organizationId/coaching_relationships",
         async ({ request }) => {
-          calls.push(await request.json());
-          return relationshipFails
-            ? HttpResponse.json({ error: "boom" }, { status: 500 })
-            : HttpResponse.json({ status_code: 201, data: { id: "rel-1" } });
+          relationships.push(await request.json());
+          return HttpResponse.json({ status_code: 201, data: { id: "rel-1" } });
         }
       )
     );
-    return calls;
+    return { created, attached, relationships };
   }
 
   async function pickCoach(user: ReturnType<typeof userEvent.setup>) {
@@ -182,8 +195,8 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     await user.click(await screen.findByRole("option", { name: "Grace Hopper" }));
   }
 
-  it("assigns the chosen coach to a newly created member", async () => {
-    const calls = captureRelationships();
+  it("sends the chosen coach in the create request, not a second one", async () => {
+    const { created, relationships } = captureAdds();
     const user = userEvent.setup();
     renderDialog(adminRole, [GRACE]);
 
@@ -194,12 +207,16 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     await pickCoach(user);
     await user.click(screen.getByRole("button", { name: "Create Member" }));
 
-    await waitFor(() => expect(calls).toHaveLength(1));
-    expect(calls[0]).toEqual({ coach_id: GRACE.id, coachee_id: "user-new" });
+    await waitFor(() => expect(created).toHaveLength(1));
+    expect(created[0]).toMatchObject({
+      email: "new@example.com",
+      coach_id: GRACE.id,
+    });
+    expect(relationships).toHaveLength(0);
   });
 
-  it("assigns the chosen coach to an attached existing member", async () => {
-    const calls = captureRelationships();
+  it("sends the chosen coach in the attach request, not a second one", async () => {
+    const { attached, relationships } = captureAdds();
     const user = userEvent.setup();
     renderDialog(adminRole, [GRACE]);
 
@@ -207,25 +224,36 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     await pickCoach(user);
     await user.click(screen.getByRole("button", { name: "Add to organization" }));
 
-    await waitFor(() => expect(calls).toHaveLength(1));
-    expect(calls[0]).toEqual({ coach_id: GRACE.id, coachee_id: ADA.id });
+    await waitFor(() => expect(attached).toHaveLength(1));
+    expect(attached[0]).toEqual({ role: "User", coach_id: GRACE.id });
+    expect(relationships).toHaveLength(0);
   });
 
-  it("does not create a relationship when no coach is chosen", async () => {
-    const calls = captureRelationships();
+  it("omits coach_id entirely when no coach is chosen", async () => {
+    const { created, attached, relationships } = captureAdds();
     const user = userEvent.setup();
     renderDialog(adminRole, [GRACE]);
 
+    await user.type(screen.getByLabelText("First Name"), "Ada");
+    await user.type(screen.getByLabelText("Last Name"), "Lovelace");
+    await user.type(screen.getByLabelText("Display Name"), "Ada");
+    await user.type(screen.getByLabelText("Email"), "new@example.com");
+    await user.click(screen.getByRole("button", { name: "Create Member" }));
+    await waitFor(() => expect(created).toHaveLength(1));
+
     await findAda(user);
     await user.click(screen.getByRole("button", { name: "Add to organization" }));
+    await waitFor(() => expect(attached).toHaveLength(1));
 
-    await waitFor(() => expect(toast.success).toHaveBeenCalled());
-    expect(calls).toHaveLength(0);
+    expect(created[0]).not.toHaveProperty("coach_id");
+    expect(attached[0]).not.toHaveProperty("coach_id");
+    expect(relationships).toHaveLength(0);
   });
 
-  /// The member is already added at this point, so the add must not read as failed.
-  it("still reports the member as added when the coach assignment fails", async () => {
-    captureRelationships(true);
+  /// The coach now shares the member request's transaction, so its failure is
+  /// the add's failure. There is no partial state left to soften the message.
+  it("reports the whole add as failed when the request is rejected", async () => {
+    captureAdds(true);
     const user = userEvent.setup();
     renderDialog(adminRole, [GRACE]);
 
@@ -233,11 +261,9 @@ describe("AddMemberDialog – pre-assigning a coach", () => {
     await pickCoach(user);
     await user.click(screen.getByRole("button", { name: "Add to organization" }));
 
-    await waitFor(() => expect(toast.warning).toHaveBeenCalled());
-    expect(toast.warning).toHaveBeenCalledWith(
-      expect.stringContaining("Assign one from the member list")
-    );
-    expect(toast.error).not.toHaveBeenCalled();
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(toast.warning).not.toHaveBeenCalled();
   });
 
   it("keeps the found user off their own coach list", async () => {

--- a/__tests__/components/members/add-member-dialog.test.tsx
+++ b/__tests__/components/members/add-member-dialog.test.tsx
@@ -59,7 +59,12 @@ describe("AddMemberDialog write-freeze handling", () => {
       })
     );
     render(
-      <AddMemberDialog open onOpenChange={vi.fn()} onMemberAdded={vi.fn()} />
+      <AddMemberDialog
+        open
+        onOpenChange={vi.fn()}
+        onMemberAdded={vi.fn()}
+        productName="Refactor Coach"
+      />
     );
 
     fillForm();
@@ -75,7 +80,12 @@ describe("AddMemberDialog write-freeze handling", () => {
   it("shows the permission-denied message on a 403", async () => {
     mockCreateNested.mockRejectedValueOnce(apiError(403, { error: "forbidden" }));
     render(
-      <AddMemberDialog open onOpenChange={vi.fn()} onMemberAdded={vi.fn()} />
+      <AddMemberDialog
+        open
+        onOpenChange={vi.fn()}
+        onMemberAdded={vi.fn()}
+        productName="Refactor Coach"
+      />
     );
 
     fillForm();
@@ -91,7 +101,12 @@ describe("AddMemberDialog write-freeze handling", () => {
   it("falls back to the generic message for other errors", async () => {
     mockCreateNested.mockRejectedValueOnce(new Error("network"));
     render(
-      <AddMemberDialog open onOpenChange={vi.fn()} onMemberAdded={vi.fn()} />
+      <AddMemberDialog
+        open
+        onOpenChange={vi.fn()}
+        onMemberAdded={vi.fn()}
+        productName="Refactor Coach"
+      />
     );
 
     fillForm();

--- a/__tests__/components/members/member-card-remove.test.tsx
+++ b/__tests__/components/members/member-card-remove.test.tsx
@@ -169,4 +169,31 @@ describe("MemberCard – remove from organization", () => {
       )
     );
   });
+  it("surfaces the coaching-history conflict rather than a generic error", async () => {
+    captureDeletes(() =>
+      HttpResponse.json(
+        {
+          error: "user_has_coaching_history",
+          message:
+            "This member still has coaching sessions in this organization. Remove or reassign those sessions before removing them.",
+          details: {
+            coaching_relationship_count: 1,
+            coaching_session_count: 10,
+          },
+        },
+        { status: 409 }
+      )
+    );
+    const user = userEvent.setup();
+    renderCard();
+
+    await openRemoveDialog(user);
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "This member still has coaching sessions in this organization. Remove or reassign those sessions before removing them."
+      )
+    );
+  });
 });

--- a/__tests__/components/members/member-card-remove.test.tsx
+++ b/__tests__/components/members/member-card-remove.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test-utils/msw-server";
+import { MemberCard } from "@/components/ui/members/member-card";
+import { Role, type UserRoleState } from "@/types/user";
+import { toast } from "sonner";
+import { createMockUser } from "../../test-utils";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+// A concrete base URL so msw can match the real API calls this card makes.
+vi.mock("@/site.config", () => ({
+  siteConfig: {
+    env: {
+      backendServiceURL: "http://localhost:4000",
+      backendApiVersion: "1.0.0-test",
+    },
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+}));
+
+const mockAuthStore = vi.fn();
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector(mockAuthStore()),
+}));
+
+vi.mock("@/lib/api/coaching-relationships", () => ({
+  useCoachingRelationshipMutation: () => ({ createNested: vi.fn() }),
+}));
+
+// Role derivation is pure and covered elsewhere; stub it so the card renders
+// without needing full relationship fixtures.
+vi.mock("@/lib/utils/user-roles", () => ({
+  getUserDisplayRoles: () => [],
+  getUserCoaches: () => [],
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const adminRole: UserRoleState = {
+  status: "success",
+  role: Role.Admin,
+  hasAccess: true,
+};
+
+function renderCard() {
+  const cardUser = createMockUser({
+    id: "user-1",
+    first_name: "Ada",
+    last_name: "Lovelace",
+    invite_status: null,
+  });
+  render(
+    <MemberCard
+      user={cardUser}
+      currentUserId="me"
+      userRelationships={[]}
+      onRefresh={vi.fn()}
+      users={[cardUser]}
+      currentUserRoleState={adminRole}
+    />
+  );
+}
+
+/**
+ * Records both the membership DELETE and the account DELETE, so a regression
+ * that removes the whole account instead of the membership is visible.
+ */
+function captureDeletes(membershipResponse: () => Response) {
+  const roleCalls: string[] = [];
+  const accountCalls: string[] = [];
+  server.use(
+    http.delete(
+      "*/organizations/:organizationId/users/:userId/role",
+      ({ request }) => {
+        roleCalls.push(request.url);
+        return membershipResponse();
+      }
+    ),
+    http.delete("*/organizations/:organizationId/users/:userId", ({ request }) => {
+      accountCalls.push(request.url);
+      return HttpResponse.json({ status_code: 200, data: null });
+    })
+  );
+  return { roleCalls, accountCalls };
+}
+
+async function openRemoveDialog(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button")); // row actions menu (icon-only)
+  await user.click(await screen.findByText("Remove from organization"));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  mockAuthStore.mockReturnValue({ isACoach: true, userSession: { id: "me" } });
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MemberCard – remove from organization", () => {
+  it("offers the action to an admin viewing another member", async () => {
+    const user = userEvent.setup();
+    renderCard();
+
+    await user.click(screen.getByRole("button"));
+
+    expect(
+      await screen.findByText("Remove from organization")
+    ).toBeInTheDocument();
+  });
+
+  it("deletes the membership sub-route, never the member's account", async () => {
+    const { roleCalls, accountCalls } = captureDeletes(() =>
+      HttpResponse.json({ status_code: 200, data: null })
+    );
+    const user = userEvent.setup();
+    renderCard();
+
+    await openRemoveDialog(user);
+    expect(
+      await screen.findByText(
+        /Remove them from this organization only\. Their account and any other organizations are unaffected\./
+      )
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => expect(roleCalls).toHaveLength(1));
+    expect(roleCalls[0]).toBe(
+      "http://localhost:4000/organizations/org-1/users/user-1/role"
+    );
+    expect(roleCalls[0].endsWith("/role")).toBe(true);
+    expect(accountCalls).toEqual([]);
+  });
+
+  it("surfaces the last-admin conflict rather than a generic error", async () => {
+    captureDeletes(() =>
+      HttpResponse.json(
+        {
+          error: "last_organization_admin",
+          message:
+            "This user is the only admin of this organization. Assign another admin before removing them.",
+        },
+        { status: 409 }
+      )
+    );
+    const user = userEvent.setup();
+    renderCard();
+
+    await openRemoveDialog(user);
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "This user is the only admin of this organization. Assign another admin before removing them."
+      )
+    );
+  });
+});

--- a/__tests__/components/members/member-card-remove.test.tsx
+++ b/__tests__/components/members/member-card-remove.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -30,7 +31,7 @@ vi.mock("@/lib/hooks/use-current-organization", () => ({
 
 const mockAuthStore = vi.fn();
 vi.mock("@/lib/providers/auth-store-provider", () => ({
-  AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  AuthStoreProvider: ({ children }: { children: ReactNode }) => children,
   useAuthStore: (selector: (state: unknown) => unknown) =>
     selector(mockAuthStore()),
 }));

--- a/__tests__/components/organization-switcher.test.tsx
+++ b/__tests__/components/organization-switcher.test.tsx
@@ -1,20 +1,25 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { describe, it, expect, vi } from 'vitest'
 import { OrganizationSwitcher } from '@/components/ui/organization-switcher'
 import { TestProviders } from '@/test-utils/providers'
 
-// Mock the organization list hook
+const { ORGANIZATIONS } = vi.hoisted(() => ({
+  ORGANIZATIONS: [
+    { id: 'org-1', name: 'Acme Corp', logo: '/logo1.png' },
+    { id: 'org-2', name: 'Beta Inc', logo: '/logo2.png' },
+  ],
+}))
+
+// Mock the organization list hook. useOrganization resolves by id, as the real
+// hook does, so the trigger reflects whichever organization is selected.
 vi.mock('@/lib/api/organizations', () => ({
   useOrganizationList: () => ({
-    organizations: [
-      { id: 'org-1', name: 'Acme Corp', logo: '/logo1.png' },
-      { id: 'org-2', name: 'Beta Inc', logo: '/logo2.png' },
-    ],
+    organizations: ORGANIZATIONS,
     isLoading: false,
     isError: false,
   }),
-  useOrganization: () => ({
-    organization: null,
+  useOrganization: (id: string) => ({
+    organization: ORGANIZATIONS.find((org) => org.id === id) ?? null,
     isLoading: false,
     isError: false,
     refresh: vi.fn(),
@@ -38,6 +43,13 @@ Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
   writable: true,
 })
 
+// The trigger renders the selected organization's name as well, so assertions
+// about the dropdown have to be scoped to the list to stay unambiguous.
+async function openList() {
+  fireEvent.click(screen.getByRole('combobox'))
+  return screen.findByRole('listbox')
+}
+
 describe('OrganizationSwitcher', () => {
   it('should render with default state', () => {
     render(
@@ -56,30 +68,30 @@ describe('OrganizationSwitcher', () => {
       </TestProviders>
     )
 
-    fireEvent.click(screen.getByRole('combobox'))
+    const list = await openList()
 
     await waitFor(() => {
-      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
-      expect(screen.getByText('Beta Inc')).toBeInTheDocument()
+      expect(within(list).getByText('Acme Corp')).toBeInTheDocument()
+      expect(within(list).getByText('Beta Inc')).toBeInTheDocument()
     })
   })
 
   it('should call onSelect when organization is selected', async () => {
     const onSelect = vi.fn()
-    
+
     render(
       <TestProviders>
         <OrganizationSwitcher onSelect={onSelect} />
       </TestProviders>
     )
 
-    fireEvent.click(screen.getByRole('combobox'))
-    
+    const list = await openList()
+
     await waitFor(() => {
-      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+      expect(within(list).getByText('Acme Corp')).toBeInTheDocument()
     })
 
-    fireEvent.click(screen.getByText('Acme Corp'))
+    fireEvent.click(within(list).getByText('Acme Corp'))
 
     expect(onSelect).toHaveBeenCalledWith('org-1')
   })
@@ -91,14 +103,67 @@ describe('OrganizationSwitcher', () => {
       </TestProviders>
     )
 
-    fireEvent.click(screen.getByRole('combobox'))
+    const list = await openList()
 
     const searchInput = screen.getByPlaceholderText('Search organization...')
     fireEvent.change(searchInput, { target: { value: 'Acme' } })
 
     await waitFor(() => {
-      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
-      expect(screen.queryByText('Beta Inc')).not.toBeInTheDocument()
+      expect(within(list).getByText('Acme Corp')).toBeInTheDocument()
+      expect(within(list).queryByText('Beta Inc')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows the selected organization\'s initials on the trigger avatar', async () => {
+    render(
+      <TestProviders>
+        <OrganizationSwitcher />
+      </TestProviders>
+    )
+
+    // Auto-initializes to the first organization, Acme Corp.
+    const trigger = screen.getByRole('combobox')
+    await waitFor(() => {
+      expect(within(trigger).getByText('AC')).toBeInTheDocument()
+    })
+    expect(within(trigger).queryByText('RG')).not.toBeInTheDocument()
+  })
+
+  it('updates the trigger avatar initials when a different organization is selected', async () => {
+    render(
+      <TestProviders>
+        <OrganizationSwitcher />
+      </TestProviders>
+    )
+
+    const trigger = screen.getByRole('combobox')
+    await waitFor(() => {
+      expect(within(trigger).getByText('AC')).toBeInTheDocument()
+    })
+
+    const list = await openList()
+    await waitFor(() => {
+      expect(within(list).getByText('Beta Inc')).toBeInTheDocument()
+    })
+    fireEvent.click(within(list).getByText('Beta Inc'))
+
+    await waitFor(() => {
+      expect(within(trigger).getByText('BI')).toBeInTheDocument()
+    })
+    expect(within(trigger).queryByText('AC')).not.toBeInTheDocument()
+  })
+
+  it('gives each organization in the list its own initials', async () => {
+    render(
+      <TestProviders>
+        <OrganizationSwitcher />
+      </TestProviders>
+    )
+
+    const list = await openList()
+    await waitFor(() => {
+      expect(within(list).getByText('AC')).toBeInTheDocument()
+      expect(within(list).getByText('BI')).toBeInTheDocument()
     })
   })
 
@@ -109,16 +174,16 @@ describe('OrganizationSwitcher', () => {
       </TestProviders>
     )
 
-    fireEvent.click(screen.getByRole('combobox'))
+    const list = await openList()
 
     const searchInput = screen.getByPlaceholderText('Search organization...')
-    
+
     // Test arrow down navigation
     fireEvent.keyDown(searchInput, { key: 'ArrowDown' })
-    
+
     // The first organization should be focused (implementation depends on actual focus behavior)
     await waitFor(() => {
-      expect(screen.getByText('Acme Corp')).toBeInTheDocument()
+      expect(within(list).getByText('Acme Corp')).toBeInTheDocument()
     })
   })
 })

--- a/__tests__/e2e/existing-member-tab-live.spec.ts
+++ b/__tests__/e2e/existing-member-tab-live.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Live end-to-end for the add-existing-member tab gate, against the real backend
+ * and the seeded local users.
+ *
+ * Read-only for the @single-org cases. The @multi-org cases require an operator
+ * to have promoted ehab to Admin of Refactor Group first (he already admins
+ * BigTable), which the runner script does around them.
+ */
+
+const PASSWORD = "password";
+const ORG = {
+  refactorGroup: "617e8b03-0c1c-49a6-b151-74e54e9e2de4",
+  bigTable: "9c5cd245-cf67-432c-b78c-2f567cae99f2",
+  acme: "f67343c9-6c15-4878-a171-be321fdaf34b",
+};
+
+test.skip(
+  !process.env.LIVE_E2E,
+  "live end-to-end, set LIVE_E2E=1 with the seeded local database"
+);
+test.describe.configure({ mode: "serial" });
+
+async function login(page: Page, email: string, password = PASSWORD) {
+  await page.goto("/");
+  await page.fill("#email", email);
+  await page.fill("#password", password);
+  await page.click('button:has-text("Sign In with Email")');
+  await page.waitForURL(/dashboard/, { timeout: 20000 });
+}
+
+async function openMembers(page: Page, organizationId: string) {
+  await page.goto(`/organizations/${organizationId}/members`);
+  await page.click('button:has-text("Add Member")');
+  await expect(page.getByRole("heading", { name: "Add New Member" })).toBeVisible();
+}
+
+const existingTab = (page: Page) =>
+  page.getByRole("tab", { name: "Add existing member" });
+
+// ── Tab hidden: admins of exactly one organization ───────────────────────────
+
+test("@single-org jim, admin of Refactor Group only, sees no existing-member tab", async ({
+  page,
+}) => {
+  await login(page, "jim@refactorgroup.com");
+  await openMembers(page, ORG.refactorGroup);
+
+  await expect(existingTab(page)).toHaveCount(0);
+  // The create form is still fully available.
+  await expect(page.getByLabel("First Name")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Create Member" })).toBeVisible();
+});
+
+test("@single-org ehab, admin of BigTable only, sees no existing-member tab", async ({
+  page,
+}) => {
+  await login(page, "ehab.bandar@gmail.com");
+  await openMembers(page, ORG.bigTable);
+
+  await expect(existingTab(page)).toHaveCount(0);
+});
+
+test("@single-org caleb, admin of Acme only, sees no existing-member tab", async ({
+  page,
+}) => {
+  await login(page, "calebbourg2@gmail.com");
+  await openMembers(page, ORG.acme);
+
+  await expect(existingTab(page)).toHaveCount(0);
+});
+
+test("@single-org a plain member cannot reach the members page at all", async ({
+  page,
+}) => {
+  await login(page, "james.hodapp@gmail.com");
+  await page.goto(`/organizations/${ORG.refactorGroup}/members`);
+
+  // Access control denies the page outright, so there is no dialog to gate.
+  await expect(page.getByRole("button", { name: "Add Member" })).toHaveCount(0);
+});
+
+// ── Tab shown: super admin ───────────────────────────────────────────────────
+
+test("@single-org the super admin sees the existing-member tab", async ({ page }) => {
+  await login(page, "admin@refactorcoach.com");
+  await openMembers(page, ORG.refactorGroup);
+
+  await expect(existingTab(page)).toBeVisible();
+});
+
+// ── Lookup outcomes, exercised as the super admin ────────────────────────────
+
+test("@single-org an unknown email reports no user found", async ({ page }) => {
+  await login(page, "admin@refactorcoach.com");
+  await openMembers(page, ORG.refactorGroup);
+  await existingTab(page).click();
+
+  await page.fill("#lookupEmail", "nobody.here@nowhere.test");
+  await page.click('button:has-text("Find")');
+
+  await expect(page.getByText("No user found with that email.")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Add to organization" })
+  ).toBeDisabled();
+});
+
+test("@single-org an existing member is rejected at lookup, not on submit", async ({
+  page,
+}) => {
+  await login(page, "admin@refactorcoach.com");
+  await openMembers(page, ORG.refactorGroup);
+  await existingTab(page).click();
+
+  // james is already a member of Refactor Group.
+  await page.fill("#lookupEmail", "james.hodapp@gmail.com");
+  await page.click('button:has-text("Find")');
+
+  await expect(
+    page.getByText("This user is already a member of this organization.")
+  ).toBeVisible();
+  // Scoped to the dialog: his member card is on the page behind it.
+  await expect(
+    page.getByRole("dialog").getByText("Jim Hodapp", { exact: true })
+  ).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Add to organization" })
+  ).toBeDisabled();
+});
+
+test("@single-org a findable non-member shows a card that Clear discards", async ({
+  page,
+}) => {
+  await login(page, "admin@refactorcoach.com");
+  await openMembers(page, ORG.bigTable);
+  await existingTab(page).click();
+
+  // caleb is in Acme and Refactor Group, not BigTable.
+  await page.fill("#lookupEmail", "calebbourg2@gmail.com");
+  await page.click('button:has-text("Find")');
+
+  await expect(page.getByText("Caleb Bourg")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Add to organization" })
+  ).toBeEnabled();
+
+  await page.getByRole("button", { name: /^Clear/ }).click();
+  await expect(page.getByText("Caleb Bourg")).toHaveCount(0);
+  await expect(
+    page.getByRole("button", { name: "Add to organization" })
+  ).toBeDisabled();
+});
+
+// ── Multi-org admin: the driving use case ────────────────────────────────────
+
+test("@multi-org ehab, now admin of two organizations, sees the tab", async ({
+  page,
+}) => {
+  await login(page, "ehab.bandar@gmail.com");
+  await openMembers(page, ORG.bigTable);
+
+  await expect(existingTab(page)).toBeVisible();
+});
+
+test("@multi-org ehab adds a Refactor Group member into BigTable", async ({
+  page,
+}) => {
+  await login(page, "ehab.bandar@gmail.com");
+  await openMembers(page, ORG.bigTable);
+  await existingTab(page).click();
+
+  // caleb is a Refactor Group member, and ehab now administers Refactor Group,
+  // so caleb is visible to him and is not yet in BigTable.
+  await page.fill("#lookupEmail", "calebbourg2@gmail.com");
+  await page.click('button:has-text("Find")');
+  await expect(page.getByText("Caleb Bourg")).toBeVisible();
+
+  await page.click('button:has-text("Add to organization")');
+
+  await expect(page.getByRole("dialog")).toBeHidden({ timeout: 20000 });
+  await expect(page.getByText("Caleb Bourg").first()).toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/__tests__/e2e/multi-org-live.spec.ts
+++ b/__tests__/e2e/multi-org-live.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Live end-to-end against the real backend and database, unlike the other e2e
+ * specs in this directory which mock the API. Requires the backend on :4000 and
+ * a seeded dev database.
+ */
+
+const PASSWORD = "password";
+const SUPER_ADMIN = "admin@refactorcoach.com";
+const EHAB = "ehab.bandar@gmail.com";
+const REFACTOR_GROUP = "617e8b03-0c1c-49a6-b151-74e54e9e2de4";
+
+async function login(page: Page, email: string) {
+  await page.goto("/");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.click('button:has-text("Sign In with Email")');
+  await page.waitForURL(/dashboard/, { timeout: 20000 });
+}
+
+async function openAddMember(page: Page, organizationId: string) {
+  await page.goto(`/organizations/${organizationId}/members`);
+  await page.click('button:has-text("Add Member")');
+  await expect(page.getByRole("heading", { name: "Add New Member" })).toBeVisible();
+}
+
+test.describe.configure({ mode: "serial" });
+
+// Not idempotent: it creates Ehab, BigTable and a session, so a second run fails
+// on the duplicate email. Opt in with LIVE_E2E=1 against a freshly seeded database.
+test.skip(
+  !process.env.LIVE_E2E,
+  "live end-to-end, set LIVE_E2E=1 with a freshly seeded database"
+);
+
+test("a: super admin adds Ehab to Refactor Group as a coachee", async ({ page }) => {
+  await login(page, SUPER_ADMIN);
+  await openAddMember(page, REFACTOR_GROUP);
+
+  await page.fill("#firstName", "Ehab");
+  await page.fill("#lastName", "Bandar");
+  await page.fill("#displayName", "Ehab Bandar");
+  await page.fill("#email", EHAB);
+
+  // The new coach picker makes him a coachee in the same request. Exact match:
+  // the org also has a "Jim Hodapp (Refactor Group)" member.
+  await page.click("#coach");
+  await page.getByRole("option", { name: "Jim Hodapp", exact: true }).click();
+
+  await page.click('button:has-text("Create Member")');
+
+  await expect(page.getByText("Ehab Bandar").first()).toBeVisible({ timeout: 15000 });
+});
+
+test("b: super admin creates the BigTable organization", async ({ page }) => {
+  await login(page, SUPER_ADMIN);
+  await page.goto("/admin/organizations");
+  await page.click('button:has-text("Add organization")');
+  await page.fill("#name", "BigTable");
+  await page.click('button:has-text("Create organization")');
+
+  await expect(page.getByText("BigTable").first()).toBeVisible({ timeout: 15000 });
+});
+
+test("c: super admin adds Ehab to BigTable as an existing member, role Admin", async ({
+  page,
+}) => {
+  await login(page, SUPER_ADMIN);
+
+  // Resolve BigTable's id from the API rather than guessing it.
+  const orgs = await page.evaluate(async () => {
+    const res = await fetch("http://localhost:4000/organizations", {
+      headers: { "x-version": "1.0.0-beta1" },
+      credentials: "include",
+    });
+    return (await res.json()).data as { id: string; name: string }[];
+  });
+  const bigTable = orgs.find((o) => o.name === "BigTable");
+  expect(bigTable, "BigTable must exist from step b").toBeTruthy();
+
+  await openAddMember(page, bigTable!.id);
+  await page.getByRole("tab", { name: "Add existing member" }).click();
+  await page.fill("#lookupEmail", EHAB);
+  await page.click('button:has-text("Find")');
+
+  await expect(page.getByText("Ehab Bandar")).toBeVisible({ timeout: 15000 });
+
+  await page.click("#existingRole");
+  await page.getByRole("option", { name: "Admin" }).click();
+  await page.click('button:has-text("Add to organization")');
+
+  await expect(page.getByText("Ehab Bandar").first()).toBeVisible({ timeout: 15000 });
+});
+
+test("d: Ehab, as BigTable admin, adds Jim to BigTable with himself as coach", async ({
+  page,
+}) => {
+  await login(page, EHAB);
+
+  const orgs = await page.evaluate(async () => {
+    const res = await fetch("http://localhost:4000/organizations", {
+      headers: { "x-version": "1.0.0-beta1" },
+      credentials: "include",
+    });
+    return (await res.json()).data as { id: string; name: string }[];
+  });
+  const bigTable = orgs.find((o) => o.name === "BigTable");
+  expect(bigTable, "Ehab must see BigTable, which he administers").toBeTruthy();
+
+  await openAddMember(page, bigTable!.id);
+  await page.getByRole("tab", { name: "Add existing member" }).click();
+  await page.fill("#lookupEmail", "james.hodapp@gmail.com");
+  await page.click('button:has-text("Find")');
+
+  // Records what Ehab actually sees, which is the point of this step.
+  const notFound = page.getByText("No user found with that email.");
+  const found = page.getByText("Jim Hodapp");
+  await expect(notFound.or(found).first()).toBeVisible({ timeout: 15000 });
+
+  // FINDING: Ehab administers only BigTable, which is empty, and he is a plain
+  // member (not admin) of Refactor Group. So he shares no administered org with
+  // Jim and the lookup correctly hides him. A brand new organization is a
+  // bootstrapping dead end for its own admin: nobody is in it yet, so there is
+  // nobody they are allowed to add. Pinned so a future scope change is deliberate.
+  await expect(notFound).toBeVisible();
+});
+
+test("d2: workaround, the super admin adds Jim to BigTable with Ehab as coach", async ({
+  page,
+}) => {
+  await login(page, SUPER_ADMIN);
+
+  const orgs = await page.evaluate(async () => {
+    const res = await fetch("http://localhost:4000/organizations", {
+      headers: { "x-version": "1.0.0-beta1" },
+      credentials: "include",
+    });
+    return (await res.json()).data as { id: string; name: string }[];
+  });
+  const bigTable = orgs.find((o) => o.name === "BigTable")!;
+
+  await openAddMember(page, bigTable.id);
+  await page.getByRole("tab", { name: "Add existing member" }).click();
+  await page.fill("#lookupEmail", "james.hodapp@gmail.com");
+  await page.click('button:has-text("Find")');
+  await expect(page.getByText("Jim Hodapp", { exact: true })).toBeVisible({ timeout: 15000 });
+
+  await page.click("#coach");
+  await page.getByRole("option", { name: "Ehab Bandar", exact: true }).click();
+  await page.click('button:has-text("Add to organization")');
+
+  await expect(page.getByText("Jim Hodapp").first()).toBeVisible({ timeout: 15000 });
+});
+
+test("e: Ehab schedules a BigTable coaching session with Jim", async ({ page }) => {
+  await login(page, EHAB);
+
+  // The dashboard opens on Refactor Group, where Ehab is only a coachee and so
+  // has no Add New button. Switch to BigTable, where he is admin and Jim's coach.
+  await page.getByRole("combobox").first().click();
+  await page.getByRole("option", { name: /BigTable/ }).click();
+  await expect(page.getByRole("combobox").first()).toContainText("BigTable");
+
+  await page.click('button:has-text("Add New")');
+  await page.getByRole("menuitem", { name: /session/i }).click();
+
+  await page.click("#coachee-select");
+  await page.getByRole("option", { name: "Jim Hodapp", exact: true }).click();
+
+  // Create Session stays disabled until a date and time are both chosen.
+  await page.getByRole("button", { name: "Go to next month" }).click();
+  await page.getByRole("gridcell", { name: "15", exact: true }).click();
+  await page.fill("#session-time", "10:00");
+
+  const submit = page.getByRole("button", { name: "Create Session" });
+  await expect(submit).toBeEnabled({ timeout: 10000 });
+  await submit.click();
+
+  // Assert the session actually exists, not merely that the word "session" is on
+  // screen: the dashboard already says "Coaching Sessions", which makes a loose
+  // text assertion pass against a no-op.
+  await expect(page.getByRole("dialog")).toBeHidden({ timeout: 20000 });
+
+  const sessions = await page.evaluate(async () => {
+    const orgRes = await fetch("http://localhost:4000/organizations", {
+      headers: { "x-version": "1.0.0-beta1" },
+      credentials: "include",
+    });
+    const orgs = (await orgRes.json()).data as { id: string; name: string }[];
+    const bigTable = orgs.find((o) => o.name === "BigTable")!;
+    const relRes = await fetch(
+      `http://localhost:4000/organizations/${bigTable.id}/coaching_relationships`,
+      { headers: { "x-version": "1.0.0-beta1" }, credentials: "include" }
+    );
+    const rels = (await relRes.json()).data as { id: string }[];
+    const sesRes = await fetch(
+      `http://localhost:4000/coaching_sessions?coaching_relationship_id=${rels[0].id}&from_date=2000-01-01&to_date=2100-01-01`,
+      { headers: { "x-version": "1.0.0-beta1" }, credentials: "include" }
+    );
+    return (await sesRes.json()).data as unknown[];
+  });
+
+  expect(sessions.length, "a BigTable session must exist for Ehab and Jim").toBeGreaterThan(0);
+});

--- a/__tests__/e2e/multi-org-scoping-live.spec.ts
+++ b/__tests__/e2e/multi-org-scoping-live.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Live end-to-end against the real backend and database, unlike the other e2e
+ * specs in this directory which mock the API. Read-only, so unlike
+ * multi-org-live.spec.ts it is repeatable: it creates nothing and asserts on
+ * data an earlier run already seeded.
+ *
+ * Requires the backend on :4000, the frontend on :3000, and ehab.bandar@gmail.com
+ * belonging to both Refactor Group and BigTable with his sessions in BigTable.
+ */
+
+const PASSWORD = "password";
+const EHAB = "ehab.bandar@gmail.com";
+
+test.skip(
+  !process.env.LIVE_E2E,
+  "live end-to-end, set LIVE_E2E=1 with a seeded multi-org database"
+);
+
+async function login(page: Page, email: string) {
+  await page.goto("/");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.click('button:has-text("Sign In with Email")');
+  await page.waitForURL(/dashboard/, { timeout: 20000 });
+}
+
+function switcher(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+async function selectOrganization(page: Page, name: string) {
+  await switcher(page).click();
+  await page.getByRole("listbox").getByText(name, { exact: true }).click();
+  await expect(switcher(page)).toContainText(name);
+}
+
+test("the switcher avatar shows the selected organization's initials, not a fixed RG", async ({
+  page,
+}) => {
+  await login(page, EHAB);
+
+  await selectOrganization(page, "Refactor Group");
+  await expect(switcher(page)).toContainText("RG");
+
+  await selectOrganization(page, "BigTable");
+  // The regression: this stayed "RG" for every organization.
+  await expect(switcher(page)).toContainText("BT");
+  await expect(switcher(page)).not.toContainText("RG");
+});
+
+test("the dropdown gives each organization its own initials", async ({ page }) => {
+  await login(page, EHAB);
+
+  await switcher(page).click();
+  const list = page.getByRole("listbox");
+  await expect(list.getByText("RG", { exact: true })).toBeVisible();
+  await expect(list.getByText("BT", { exact: true })).toBeVisible();
+});
+
+test("session requests carry the selected organization and refetch on switch", async ({
+  page,
+}) => {
+  await login(page, EHAB);
+
+  const sessionRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (url.includes("/coaching_sessions")) sessionRequests.push(url);
+  });
+
+  await selectOrganization(page, "Refactor Group");
+  await expect
+    .poll(() => sessionRequests.some((url) => url.includes("organization_id=")), {
+      timeout: 15000,
+    })
+    .toBe(true);
+
+  const beforeSwitch = sessionRequests.length;
+  await selectOrganization(page, "BigTable");
+
+  // Pins the SWR cache key. Without organization_id in it, switching would
+  // serve the previous organization's cached list and issue nothing new.
+  await expect
+    .poll(() => sessionRequests.length, { timeout: 15000 })
+    .toBeGreaterThan(beforeSwitch);
+
+  const organizationIds = new Set(
+    sessionRequests
+      .map((url) => new URL(url).searchParams.get("organization_id"))
+      .filter(Boolean)
+  );
+  expect(organizationIds.size, "both organizations must appear").toBe(2);
+});
+
+// Ehab's sessions all live in BigTable, so Refactor Group must render empty.
+test("the Upcoming and Previous tabs are empty in the organization that has no sessions", async ({
+  page,
+}) => {
+  await login(page, EHAB);
+
+  // The week bucket's trigger carries a count and stays in the DOM whether or
+  // not the accordion is expanded, unlike the session rows themselves. Its text
+  // is title case in the DOM and uppercased only by CSS.
+  const weekBucket = page.getByRole("button").filter({ hasText: /This Week ·/ });
+
+  await selectOrganization(page, "Refactor Group");
+  await expect(page.getByText(/No upcoming sessions scheduled for today/)).toBeVisible({
+    timeout: 15000,
+  });
+  await expect(weekBucket).toHaveCount(0);
+
+  await selectOrganization(page, "BigTable");
+  await expect(weekBucket).toContainText("(1)", { timeout: 15000 });
+});
+
+test("the Upcoming Session card is empty in the organization that has no sessions", async ({
+  page,
+}) => {
+  await login(page, EHAB);
+
+  await selectOrganization(page, "Refactor Group");
+  await expect(page.getByText("Session with Jim Hodapp")).toHaveCount(0, {
+    timeout: 15000,
+  });
+
+  await selectOrganization(page, "BigTable");
+  await expect(page.getByText("Session with Jim Hodapp").first()).toBeVisible({
+    timeout: 15000,
+  });
+});

--- a/__tests__/e2e/multi-org-scoping-live.spec.ts
+++ b/__tests__/e2e/multi-org-scoping-live.spec.ts
@@ -13,12 +13,22 @@ import { test, expect, type Page } from "@playwright/test";
 const PASSWORD = "password";
 const EHAB = "ehab.bandar@gmail.com";
 
+/**
+ * Browser time is pinned for every test in this file. The seeded BigTable
+ * sessions sit at fixed instants (2026-08-07 and 2026-09-15), so which bucket
+ * they land in, and whether either is still "upcoming", otherwise depends on the
+ * day the suite happens to run. Both assertions below broke exactly that way
+ * once the date rolled over.
+ */
+const PINNED_NOW = new Date("2026-08-06T15:00:00.000Z");
+
 test.skip(
   !process.env.LIVE_E2E,
   "live end-to-end, set LIVE_E2E=1 with a seeded multi-org database"
 );
 
 async function login(page: Page, email: string) {
+  await page.clock.setFixedTime(PINNED_NOW);
   await page.goto("/");
   await page.fill("#email", email);
   await page.fill("#password", PASSWORD);
@@ -129,4 +139,29 @@ test("the Upcoming Session card is empty in the organization that has no session
   await expect(page.getByText("Session with Jim Hodapp").first()).toBeVisible({
     timeout: 15000,
   });
+});
+
+test("a cold dashboard load never requests sessions without an organization", async ({
+  page,
+}) => {
+  const unscoped: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (!url.includes("/coaching_sessions")) return;
+    if (!new URL(url).searchParams.get("organization_id")) unscoped.push(url);
+  });
+
+  // Fresh context, so the organization is not known until /organizations returns.
+  await login(page, EHAB);
+  await expect(switcher(page)).toContainText(/Refactor Group|BigTable/);
+  await expect(page.getByText(/Coaching Sessions/).first()).toBeVisible({
+    timeout: 15000,
+  });
+
+  // Firing before the organization resolves returns every organization's
+  // sessions, and they render before the scoped result replaces them.
+  expect(
+    unscoped.map((url) => new URL(url).pathname + new URL(url).search),
+    "session requests must wait for the organization"
+  ).toEqual([]);
 });

--- a/__tests__/hooks/use-todays-sessions.test.tsx
+++ b/__tests__/hooks/use-todays-sessions.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useTodaysSessions } from "@/lib/hooks/use-todays-sessions";
+import { useEnrichedCoachingSessionsForUser } from "@/lib/api/coaching-sessions";
 import { TestProviders } from "@/test-utils/providers";
 import { DateTime } from "ts-luxon";
 import {
@@ -12,8 +13,10 @@ import {
 
 /**
  * Test Suite: useTodaysSessions Hook
- * Story: "Fetch and enrich all of today's coaching sessions across organizations"
+ * Story: "Fetch and enrich today's coaching sessions for the current organization"
  */
+
+const CURRENT_ORGANIZATION_ID = "org-1";
 
 // Mock the auth store
 const mockUser = createMockUser({
@@ -62,6 +65,25 @@ vi.mock("@/lib/api/organizations", () => ({
     organizations: mockOrganizations,
     isLoading: false,
     isError: undefined,
+  })),
+  useOrganization: vi.fn(() => ({
+    organization: null,
+    isLoading: false,
+    isError: false,
+    refresh: vi.fn(),
+  })),
+}));
+
+// The sidebar's selected organization, which scopes the request.
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: vi.fn(() => ({
+    currentOrganizationId: "org-1",
+    currentOrganization: null,
+    isLoading: false,
+    isError: false,
+    setCurrentOrganizationId: vi.fn(),
+    resetOrganizationState: vi.fn(),
+    refresh: vi.fn(),
   })),
 }));
 
@@ -138,7 +160,25 @@ describe("useTodaysSessions", () => {
     expect(result.current.isLoading).toBeDefined();
   });
 
-  it("should fetch sessions from all organizations", async () => {
+  it("scopes the request to the currently selected organization", () => {
+    renderHook(() => useTodaysSessions(), { wrapper: TestProviders });
+
+    // Ninth argument is organizationId. Omitting it returns every organization's
+    // sessions, which is what made the Upcoming Session card bleed across orgs.
+    expect(vi.mocked(useEnrichedCoachingSessionsForUser)).toHaveBeenCalledWith(
+      mockUser.id,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      "date",
+      "asc",
+      undefined,
+      undefined,
+      CURRENT_ORGANIZATION_ID
+    );
+  });
+
+  it("should return every session the scoped request yields", async () => {
     const { result } = renderHook(() => useTodaysSessions(), {
       wrapper: TestProviders,
     });

--- a/__tests__/lib/api/coaching-sessions-org-scoping.test.tsx
+++ b/__tests__/lib/api/coaching-sessions-org-scoping.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ReactNode } from "react";
+import { DateTime } from "ts-luxon";
+import { renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import {
+  useEnrichedCoachingSessionsForUser,
+  useEnrichedCoachingSessionsForUserCounts,
+} from "@/lib/api/coaching-sessions";
+import { EntityApi } from "@/lib/api/entity-api";
+
+// Real SWR, stubbed HTTP boundary: asserts the outgoing request and lets an
+// organization switch exercise the real cache key.
+function SwrWrapper({ children }: { children: ReactNode }) {
+  return (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      {children}
+    </SWRConfig>
+  );
+}
+
+const FROM = DateTime.fromISO("2026-07-01");
+const TO = DateTime.fromISO("2026-07-31");
+const USER_ID = "user-1";
+
+describe("user coaching sessions are scoped by organization", () => {
+  let listNestedFn: ReturnType<typeof vi.spyOn>;
+  let getFn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    listNestedFn = vi
+      .spyOn(EntityApi, "listNestedFn")
+      .mockResolvedValue([] as never);
+    getFn = vi
+      .spyOn(EntityApi, "getFn")
+      .mockResolvedValue({ counts: [] } as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends organization_id on the session list request", async () => {
+    renderHook(
+      () =>
+        useEnrichedCoachingSessionsForUser(
+          USER_ID,
+          FROM,
+          TO,
+          [],
+          undefined,
+          undefined,
+          undefined,
+          "America/Los_Angeles",
+          "org-1"
+        ),
+      { wrapper: SwrWrapper }
+    );
+
+    await waitFor(() => expect(listNestedFn).toHaveBeenCalled());
+    const [, , , options] = listNestedFn.mock.calls[0];
+    expect(options.params.organization_id).toBe("org-1");
+  });
+
+  it("omits organization_id when there is no current organization", async () => {
+    renderHook(
+      () =>
+        useEnrichedCoachingSessionsForUser(
+          USER_ID,
+          FROM,
+          TO,
+          [],
+          undefined,
+          undefined,
+          undefined,
+          "America/Los_Angeles"
+        ),
+      { wrapper: SwrWrapper }
+    );
+
+    await waitFor(() => expect(listNestedFn).toHaveBeenCalled());
+    const [, , , options] = listNestedFn.mock.calls[0];
+    expect(options.params).not.toHaveProperty("organization_id");
+  });
+
+  // Pins organization_id into the SWR key. Without it the switch would serve
+  // the previous organization's cached list, reproducing the original bug.
+  it("issues a new request when the current organization changes", async () => {
+    const { rerender } = renderHook(
+      ({ organizationId }: { organizationId: string }) =>
+        useEnrichedCoachingSessionsForUser(
+          USER_ID,
+          FROM,
+          TO,
+          [],
+          undefined,
+          undefined,
+          undefined,
+          "America/Los_Angeles",
+          organizationId
+        ),
+      { wrapper: SwrWrapper, initialProps: { organizationId: "org-1" } }
+    );
+
+    await waitFor(() => expect(listNestedFn).toHaveBeenCalledTimes(1));
+
+    rerender({ organizationId: "org-2" });
+
+    await waitFor(() => expect(listNestedFn).toHaveBeenCalledTimes(2));
+    const [, , , options] = listNestedFn.mock.calls[1];
+    expect(options.params.organization_id).toBe("org-2");
+  });
+
+  it("sends organization_id on the counts request", async () => {
+    renderHook(
+      () =>
+        useEnrichedCoachingSessionsForUserCounts(
+          USER_ID,
+          FROM,
+          TO,
+          "America/Los_Angeles",
+          undefined,
+          "org-1"
+        ),
+      { wrapper: SwrWrapper }
+    );
+
+    await waitFor(() => expect(getFn).toHaveBeenCalled());
+    const [, options] = getFn.mock.calls[0];
+    expect(options.params.organization_id).toBe("org-1");
+  });
+});

--- a/__tests__/types/organization.test.ts
+++ b/__tests__/types/organization.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   defaultOrganization,
   isOrganizationArchived,
+  organizationInitials,
   OrganizationStatusFilter,
 } from "@/types/organization";
 
@@ -25,6 +26,43 @@ describe("isOrganizationArchived", () => {
 describe("defaultOrganization", () => {
   it("is active (no archived_at)", () => {
     expect(defaultOrganization().archived_at).toBeUndefined();
+  });
+});
+
+describe("organizationInitials", () => {
+  it("takes the first letter of the first two words", () => {
+    expect(organizationInitials("Refactor Group")).toBe("RG");
+    expect(organizationInitials("Big Table Industries")).toBe("BT");
+  });
+
+  it("takes the first two letters of a single-word name", () => {
+    expect(organizationInitials("BigTable")).toBe("BI");
+    expect(organizationInitials("Acme")).toBe("AC");
+  });
+
+  it("varies with the name rather than returning a fixed value", () => {
+    const initials = ["Refactor Group", "BigTable", "Zeta Labs"].map(
+      organizationInitials
+    );
+    expect(new Set(initials).size).toBe(3);
+  });
+
+  it("uppercases lowercase names", () => {
+    expect(organizationInitials("acme corp")).toBe("AC");
+  });
+
+  it("does not pad a one-letter name", () => {
+    expect(organizationInitials("X")).toBe("X");
+  });
+
+  it("ignores surrounding and repeated whitespace", () => {
+    expect(organizationInitials("  Refactor   Group  ")).toBe("RG");
+  });
+
+  it("falls back to ? for an empty or missing name", () => {
+    expect(organizationInitials("")).toBe("?");
+    expect(organizationInitials("   ")).toBe("?");
+    expect(organizationInitials(undefined)).toBe("?");
   });
 });
 

--- a/__tests__/types/organization.test.ts
+++ b/__tests__/types/organization.test.ts
@@ -35,8 +35,18 @@ describe("organizationInitials", () => {
     expect(organizationInitials("Big Table Industries")).toBe("BT");
   });
 
-  it("takes the first two letters of a single-word name", () => {
-    expect(organizationInitials("BigTable")).toBe("BI");
+  it("treats the capitals of a camel or Pascal case word as word boundaries", () => {
+    expect(organizationInitials("BigTable")).toBe("BT");
+    expect(organizationInitials("bigTable")).toBe("BT");
+    expect(organizationInitials("GitHub")).toBe("GH");
+  });
+
+  it("takes only the first two capitals when a word has more", () => {
+    expect(organizationInitials("BigTableCorp")).toBe("BT");
+    expect(organizationInitials("IBM")).toBe("IB");
+  });
+
+  it("falls back to the first two letters when a single word has one capital", () => {
     expect(organizationInitials("Acme")).toBe("AC");
   });
 
@@ -47,8 +57,13 @@ describe("organizationInitials", () => {
     expect(new Set(initials).size).toBe(3);
   });
 
-  it("uppercases lowercase names", () => {
+  it("uppercases names with no capitals at all", () => {
     expect(organizationInitials("acme corp")).toBe("AC");
+    expect(organizationInitials("acme")).toBe("AC");
+  });
+
+  it("prefers word boundaries over capitals for multi-word names", () => {
+    expect(organizationInitials("BigTable Inc")).toBe("BI");
   });
 
   it("does not pad a one-letter name", () => {

--- a/__tests__/types/user.test.ts
+++ b/__tests__/types/user.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getUserRoleForOrganization, parseUser, Role } from '@/types/user';
+import {
+  canAddExistingMembers,
+  getUserRoleForOrganization,
+  parseUser,
+  Role,
+} from '@/types/user';
 import type { UserRole } from '@/types/user';
 
 describe('parseUser', () => {
@@ -146,5 +151,50 @@ describe('getUserRoleForOrganization', () => {
     expect(getUserRoleForOrganization(roles, 'org-1')).toBe(Role.User);
     expect(getUserRoleForOrganization(roles, 'org-2')).toBe(Role.Admin);
     expect(getUserRoleForOrganization(roles, 'org-3')).toBe(Role.User);
+  });
+});
+
+describe('canAddExistingMembers', () => {
+  const role = (r: Role, organization_id: string | null): UserRole => ({
+    id: `role-${r}-${organization_id}`,
+    user_id: 'user-1',
+    role: r,
+    organization_id,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  });
+
+  it('is false for an admin of a single organization', () => {
+    // Everyone they can look up is already a member there, so the flow can only
+    // ever return "already a member".
+    expect(canAddExistingMembers([role(Role.Admin, 'org-1')])).toBe(false);
+  });
+
+  it('is true for an admin of two organizations', () => {
+    expect(
+      canAddExistingMembers([role(Role.Admin, 'org-1'), role(Role.Admin, 'org-2')])
+    ).toBe(true);
+  });
+
+  it('does not count organizations where the user is only a member', () => {
+    // Visibility requires Admin in the shared organization, not membership.
+    expect(
+      canAddExistingMembers([role(Role.Admin, 'org-1'), role(Role.User, 'org-2')])
+    ).toBe(false);
+  });
+
+  it('counts distinct organizations, not role rows', () => {
+    expect(
+      canAddExistingMembers([role(Role.Admin, 'org-1'), role(Role.Admin, 'org-1')])
+    ).toBe(false);
+  });
+
+  it('is true for a super admin holding no organization roles', () => {
+    expect(canAddExistingMembers([role(Role.SuperAdmin, null)])).toBe(true);
+  });
+
+  it('is false for a plain member and for no roles at all', () => {
+    expect(canAddExistingMembers([role(Role.User, 'org-1')])).toBe(false);
+    expect(canAddExistingMembers([])).toBe(false);
   });
 });

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -13,6 +13,7 @@ import { ForbiddenError } from "@/components/ui/errors/forbidden-error";
 import { MemberContainer } from "@/components/ui/members/member-container";
 import { PageContainer } from "@/components/ui/page-container";
 import { shouldDenyMembersPageAccess } from "./access-control";
+import { siteConfig } from "@/site.config";
 
 export default function MembersPage({
   params,
@@ -92,6 +93,7 @@ export default function MembersPage({
         onRefresh={handleRefresh}
         isLoading={isRelationshipsLoading || isUsersLoading}
         openAddMemberDialog={openAddMemberDialog}
+        productName={siteConfig.name}
       />
     </PageContainer>
   );

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -275,6 +275,7 @@ export function CoachingSessionsCard({
             <BucketsContainer
               userId={userId}
               relationshipFilter={relationshipFilter}
+              organizationId={currentOrganizationId || undefined}
               viewerId={userSession.id}
               userTimezone={userSession.timezone || getBrowserTimezone()}
               mountNow={mountNow}

--- a/src/components/ui/dashboard/coaching-sessions-card.tsx
+++ b/src/components/ui/dashboard/coaching-sessions-card.tsx
@@ -271,11 +271,13 @@ export function CoachingSessionsCard({
             relationshipOptions={relationshipOptions}
           />
 
-          {userSession && userId && (
+          {/* Waits for the organization: mounting before it resolves fetches and
+              briefly renders every organization's sessions. */}
+          {userSession && userId && currentOrganizationId && (
             <BucketsContainer
               userId={userId}
               relationshipFilter={relationshipFilter}
-              organizationId={currentOrganizationId || undefined}
+              organizationId={currentOrganizationId}
               viewerId={userSession.id}
               userTimezone={userSession.timezone || getBrowserTimezone()}
               mountNow={mountNow}

--- a/src/components/ui/dashboard/session-buckets/bucket-accordion.tsx
+++ b/src/components/ui/dashboard/session-buckets/bucket-accordion.tsx
@@ -42,6 +42,7 @@ export interface BucketAccordionProps {
   onToggle: () => void;
   userId: Id;
   relationshipId: Id | undefined;
+  organizationId: Id | undefined;
   viewerId: Id;
   userTimezone: string;
   selectedId: Id | undefined;
@@ -79,6 +80,7 @@ export function BucketAccordion({
   onToggle,
   userId,
   relationshipId,
+  organizationId,
   viewerId,
   userTimezone,
   selectedId,
@@ -104,7 +106,8 @@ export function BucketAccordion({
     "date",
     isPastView ? "desc" : "asc",
     relationshipId,
-    userTimezone
+    userTimezone,
+    organizationId
   );
 
   const filteredSessions = (enrichedSessions ?? []).filter((s) =>

--- a/src/components/ui/dashboard/session-buckets/bucket-list.tsx
+++ b/src/components/ui/dashboard/session-buckets/bucket-list.tsx
@@ -24,6 +24,7 @@ export interface BucketListProps {
   mountNow: DateTime;
   userId: Id;
   relationshipId: Id | undefined;
+  organizationId: Id | undefined;
   viewerId: Id;
   userTimezone: string;
   selectedId: Id | undefined;
@@ -56,6 +57,7 @@ export function BucketList({
   mountNow,
   userId,
   relationshipId,
+  organizationId,
   viewerId,
   userTimezone,
   selectedId,
@@ -162,6 +164,7 @@ export function BucketList({
               onToggle={() => toggleKey(bucket.key)}
               userId={userId}
               relationshipId={relationshipId}
+              organizationId={organizationId}
               viewerId={viewerId}
               userTimezone={userTimezone}
               selectedId={selectedId}

--- a/src/components/ui/dashboard/session-buckets/buckets-container.tsx
+++ b/src/components/ui/dashboard/session-buckets/buckets-container.tsx
@@ -43,6 +43,7 @@ import { UserActionsScope } from "@/types/assigned-actions";
 export interface BucketsContainerProps {
   userId: Id;
   relationshipFilter: Id | undefined;
+  organizationId: Id | undefined;
   viewerId: Id;
   userTimezone: string;
   mountNow: DateTime;
@@ -74,6 +75,7 @@ const WEEK_INCLUDES: CoachingSessionInclude[] = [];
 export function BucketsContainer({
   userId,
   relationshipFilter,
+  organizationId,
   viewerId,
   userTimezone,
   mountNow,
@@ -151,7 +153,8 @@ export function BucketsContainer({
     fetchRangeStart,
     fetchRangeEnd,
     userTimezone,
-    relationshipFilter
+    relationshipFilter,
+    organizationId
   );
 
   type ShowMoreDirection = "later" | "earlier";
@@ -259,7 +262,8 @@ export function BucketsContainer({
     undefined,
     undefined,
     relationshipFilter,
-    userTimezone
+    userTimezone,
+    organizationId
   );
   const { thisWeekUpcomingCount, thisWeekPreviousCount } = useMemo(() => {
     const all = weekSessions ?? [];
@@ -374,6 +378,7 @@ export function BucketsContainer({
             now={now}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             selectedId={selectedId}
@@ -388,6 +393,7 @@ export function BucketsContainer({
             now={now}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             selectedId={selectedId}
@@ -405,6 +411,7 @@ export function BucketsContainer({
             mountNow={mountNow}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             selectedId={selectedId}
@@ -430,6 +437,7 @@ export function BucketsContainer({
             now={now}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             selectedId={selectedId}
@@ -444,6 +452,7 @@ export function BucketsContainer({
             now={now}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             selectedId={selectedId}
@@ -461,6 +470,7 @@ export function BucketsContainer({
             mountNow={mountNow}
             userId={userId}
             relationshipId={relationshipFilter}
+            organizationId={organizationId}
             viewerId={viewerId}
             userTimezone={userTimezone}
             recentlyAddedKeys={recentlyAddedKeys}

--- a/src/components/ui/dashboard/session-buckets/this-week-accordion.tsx
+++ b/src/components/ui/dashboard/session-buckets/this-week-accordion.tsx
@@ -30,6 +30,7 @@ export interface ThisWeekAccordionProps {
   now: DateTime;
   userId: Id;
   relationshipId: Id | undefined;
+  organizationId: Id | undefined;
   viewerId: Id;
   userTimezone: string;
   selectedId: Id | undefined;
@@ -50,6 +51,7 @@ export function ThisWeekAccordion({
   now,
   userId,
   relationshipId,
+  organizationId,
   viewerId,
   userTimezone,
   selectedId,
@@ -76,7 +78,8 @@ export function ThisWeekAccordion({
     "date",
     isPastView ? "desc" : "asc",
     relationshipId,
-    userTimezone
+    userTimezone,
+    organizationId
   );
 
   const filteredSessions = useMemo(() => {

--- a/src/components/ui/dashboard/session-buckets/today-section.tsx
+++ b/src/components/ui/dashboard/session-buckets/today-section.tsx
@@ -26,6 +26,7 @@ export interface TodaySectionProps {
   now: DateTime;
   userId: Id;
   relationshipId: Id | undefined;
+  organizationId: Id | undefined;
   viewerId: Id;
   userTimezone: string;
   selectedId: Id | undefined;
@@ -46,6 +47,7 @@ export function TodaySection({
   now,
   userId,
   relationshipId,
+  organizationId,
   viewerId,
   userTimezone,
   selectedId,
@@ -72,7 +74,8 @@ export function TodaySection({
     "date",
     isPastView ? "desc" : "asc",
     relationshipId,
-    userTimezone
+    userTimezone,
+    organizationId
   );
 
   const visibleSessions = useMemo(() => {

--- a/src/components/ui/members/add-member-button.tsx
+++ b/src/components/ui/members/add-member-button.tsx
@@ -4,19 +4,22 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { AddMemberDialog } from "./add-member-dialog";
-import { UserRoleState } from "@/types/user";
+import { User, UserRoleState } from "@/types/user";
 
 interface AddMemberButtonProps {
   onMemberAdded: () => void;
   /// Force the AddMemberDialog to open
   openAddMemberDialog: boolean;
   currentUserRoleState: UserRoleState;
+  /// Candidates offered when pre-assigning a coach
+  organizationMembers?: User[];
 }
 
 export function AddMemberButton({
   onMemberAdded,
   openAddMemberDialog,
   currentUserRoleState,
+  organizationMembers,
 }: AddMemberButtonProps) {
   const [open, setOpen] = useState(false);
 
@@ -35,6 +38,7 @@ export function AddMemberButton({
         onOpenChange={setOpen}
         onMemberAdded={onMemberAdded}
         currentUserRoleState={currentUserRoleState}
+        organizationMembers={organizationMembers}
       />
     </>
   );

--- a/src/components/ui/members/add-member-button.tsx
+++ b/src/components/ui/members/add-member-button.tsx
@@ -14,6 +14,9 @@ interface AddMemberButtonProps {
   /// Candidates offered when pre-assigning a coach
   organizationMembers?: User[];
   productName: string;
+  /// False hides the add-existing-member tab, which has nothing to offer an
+  /// admin of a single organization.
+  canAddExistingMembers: boolean;
 }
 
 export function AddMemberButton({
@@ -22,6 +25,7 @@ export function AddMemberButton({
   currentUserRoleState,
   organizationMembers,
   productName,
+  canAddExistingMembers,
 }: AddMemberButtonProps) {
   const [open, setOpen] = useState(false);
 
@@ -42,6 +46,7 @@ export function AddMemberButton({
         currentUserRoleState={currentUserRoleState}
         organizationMembers={organizationMembers}
         productName={productName}
+        canAddExistingMembers={canAddExistingMembers}
       />
     </>
   );

--- a/src/components/ui/members/add-member-button.tsx
+++ b/src/components/ui/members/add-member-button.tsx
@@ -4,16 +4,19 @@ import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { AddMemberDialog } from "./add-member-dialog";
+import { UserRoleState } from "@/types/user";
 
 interface AddMemberButtonProps {
   onMemberAdded: () => void;
   /// Force the AddMemberDialog to open
   openAddMemberDialog: boolean;
+  currentUserRoleState: UserRoleState;
 }
 
 export function AddMemberButton({
   onMemberAdded,
   openAddMemberDialog,
+  currentUserRoleState,
 }: AddMemberButtonProps) {
   const [open, setOpen] = useState(false);
 
@@ -31,6 +34,7 @@ export function AddMemberButton({
         open={open}
         onOpenChange={setOpen}
         onMemberAdded={onMemberAdded}
+        currentUserRoleState={currentUserRoleState}
       />
     </>
   );

--- a/src/components/ui/members/add-member-button.tsx
+++ b/src/components/ui/members/add-member-button.tsx
@@ -13,6 +13,7 @@ interface AddMemberButtonProps {
   currentUserRoleState: UserRoleState;
   /// Candidates offered when pre-assigning a coach
   organizationMembers?: User[];
+  productName: string;
 }
 
 export function AddMemberButton({
@@ -20,6 +21,7 @@ export function AddMemberButton({
   openAddMemberDialog,
   currentUserRoleState,
   organizationMembers,
+  productName,
 }: AddMemberButtonProps) {
   const [open, setOpen] = useState(false);
 
@@ -39,6 +41,7 @@ export function AddMemberButton({
         onMemberAdded={onMemberAdded}
         currentUserRoleState={currentUserRoleState}
         organizationMembers={organizationMembers}
+        productName={productName}
       />
     </>
   );

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -150,6 +150,15 @@ export function AddMemberDialog({
     setExistingRole(Role.User);
   };
 
+  // A found user belongs to the email that produced it, so editing the field
+  // invalidates it. Without this the Add button can act on a stale selection
+  // while the field shows a different address.
+  const handleLookupEmailChange = (value: string) => {
+    setLookupEmail(value);
+    setFoundUser(null);
+    setLookupMessage(null);
+  };
+
   const handleAddExisting = async () => {
     if (!foundUser) return;
     setIsAdding(true);
@@ -247,7 +256,7 @@ export function AddMemberDialog({
             name="lookupEmail"
             type="email"
             value={lookupEmail}
-            onChange={(e) => setLookupEmail(e.target.value)}
+            onChange={(e) => handleLookupEmailChange(e.target.value)}
             placeholder="Enter email address"
           />
           <Button
@@ -264,11 +273,22 @@ export function AddMemberDialog({
         <p className="text-sm text-destructive">{lookupMessage}</p>
       )}
       {foundUser && (
-        <div className="rounded-md border p-3">
-          <p className="font-medium">
-            {foundUser.first_name} {foundUser.last_name}
-          </p>
-          <p className="text-sm text-muted-foreground">{foundUser.email}</p>
+        <div className="flex items-start justify-between gap-2 rounded-md border p-3">
+          <div>
+            <p className="font-medium">
+              {foundUser.first_name} {foundUser.last_name}
+            </p>
+            <p className="text-sm text-muted-foreground">{foundUser.email}</p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={resetLookup}
+            aria-label={`Clear ${foundUser.first_name} ${foundUser.last_name}`}
+          >
+            Clear
+          </Button>
         </div>
       )}
       <div className="space-y-2">

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -27,6 +27,7 @@ import { UserApi } from "@/lib/api/users";
 import {
   organizationArchivedMessage,
   userAlreadyInOrganizationMessage,
+  USER_ALREADY_IN_ORGANIZATION_MESSAGE,
 } from "@/lib/api/organization-errors";
 import {
   NewUser,
@@ -152,11 +153,19 @@ export function AddMemberDialog({
       if (lookupRequest.current !== request) return;
       // None also covers a real user outside this admin's scope. The backend
       // makes those cases indistinguishable, so the copy must too.
-      if (result.some) {
-        setFoundUser(result);
-      } else {
+      if (result.none) {
         setLookupMessage("No user found with that email.");
+        return;
       }
+      // Say so now rather than letting them pick a role and a coach first only
+      // for the request to come back 409. The server still enforces this, since
+      // the member list can be stale and may be absent entirely.
+      const found = result.val;
+      if (organizationMembers?.some((member) => member.id === found.id)) {
+        setLookupMessage(USER_ALREADY_IN_ORGANIZATION_MESSAGE);
+        return;
+      }
+      setFoundUser(result);
     } catch (error) {
       if (lookupRequest.current !== request) return;
       console.error("Error looking up user:", error);
@@ -220,8 +229,11 @@ export function AddMemberDialog({
     }
   };
 
-  /// Optional coach picker. `excludeId` keeps a member off their own coach list.
-  const coachField = (excludeId?: string) =>
+  /// Optional coach picker, listing the organization's existing members.
+  ///
+  /// No self-exclusion is needed: a brand new member is not in the list yet, and
+  /// an existing one is rejected at lookup before the card ever renders.
+  const coachField = () =>
     organizationMembers &&
     organizationMembers.length > 0 && (
       <div className="space-y-2">
@@ -232,13 +244,11 @@ export function AddMemberDialog({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value={NO_COACH}>No coach</SelectItem>
-            {organizationMembers
-              .filter((member) => member.id !== excludeId)
-              .map((member) => (
-                <SelectItem key={member.id} value={member.id}>
-                  {member.first_name} {member.last_name}
-                </SelectItem>
-              ))}
+            {organizationMembers.map((member) => (
+              <SelectItem key={member.id} value={member.id}>
+                {member.first_name} {member.last_name}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
@@ -371,7 +381,7 @@ export function AddMemberDialog({
           </SelectContent>
         </Select>
       </div>
-      {coachField(foundUser.some ? foundUser.val.id : undefined)}
+      {coachField()}
       <DialogFooter>
         <Button
           type="button"

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -56,6 +56,9 @@ interface AddMemberDialogProps {
   organizationMembers?: User[];
   /// Product name, threaded from the page rather than read from global config.
   productName: string;
+  /// False hides the add-existing-member tab, which has nothing to offer an
+  /// admin of a single organization.
+  canAddExistingMembers: boolean;
 }
 
 export function AddMemberDialog({
@@ -65,6 +68,7 @@ export function AddMemberDialog({
   currentUserRoleState,
   organizationMembers,
   productName,
+  canAddExistingMembers,
 }: AddMemberDialogProps) {
   const { currentOrganizationId, currentOrganization } =
     useCurrentOrganization();
@@ -88,9 +92,12 @@ export function AddMemberDialog({
   /// Identifies the newest lookup, so a slower earlier one cannot land on top of it.
   const lookupRequest = useRef(0);
 
-  // Org admins get this too, not just super admins
+  // Org admins get this too, not just super admins, but only when the lookup
+  // can actually find them someone who is not already a member.
   const canAddExisting =
-    !!currentUserRoleState && isAdminOrSuperAdmin(currentUserRoleState);
+    !!currentUserRoleState &&
+    isAdminOrSuperAdmin(currentUserRoleState) &&
+    canAddExistingMembers;
 
   /// The chosen coach, or undefined to leave the key off the request entirely.
   const selectedCoachId = coachId === NO_COACH ? undefined : coachId;

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -14,9 +14,27 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUserMutation } from "@/lib/api/organizations/users";
-import { organizationArchivedMessage } from "@/lib/api/organization-errors";
-import { NewUser } from "@/types/user";
+import { UserApi } from "@/lib/api/users";
+import {
+  organizationArchivedMessage,
+  userAlreadyInOrganizationMessage,
+} from "@/lib/api/organization-errors";
+import {
+  NewUser,
+  Role,
+  UserLookupResult,
+  UserRoleState,
+  isAdminOrSuperAdmin,
+} from "@/types/user";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
@@ -26,16 +44,19 @@ interface AddMemberDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onMemberAdded: () => void;
+  /// Omitted for callers that only offer creating a brand new member
+  currentUserRoleState?: UserRoleState;
 }
 
 export function AddMemberDialog({
   open,
   onOpenChange,
   onMemberAdded,
+  currentUserRoleState,
 }: AddMemberDialogProps) {
   const { currentOrganizationId } = useCurrentOrganization();
 
-  const { createNested: createUserNested } = useUserMutation(
+  const { createNested: createUserNested, attachExisting } = useUserMutation(
     currentOrganizationId
   );
   const [formData, setFormData] = useState({
@@ -44,6 +65,16 @@ export function AddMemberDialog({
     displayName: "",
     email: "",
   });
+  const [lookupEmail, setLookupEmail] = useState("");
+  const [foundUser, setFoundUser] = useState<UserLookupResult | null>(null);
+  const [lookupMessage, setLookupMessage] = useState<string | null>(null);
+  const [isLookingUp, setIsLookingUp] = useState(false);
+  const [existingRole, setExistingRole] = useState<Role>(Role.User);
+  const [isAdding, setIsAdding] = useState(false);
+
+  // Org admins get this too, not just super admins
+  const canAddExisting =
+    !!currentUserRoleState && isAdminOrSuperAdmin(currentUserRoleState);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -86,70 +117,215 @@ export function AddMemberDialog({
     }
   };
 
+  const handleFind = async () => {
+    setFoundUser(null);
+    setLookupMessage(null);
+    setIsLookingUp(true);
+
+    try {
+      const result = await UserApi.lookupByEmail(lookupEmail);
+      // A null result also covers a real user outside this admin's scope. The
+      // backend makes those cases indistinguishable, so the copy must too.
+      if (result) {
+        setFoundUser(result);
+      } else {
+        setLookupMessage("No user found with that email.");
+      }
+    } catch (error) {
+      console.error("Error looking up user:", error);
+      setLookupMessage(
+        isForbiddenError(error)
+          ? PERMISSION_DENIED_MESSAGE
+          : "There was an error looking up that email."
+      );
+    } finally {
+      setIsLookingUp(false);
+    }
+  };
+
+  const resetLookup = () => {
+    setLookupEmail("");
+    setFoundUser(null);
+    setLookupMessage(null);
+    setExistingRole(Role.User);
+  };
+
+  const handleAddExisting = async () => {
+    if (!foundUser) return;
+    setIsAdding(true);
+
+    try {
+      await attachExisting(currentOrganizationId, foundUser.id, existingRole);
+      onMemberAdded();
+      toast.success(
+        `${foundUser.first_name} ${foundUser.last_name} added to this organization`
+      );
+      resetLookup();
+      onOpenChange(false);
+    } catch (error) {
+      console.error("Error adding existing user:", error);
+      toast.error(
+        userAlreadyInOrganizationMessage(error) ??
+          organizationArchivedMessage(error) ??
+          (isForbiddenError(error)
+            ? PERMISSION_DENIED_MESSAGE
+            : "There was an error adding the member")
+      );
+    } finally {
+      setIsAdding(false);
+    }
+  };
+
+  const createMemberForm = (
+    <form onSubmit={handleSubmit}>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="firstName">First Name</Label>
+          <Input
+            id="firstName"
+            name="firstName"
+            value={formData.firstName}
+            onChange={handleInputChange}
+            placeholder="Enter first name"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="lastName">Last Name</Label>
+          <Input
+            id="lastName"
+            name="lastName"
+            value={formData.lastName}
+            onChange={handleInputChange}
+            placeholder="Enter last name"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="displayName">Display Name</Label>
+          <Input
+            id="displayName"
+            name="displayName"
+            value={formData.displayName}
+            onChange={handleInputChange}
+            placeholder="Enter display name"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            value={formData.email}
+            onChange={handleInputChange}
+            placeholder="Enter email address"
+            required
+          />
+        </div>
+      </div>
+      <div className="pt-4">
+        <DialogFooter>
+          <Button type="submit">Create Member</Button>
+        </DialogFooter>
+      </div>
+    </form>
+  );
+
+  const addExistingForm = (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        This person already has a Refactor account. Adding them here gives them
+        access to this organization using their existing profile.
+      </p>
+      <div className="space-y-2">
+        <Label htmlFor="lookupEmail">Email</Label>
+        <div className="flex gap-2">
+          <Input
+            id="lookupEmail"
+            name="lookupEmail"
+            type="email"
+            value={lookupEmail}
+            onChange={(e) => setLookupEmail(e.target.value)}
+            placeholder="Enter email address"
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={handleFind}
+            disabled={isLookingUp || lookupEmail.trim().length === 0}
+          >
+            Find
+          </Button>
+        </div>
+      </div>
+      {lookupMessage && (
+        <p className="text-sm text-destructive">{lookupMessage}</p>
+      )}
+      {foundUser && (
+        <div className="rounded-md border p-3">
+          <p className="font-medium">
+            {foundUser.first_name} {foundUser.last_name}
+          </p>
+          <p className="text-sm text-muted-foreground">{foundUser.email}</p>
+        </div>
+      )}
+      <div className="space-y-2">
+        <Label htmlFor="existingRole">Role</Label>
+        <Select
+          value={existingRole}
+          onValueChange={(value) => setExistingRole(value as Role)}
+        >
+          <SelectTrigger id="existingRole" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {/* "Member" is the recipient-facing word for Role.User */}
+            <SelectItem value={Role.User}>Member</SelectItem>
+            <SelectItem value={Role.Admin}>Admin</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <DialogFooter>
+        <Button
+          type="button"
+          onClick={handleAddExisting}
+          disabled={!foundUser || isAdding}
+        >
+          Add to organization
+        </Button>
+      </DialogFooter>
+    </div>
+  );
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Add New Member</DialogTitle>
           <DialogDescription>
-            Create a new member account. They&apos;ll receive an email with a
-            link to set up their password.
+            {canAddExisting
+              ? "Create a new member account, or add someone who already has a Refactor account."
+              : "Create a new member account. They'll receive an email with a link to set up their password."}
           </DialogDescription>
         </DialogHeader>
-        <form onSubmit={handleSubmit}>
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="firstName">First Name</Label>
-              <Input
-                id="firstName"
-                name="firstName"
-                value={formData.firstName}
-                onChange={handleInputChange}
-                placeholder="Enter first name"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="lastName">Last Name</Label>
-              <Input
-                id="lastName"
-                name="lastName"
-                value={formData.lastName}
-                onChange={handleInputChange}
-                placeholder="Enter last name"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="displayName">Display Name</Label>
-              <Input
-                id="displayName"
-                name="displayName"
-                value={formData.displayName}
-                onChange={handleInputChange}
-                placeholder="Enter display name"
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                value={formData.email}
-                onChange={handleInputChange}
-                placeholder="Enter email address"
-                required
-              />
-            </div>
-          </div>
-          <div className="pt-4">
-            <DialogFooter>
-              <Button type="submit">Create Member</Button>
-            </DialogFooter>
-          </div>
-        </form>
+        {canAddExisting ? (
+          <Tabs defaultValue="create" className="w-full">
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="create">Create new member</TabsTrigger>
+              <TabsTrigger value="existing">Add existing member</TabsTrigger>
+            </TabsList>
+            <TabsContent value="create" className="mt-4">
+              {createMemberForm}
+            </TabsContent>
+            <TabsContent value="existing" className="mt-4">
+              {addExistingForm}
+            </TabsContent>
+          </Tabs>
+        ) : (
+          createMemberForm
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -40,6 +40,7 @@ import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { type Option, None } from "@/types/option";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
+import { siteConfig } from "@/site.config";
 import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 
 /// Sentinel for the "no coach" option, since Select cannot hold an empty value.
@@ -62,10 +63,11 @@ export function AddMemberDialog({
   currentUserRoleState,
   organizationMembers,
 }: AddMemberDialogProps) {
-  const { currentOrganizationId } = useCurrentOrganization();
+  const { currentOrganizationId, currentOrganization } =
+    useCurrentOrganization();
 
   const { createNested: createUserNested, attachExisting } = useUserMutation(
-    currentOrganizationId
+    currentOrganizationId,
   );
   const [formData, setFormData] = useState({
     firstName: "",
@@ -127,7 +129,7 @@ export function AddMemberDialog({
         organizationArchivedMessage(error) ??
           (isForbiddenError(error)
             ? PERMISSION_DENIED_MESSAGE
-            : "There was an error adding the member")
+            : "There was an error adding the member"),
       );
     }
   };
@@ -151,7 +153,7 @@ export function AddMemberDialog({
       setLookupMessage(
         isForbiddenError(error)
           ? PERMISSION_DENIED_MESSAGE
-          : "There was an error looking up that email."
+          : "There was an error looking up that email.",
       );
     } finally {
       setIsLookingUp(false);
@@ -185,7 +187,7 @@ export function AddMemberDialog({
         currentOrganizationId,
         target.id,
         existingRole,
-        selectedCoachId
+        selectedCoachId,
       );
       onMemberAdded();
       const name = `${target.first_name} ${target.last_name}`;
@@ -199,7 +201,7 @@ export function AddMemberDialog({
           organizationArchivedMessage(error) ??
           (isForbiddenError(error)
             ? PERMISSION_DENIED_MESSAGE
-            : "There was an error adding the member")
+            : "There was an error adding the member"),
       );
     } finally {
       setIsAdding(false);
@@ -291,8 +293,10 @@ export function AddMemberDialog({
   const addExistingForm = (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        This person already has a Refactor account. Adding them here gives them
-        access to this organization using their existing profile.
+        Add a user that already has an account. Adding them here gives them
+        access to the organization{" "}
+        {currentOrganization?.name ?? "you are viewing"} using their existing
+        profile.
       </p>
       <div className="space-y-2">
         <Label htmlFor="lookupEmail">Email</Label>
@@ -375,7 +379,7 @@ export function AddMemberDialog({
           <DialogTitle>Add New Member</DialogTitle>
           <DialogDescription>
             {canAddExisting
-              ? "Create a new member account, or add someone who already has a Refactor account."
+              ? `Create a new member account, or add someone who already has a ${siteConfig.name} account.`
               : "Create a new member account. They'll receive an email with a link to set up their password."}
           </DialogDescription>
         </DialogHeader>

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -40,7 +40,6 @@ import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { type Option, None } from "@/types/option";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { siteConfig } from "@/site.config";
 import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 
 /// Sentinel for the "no coach" option, since Select cannot hold an empty value.
@@ -54,6 +53,8 @@ interface AddMemberDialogProps {
   currentUserRoleState?: UserRoleState;
   /// Candidates offered when pre-assigning a coach. Omitted hides the field.
   organizationMembers?: User[];
+  /// Product name, threaded from the page rather than read from global config.
+  productName: string;
 }
 
 export function AddMemberDialog({
@@ -62,6 +63,7 @@ export function AddMemberDialog({
   onMemberAdded,
   currentUserRoleState,
   organizationMembers,
+  productName,
 }: AddMemberDialogProps) {
   const { currentOrganizationId, currentOrganization } =
     useCurrentOrganization();
@@ -82,6 +84,8 @@ export function AddMemberDialog({
   const [existingRole, setExistingRole] = useState<Role>(Role.User);
   const [isAdding, setIsAdding] = useState(false);
   const [coachId, setCoachId] = useState<string>(NO_COACH);
+  /// Identifies the newest lookup, so a slower earlier one cannot land on top of it.
+  const lookupRequest = useRef(0);
 
   // Org admins get this too, not just super admins
   const canAddExisting =
@@ -135,12 +139,17 @@ export function AddMemberDialog({
   };
 
   const handleFind = async () => {
+    const request = ++lookupRequest.current;
     setFoundUser(None);
     setLookupMessage(null);
     setIsLookingUp(true);
 
     try {
       const result = await UserApi.lookupByEmail(lookupEmail);
+      // Editing the email, or starting another lookup, supersedes this one.
+      // Without the check a slow reply repopulates the card for an address the
+      // field no longer shows, and Add attaches that user instead.
+      if (lookupRequest.current !== request) return;
       // None also covers a real user outside this admin's scope. The backend
       // makes those cases indistinguishable, so the copy must too.
       if (result.some) {
@@ -149,6 +158,7 @@ export function AddMemberDialog({
         setLookupMessage("No user found with that email.");
       }
     } catch (error) {
+      if (lookupRequest.current !== request) return;
       console.error("Error looking up user:", error);
       setLookupMessage(
         isForbiddenError(error)
@@ -156,7 +166,7 @@ export function AddMemberDialog({
           : "There was an error looking up that email.",
       );
     } finally {
-      setIsLookingUp(false);
+      if (lookupRequest.current === request) setIsLookingUp(false);
     }
   };
 
@@ -172,9 +182,11 @@ export function AddMemberDialog({
   // invalidates it. Without this the Add button can act on a stale selection
   // while the field shows a different address.
   const handleLookupEmailChange = (value: string) => {
+    lookupRequest.current += 1;
     setLookupEmail(value);
     setFoundUser(None);
     setLookupMessage(null);
+    setIsLookingUp(false);
   };
 
   const handleAddExisting = async () => {
@@ -379,7 +391,7 @@ export function AddMemberDialog({
           <DialogTitle>Add New Member</DialogTitle>
           <DialogDescription>
             {canAddExisting
-              ? `Create a new member account, or add someone who already has a ${siteConfig.name} account.`
+              ? `Create a new member account, or add someone who already has a ${productName} account.`
               : "Create a new member account. They'll receive an email with a link to set up their password."}
           </DialogDescription>
         </DialogHeader>

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUserMutation } from "@/lib/api/organizations/users";
+import { useCoachingRelationshipMutation } from "@/lib/api/coaching-relationships";
 import { UserApi } from "@/lib/api/users";
 import {
   organizationArchivedMessage,
@@ -31,6 +32,7 @@ import {
 import {
   NewUser,
   Role,
+  User,
   UserLookupResult,
   UserRoleState,
   isAdminOrSuperAdmin,
@@ -38,7 +40,10 @@ import {
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
+import { Id, isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
+
+/// Sentinel for the "no coach" option, since Select cannot hold an empty value.
+const NO_COACH = "none";
 
 interface AddMemberDialogProps {
   open: boolean;
@@ -46,6 +51,8 @@ interface AddMemberDialogProps {
   onMemberAdded: () => void;
   /// Omitted for callers that only offer creating a brand new member
   currentUserRoleState?: UserRoleState;
+  /// Candidates offered when pre-assigning a coach. Omitted hides the field.
+  organizationMembers?: User[];
 }
 
 export function AddMemberDialog({
@@ -53,10 +60,14 @@ export function AddMemberDialog({
   onOpenChange,
   onMemberAdded,
   currentUserRoleState,
+  organizationMembers,
 }: AddMemberDialogProps) {
   const { currentOrganizationId } = useCurrentOrganization();
 
   const { createNested: createUserNested, attachExisting } = useUserMutation(
+    currentOrganizationId
+  );
+  const { createNested: createRelationship } = useCoachingRelationshipMutation(
     currentOrganizationId
   );
   const [formData, setFormData] = useState({
@@ -71,10 +82,31 @@ export function AddMemberDialog({
   const [isLookingUp, setIsLookingUp] = useState(false);
   const [existingRole, setExistingRole] = useState<Role>(Role.User);
   const [isAdding, setIsAdding] = useState(false);
+  const [coachId, setCoachId] = useState<string>(NO_COACH);
 
   // Org admins get this too, not just super admins
   const canAddExisting =
     !!currentUserRoleState && isAdminOrSuperAdmin(currentUserRoleState);
+
+  // Runs only after the member exists, so a failure here leaves a coachless
+  // member rather than blocking the add. Returns whether the coach was assigned.
+  const assignSelectedCoach = async (coacheeId: Id): Promise<boolean> => {
+    if (coachId === NO_COACH) return true;
+
+    try {
+      await createRelationship(currentOrganizationId, {
+        coach_id: coachId,
+        coachee_id: coacheeId,
+      });
+      return true;
+    } catch (error) {
+      console.error("Error assigning coach:", error);
+      return false;
+    }
+  };
+
+  const coachAssignmentFailedMessage =
+    "They were added, but assigning the coach failed. Assign one from the member list.";
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -96,15 +128,22 @@ export function AddMemberDialog({
     };
 
     try {
-      await createUserNested(currentOrganizationId, newUser);
+      const created = await createUserNested(currentOrganizationId, newUser);
+      const coachAssigned = await assignSelectedCoach(created.id);
       setFormData({
         firstName: "",
         lastName: "",
         displayName: "",
         email: "",
       });
+      setCoachId(NO_COACH);
       onMemberAdded();
-      toast.success(`New Member ${formData.firstName} ${formData.lastName} added successfully`);
+      const name = `${formData.firstName} ${formData.lastName}`;
+      if (coachAssigned) {
+        toast.success(`New Member ${name} added successfully`);
+      } else {
+        toast.warning(`${name} added. ${coachAssignmentFailedMessage}`);
+      }
       onOpenChange(false);
     } catch (error) {
       console.error("Error creating user:", error);
@@ -148,6 +187,7 @@ export function AddMemberDialog({
     setFoundUser(null);
     setLookupMessage(null);
     setExistingRole(Role.User);
+    setCoachId(NO_COACH);
   };
 
   // A found user belongs to the email that produced it, so editing the field
@@ -165,10 +205,14 @@ export function AddMemberDialog({
 
     try {
       await attachExisting(currentOrganizationId, foundUser.id, existingRole);
+      const coachAssigned = await assignSelectedCoach(foundUser.id);
       onMemberAdded();
-      toast.success(
-        `${foundUser.first_name} ${foundUser.last_name} added to this organization`
-      );
+      const name = `${foundUser.first_name} ${foundUser.last_name}`;
+      if (coachAssigned) {
+        toast.success(`${name} added to this organization`);
+      } else {
+        toast.warning(`${name} added to this organization. ${coachAssignmentFailedMessage}`);
+      }
       resetLookup();
       onOpenChange(false);
     } catch (error) {
@@ -184,6 +228,30 @@ export function AddMemberDialog({
       setIsAdding(false);
     }
   };
+
+  /// Optional coach picker. `excludeId` keeps a member off their own coach list.
+  const coachField = (excludeId?: string) =>
+    organizationMembers &&
+    organizationMembers.length > 0 && (
+      <div className="space-y-2">
+        <Label htmlFor="coach">Coach (optional)</Label>
+        <Select value={coachId} onValueChange={setCoachId}>
+          <SelectTrigger id="coach" className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={NO_COACH}>No coach</SelectItem>
+            {organizationMembers
+              .filter((member) => member.id !== excludeId)
+              .map((member) => (
+                <SelectItem key={member.id} value={member.id}>
+                  {member.first_name} {member.last_name}
+                </SelectItem>
+              ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
 
   const createMemberForm = (
     <form onSubmit={handleSubmit}>
@@ -233,6 +301,7 @@ export function AddMemberDialog({
             required
           />
         </div>
+        {coachField()}
       </div>
       <div className="pt-4">
         <DialogFooter>
@@ -307,6 +376,7 @@ export function AddMemberDialog({
           </SelectContent>
         </Select>
       </div>
+      {coachField(foundUser?.id)}
       <DialogFooter>
         <Button
           type="button"

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -23,7 +23,6 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUserMutation } from "@/lib/api/organizations/users";
-import { useCoachingRelationshipMutation } from "@/lib/api/coaching-relationships";
 import { UserApi } from "@/lib/api/users";
 import {
   organizationArchivedMessage,
@@ -40,7 +39,7 @@ import {
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
-import { Id, isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
+import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
 
 /// Sentinel for the "no coach" option, since Select cannot hold an empty value.
 const NO_COACH = "none";
@@ -67,9 +66,6 @@ export function AddMemberDialog({
   const { createNested: createUserNested, attachExisting } = useUserMutation(
     currentOrganizationId
   );
-  const { createNested: createRelationship } = useCoachingRelationshipMutation(
-    currentOrganizationId
-  );
   const [formData, setFormData] = useState({
     firstName: "",
     lastName: "",
@@ -88,25 +84,8 @@ export function AddMemberDialog({
   const canAddExisting =
     !!currentUserRoleState && isAdminOrSuperAdmin(currentUserRoleState);
 
-  // Runs only after the member exists, so a failure here leaves a coachless
-  // member rather than blocking the add. Returns whether the coach was assigned.
-  const assignSelectedCoach = async (coacheeId: Id): Promise<boolean> => {
-    if (coachId === NO_COACH) return true;
-
-    try {
-      await createRelationship(currentOrganizationId, {
-        coach_id: coachId,
-        coachee_id: coacheeId,
-      });
-      return true;
-    } catch (error) {
-      console.error("Error assigning coach:", error);
-      return false;
-    }
-  };
-
-  const coachAssignmentFailedMessage =
-    "They were added, but assigning the coach failed. Assign one from the member list.";
+  /// The chosen coach, or undefined to leave the key off the request entirely.
+  const selectedCoachId = coachId === NO_COACH ? undefined : coachId;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -125,11 +104,11 @@ export function AddMemberDialog({
       display_name: formData.displayName,
       email: formData.email,
       timezone: getBrowserTimezone(), // Default to browser timezone for new users
+      ...(selectedCoachId ? { coach_id: selectedCoachId } : {}),
     };
 
     try {
-      const created = await createUserNested(currentOrganizationId, newUser);
-      const coachAssigned = await assignSelectedCoach(created.id);
+      await createUserNested(currentOrganizationId, newUser);
       setFormData({
         firstName: "",
         lastName: "",
@@ -139,11 +118,7 @@ export function AddMemberDialog({
       setCoachId(NO_COACH);
       onMemberAdded();
       const name = `${formData.firstName} ${formData.lastName}`;
-      if (coachAssigned) {
-        toast.success(`New Member ${name} added successfully`);
-      } else {
-        toast.warning(`${name} added. ${coachAssignmentFailedMessage}`);
-      }
+      toast.success(`New Member ${name} added successfully`);
       onOpenChange(false);
     } catch (error) {
       console.error("Error creating user:", error);
@@ -204,15 +179,15 @@ export function AddMemberDialog({
     setIsAdding(true);
 
     try {
-      await attachExisting(currentOrganizationId, foundUser.id, existingRole);
-      const coachAssigned = await assignSelectedCoach(foundUser.id);
+      await attachExisting(
+        currentOrganizationId,
+        foundUser.id,
+        existingRole,
+        selectedCoachId
+      );
       onMemberAdded();
       const name = `${foundUser.first_name} ${foundUser.last_name}`;
-      if (coachAssigned) {
-        toast.success(`${name} added to this organization`);
-      } else {
-        toast.warning(`${name} added to this organization. ${coachAssignmentFailedMessage}`);
-      }
+      toast.success(`${name} added to this organization`);
       resetLookup();
       onOpenChange(false);
     } catch (error) {

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -37,6 +37,7 @@ import {
   isAdminOrSuperAdmin,
 } from "@/types/user";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
+import { type Option, None } from "@/types/option";
 import { toast } from "sonner";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
 import { isForbiddenError, PERMISSION_DENIED_MESSAGE } from "@/types/general";
@@ -73,7 +74,7 @@ export function AddMemberDialog({
     email: "",
   });
   const [lookupEmail, setLookupEmail] = useState("");
-  const [foundUser, setFoundUser] = useState<UserLookupResult | null>(null);
+  const [foundUser, setFoundUser] = useState<Option<UserLookupResult>>(None);
   const [lookupMessage, setLookupMessage] = useState<string | null>(null);
   const [isLookingUp, setIsLookingUp] = useState(false);
   const [existingRole, setExistingRole] = useState<Role>(Role.User);
@@ -132,15 +133,15 @@ export function AddMemberDialog({
   };
 
   const handleFind = async () => {
-    setFoundUser(null);
+    setFoundUser(None);
     setLookupMessage(null);
     setIsLookingUp(true);
 
     try {
       const result = await UserApi.lookupByEmail(lookupEmail);
-      // A null result also covers a real user outside this admin's scope. The
-      // backend makes those cases indistinguishable, so the copy must too.
-      if (result) {
+      // None also covers a real user outside this admin's scope. The backend
+      // makes those cases indistinguishable, so the copy must too.
+      if (result.some) {
         setFoundUser(result);
       } else {
         setLookupMessage("No user found with that email.");
@@ -159,7 +160,7 @@ export function AddMemberDialog({
 
   const resetLookup = () => {
     setLookupEmail("");
-    setFoundUser(null);
+    setFoundUser(None);
     setLookupMessage(null);
     setExistingRole(Role.User);
     setCoachId(NO_COACH);
@@ -170,23 +171,24 @@ export function AddMemberDialog({
   // while the field shows a different address.
   const handleLookupEmailChange = (value: string) => {
     setLookupEmail(value);
-    setFoundUser(null);
+    setFoundUser(None);
     setLookupMessage(null);
   };
 
   const handleAddExisting = async () => {
-    if (!foundUser) return;
+    if (foundUser.none) return;
+    const target = foundUser.val;
     setIsAdding(true);
 
     try {
       await attachExisting(
         currentOrganizationId,
-        foundUser.id,
+        target.id,
         existingRole,
         selectedCoachId
       );
       onMemberAdded();
-      const name = `${foundUser.first_name} ${foundUser.last_name}`;
+      const name = `${target.first_name} ${target.last_name}`;
       toast.success(`${name} added to this organization`);
       resetLookup();
       onOpenChange(false);
@@ -309,27 +311,29 @@ export function AddMemberDialog({
             onClick={handleFind}
             disabled={isLookingUp || lookupEmail.trim().length === 0}
           >
-            Find
+            {isLookingUp ? "Finding..." : "Find"}
           </Button>
         </div>
       </div>
       {lookupMessage && (
         <p className="text-sm text-destructive">{lookupMessage}</p>
       )}
-      {foundUser && (
+      {foundUser.some && (
         <div className="flex items-start justify-between gap-2 rounded-md border p-3">
           <div>
             <p className="font-medium">
-              {foundUser.first_name} {foundUser.last_name}
+              {foundUser.val.first_name} {foundUser.val.last_name}
             </p>
-            <p className="text-sm text-muted-foreground">{foundUser.email}</p>
+            <p className="text-sm text-muted-foreground">
+              {foundUser.val.email}
+            </p>
           </div>
           <Button
             type="button"
             variant="ghost"
             size="sm"
             onClick={resetLookup}
-            aria-label={`Clear ${foundUser.first_name} ${foundUser.last_name}`}
+            aria-label={`Clear ${foundUser.val.first_name} ${foundUser.val.last_name}`}
           >
             Clear
           </Button>
@@ -351,12 +355,12 @@ export function AddMemberDialog({
           </SelectContent>
         </Select>
       </div>
-      {coachField(foundUser?.id)}
+      {coachField(foundUser.some ? foundUser.val.id : undefined)}
       <DialogFooter>
         <Button
           type="button"
           onClick={handleAddExisting}
-          disabled={!foundUser || isAdding}
+          disabled={foundUser.none || isAdding}
         >
           Add to organization
         </Button>

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -80,7 +80,7 @@ export function MemberCard({
   currentUserRoleState,
 }: MemberCardProps) {
   const { currentOrganizationId } = useCurrentOrganization();
-  const { isACoach, userSession } = useAuthStore((state: AuthStore) => state);
+  const { userSession } = useAuthStore((state: AuthStore) => state);
 
   // Extract user properties
   const { id: userId, first_name: firstName, last_name: lastName, email } = user;
@@ -96,8 +96,6 @@ export function MemberCard({
   const { createNested: createRelationship } =
     useCoachingRelationshipMutation(currentOrganizationId);
 
-  console.log("is a coach", isACoach);
-
   // Only admins and super admins can delete users (but not themselves)
   const canDeleteUser =
     currentUserRoleState.hasAccess &&
@@ -112,6 +110,7 @@ export function MemberCard({
     try {
       await deleteUser(currentOrganizationId, userId);
       toast.success("Member deleted successfully");
+      onRefresh();
     } catch (error) {
       console.error("Error deleting member:", error);
       toast.error(
@@ -122,7 +121,6 @@ export function MemberCard({
             : "Error deleting member")
       );
     }
-    onRefresh();
   };
 
   const handleRemoveFromOrganization = async () => {

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -12,7 +12,17 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
-import { MoreHorizontal, Send, Trash2 } from "lucide-react";
+import { MoreHorizontal, Send, Trash2, UserMinus } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import {
   Dialog,
   DialogContent,
@@ -39,7 +49,11 @@ import {
 } from "@/types/user";
 import { RelationshipRole } from "@/types/relationship-role";
 import { useCoachingRelationshipMutation } from "@/lib/api/coaching-relationships";
-import { organizationArchivedMessage } from "@/lib/api/organization-errors";
+import {
+  lastOrganizationAdminMessage,
+  organizationArchivedMessage,
+  userBelongsToMultipleOrganizationsMessage,
+} from "@/lib/api/organization-errors";
 import { toast } from "sonner";
 
 interface MemberCardProps {
@@ -76,7 +90,7 @@ export function MemberCard({
 
   // Get coaches for this user
   const coaches = getUserCoaches(userId, userRelationships);
-  const { error: deleteError, deleteNested: deleteUser } = useUserMutation(
+  const { deleteNested: deleteUser, removeFromOrganization } = useUserMutation(
     currentOrganizationId
   );
   const { createNested: createRelationship } =
@@ -94,17 +108,43 @@ export function MemberCard({
     if (!confirm("Are you sure you want to delete this member?")) {
       return;
     }
-    await deleteUser(currentOrganizationId, userId);
-    onRefresh();
 
-    if (deleteError) {
-      console.error("Error deleting member:", deleteError);
-      toast.error("Error deleting member");
-      onRefresh();
-      return;
+    try {
+      await deleteUser(currentOrganizationId, userId);
+      toast.success("Member deleted successfully");
+    } catch (error) {
+      console.error("Error deleting member:", error);
+      toast.error(
+        userBelongsToMultipleOrganizationsMessage(error) ??
+          organizationArchivedMessage(error) ??
+          (isForbiddenError(error)
+            ? PERMISSION_DENIED_MESSAGE
+            : "Error deleting member")
+      );
     }
-    toast.success("Member deleted successfully");
     onRefresh();
+  };
+
+  const handleRemoveFromOrganization = async () => {
+    setIsRemoving(true);
+
+    try {
+      await removeFromOrganization(currentOrganizationId, userId);
+      toast.success(`${firstName} ${lastName} removed from this organization`);
+      setRemoveDialogOpen(false);
+      onRefresh();
+    } catch (error) {
+      console.error("Error removing member from organization:", error);
+      toast.error(
+        lastOrganizationAdminMessage(error) ??
+          organizationArchivedMessage(error) ??
+          (isForbiddenError(error)
+            ? PERMISSION_DENIED_MESSAGE
+            : "Error removing member from this organization")
+      );
+    } finally {
+      setIsRemoving(false);
+    }
   };
 
   const handleResendInvite = async () => {
@@ -155,6 +195,8 @@ export function MemberCard({
   const [assignMode, setAssignMode] = useState<RelationshipRole>(RelationshipRole.Coach);
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [assignedMember, setAssignedMember] = useState<Member | null>(null);
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
 
   const handleCreateCoachingRelationship = async () => {
     if (!selectedMember || !assignedMember) return;
@@ -267,6 +309,9 @@ export function MemberCard({
             {canDeleteUser && (
               <>
                 {userId !== currentUserId && <DropdownMenuSeparator />}
+                <DropdownMenuItem onClick={() => setRemoveDialogOpen(true)}>
+                  <UserMinus className="mr-2 h-4 w-4" /> Remove from organization
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={handleDelete}
                   className="text-destructive focus:text-destructive"
@@ -278,6 +323,33 @@ export function MemberCard({
           </DropdownMenuContent>
         </DropdownMenu>
       )}
+
+      {/* Remove from organization confirmation */}
+      <AlertDialog open={removeDialogOpen} onOpenChange={setRemoveDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Remove {firstName} {lastName} from this organization
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove them from this organization only. Their account and any
+              other organizations are unaffected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRemoving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                handleRemoveFromOrganization();
+              }}
+              disabled={isRemoving}
+            >
+              {isRemoving ? "Removing..." : "Remove"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Assign Coach/Coachee Modal */}
       <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -53,6 +53,7 @@ import {
   lastOrganizationAdminMessage,
   organizationArchivedMessage,
   userBelongsToMultipleOrganizationsMessage,
+  userHasCoachingHistoryMessage,
 } from "@/lib/api/organization-errors";
 import { toast } from "sonner";
 
@@ -134,7 +135,8 @@ export function MemberCard({
     } catch (error) {
       console.error("Error removing member from organization:", error);
       toast.error(
-        lastOrganizationAdminMessage(error) ??
+        userHasCoachingHistoryMessage(error) ??
+          lastOrganizationAdminMessage(error) ??
           organizationArchivedMessage(error) ??
           (isForbiddenError(error)
             ? PERMISSION_DENIED_MESSAGE

--- a/src/components/ui/members/member-container.tsx
+++ b/src/components/ui/members/member-container.tsx
@@ -60,6 +60,7 @@ export function MemberContainer({
             onMemberAdded={onRefresh}
             openAddMemberDialog={openAddMemberDialog}
             currentUserRoleState={currentUserRoleState}
+            organizationMembers={displayUsers}
           />
         )}
       </div>

--- a/src/components/ui/members/member-container.tsx
+++ b/src/components/ui/members/member-container.tsx
@@ -59,6 +59,7 @@ export function MemberContainer({
           <AddMemberButton
             onMemberAdded={onRefresh}
             openAddMemberDialog={openAddMemberDialog}
+            currentUserRoleState={currentUserRoleState}
           />
         )}
       </div>

--- a/src/components/ui/members/member-container.tsx
+++ b/src/components/ui/members/member-container.tsx
@@ -15,6 +15,7 @@ interface MemberContainerProps {
   onRefresh: () => void;
   isLoading: boolean;
   openAddMemberDialog: boolean;
+  productName: string;
 }
 
 export function MemberContainer({
@@ -25,6 +26,7 @@ export function MemberContainer({
   isLoading,
   /// Force the AddMemberDialog to open
   openAddMemberDialog,
+  productName,
 }: MemberContainerProps) {
   const { setIsACoach, isACoach } = useAuthStore((state) => state);
   const currentUserRoleState = useCurrentUserRole();
@@ -61,6 +63,7 @@ export function MemberContainer({
             openAddMemberDialog={openAddMemberDialog}
             currentUserRoleState={currentUserRoleState}
             organizationMembers={displayUsers}
+            productName={productName}
           />
         )}
       </div>

--- a/src/components/ui/members/member-container.tsx
+++ b/src/components/ui/members/member-container.tsx
@@ -1,6 +1,11 @@
 import { MemberList } from "./member-list";
 import { AddMemberButton } from "./add-member-button";
-import { User, isAdminOrSuperAdmin, sortUsersAlphabetically } from "@/types/user";
+import {
+  User,
+  canAddExistingMembers,
+  isAdminOrSuperAdmin,
+  sortUsersAlphabetically,
+} from "@/types/user";
 import { CoachingRelationshipWithUserNames, isUserCoach } from "@/types/coaching-relationship";
 import { UserSession } from "@/types/user-session";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
@@ -64,6 +69,7 @@ export function MemberContainer({
             currentUserRoleState={currentUserRoleState}
             organizationMembers={displayUsers}
             productName={productName}
+            canAddExistingMembers={canAddExistingMembers(userSession.roles)}
           />
         )}
       </div>

--- a/src/components/ui/organization-switcher.tsx
+++ b/src/components/ui/organization-switcher.tsx
@@ -24,12 +24,12 @@ import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 import type { PopoverProps } from "@radix-ui/react-popover";
 import type { Id } from "@/types/general";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
-import { organizationToString } from "@/types/organization";
+import {
+  organizationInitials,
+  organizationToString,
+} from "@/types/organization";
 import { isUserCoach } from "@/types/coaching-relationship";
 import { useEffect } from "react";
-
-const LOGO = "/placeholder.svg?height=40&width=40";
-const SHORT_NAME = "RG";
 
 interface OrganizationSelectorProps extends PopoverProps {
   /// Called when an Organization is selected
@@ -175,10 +175,12 @@ export function OrganizationSwitcher({
               <div className="flex items-center justify-center">
                 <Avatar className="h-7 w-7">
                   <AvatarImage
-                    src={currentOrganization?.logo || LOGO}
+                    src={currentOrganization?.logo}
                     alt={currentOrganization?.name || "Organization"}
                   />
-                  <AvatarFallback>{SHORT_NAME}</AvatarFallback>
+                  <AvatarFallback>
+                    {organizationInitials(currentOrganization?.name)}
+                  </AvatarFallback>
                 </Avatar>
               </div>
             </TooltipTrigger>
@@ -230,10 +232,12 @@ export function OrganizationSwitcher({
           <div className="flex items-center gap-2 text-left">
             <Avatar className="h-6 w-6">
               <AvatarImage
-                src={currentOrganization?.logo || LOGO}
+                src={currentOrganization?.logo}
                 alt={currentOrganization?.name || "Organization"}
               />
-              <AvatarFallback>{SHORT_NAME}</AvatarFallback>
+              <AvatarFallback>
+                {organizationInitials(currentOrganization?.name)}
+              </AvatarFallback>
             </Avatar>
             <span className="truncate">
               {currentOrganization?.name || "Select Organization"}
@@ -297,7 +301,9 @@ export function OrganizationSwitcher({
                     <div className="flex items-center gap-2 w-full">
                       <Avatar className="h-6 w-6">
                         <AvatarImage src={org.logo} alt={org.name} />
-                        <AvatarFallback>{SHORT_NAME}</AvatarFallback>
+                        <AvatarFallback>
+                          {organizationInitials(org.name)}
+                        </AvatarFallback>
                       </Avatar>
                       <span>{org.name}</span>
                       {currentOrganizationId === org.id && (

--- a/src/lib/api/coaching-sessions.ts
+++ b/src/lib/api/coaching-sessions.ts
@@ -202,6 +202,7 @@ export const CoachingSessionApi = {
    * @param sortBy Optional field to sort by
    * @param sortOrder Optional sort order
    * @param relationshipId Optional coaching relationship ID to filter sessions
+   * @param organizationId Optional organization to scope sessions to
    * @returns Promise resolving to array of EnrichedCoachingSession objects
    */
   listForUser: async (
@@ -212,7 +213,8 @@ export const CoachingSessionApi = {
     sortBy?: CoachingSessionSortField,
     sortOrder?: ApiSortOrder,
     relationshipId?: Id,
-    tz?: string
+    tz?: string,
+    organizationId?: Id
   ): Promise<EnrichedCoachingSession[]> => {
     const params: Record<string, string> = {
       from_date: fromDate.toISODate() || '',
@@ -221,6 +223,10 @@ export const CoachingSessionApi = {
 
     if (relationshipId) {
       params.coaching_relationship_id = relationshipId;
+    }
+
+    if (organizationId) {
+      params.organization_id = organizationId;
     }
 
     if (include && include.length > 0) {
@@ -245,7 +251,8 @@ export const CoachingSessionApi = {
     fromDate: DateTime,
     toDate: DateTime,
     tz: string,
-    relationshipId?: Id
+    relationshipId?: Id,
+    organizationId?: Id
   ): Promise<CoachingSessionCountByMonth[]> => {
     const fromIso = fromDate.toISODate();
     const toIso = toDate.toISODate();
@@ -262,6 +269,9 @@ export const CoachingSessionApi = {
     };
     if (relationshipId) {
       params.coaching_relationship_id = relationshipId;
+    }
+    if (organizationId) {
+      params.organization_id = organizationId;
     }
 
     const url = `${USERS_BASEURL}/${userId}/coaching_sessions/counts`;
@@ -395,6 +405,9 @@ export const useCoachingSessionMutation = () => {
  * @param sortBy Optional field to sort by
  * @param sortOrder Optional sort order
  * @param relationshipId Optional coaching relationship ID to filter sessions
+ * @param organizationId Optional organization to scope sessions to. Part of the
+ *   SWR key, so switching organizations refetches instead of serving the
+ *   previous organization's cached list.
  * @returns Object containing enriched sessions, loading state, error, and refresh function
  */
 export const useEnrichedCoachingSessionsForUser = (
@@ -405,7 +418,8 @@ export const useEnrichedCoachingSessionsForUser = (
   sortBy?: CoachingSessionSortField,
   sortOrder?: ApiSortOrder,
   relationshipId?: Id,
-  tz?: string
+  tz?: string,
+  organizationId?: Id
 ) => {
   // Only create params when userId is valid - null params skips the SWR fetch
   const params = userId
@@ -415,6 +429,7 @@ export const useEnrichedCoachingSessionsForUser = (
         to_date: toDate.toISODate(),
         ...(include && include.length > 0 && { include: include.join(',') }),
         ...(relationshipId && { coaching_relationship_id: relationshipId }),
+        ...(organizationId && { organization_id: organizationId }),
         ...(sortBy && { sort_by: sortBy }),
         ...(sortOrder && { sort_order: sortOrder }),
         ...(tz && { tz }),
@@ -433,7 +448,8 @@ export const useEnrichedCoachingSessionsForUser = (
           sortBy,
           sortOrder,
           relationshipId,
-          tz
+          tz,
+          organizationId
         )
       : Promise.resolve([]);
 
@@ -462,6 +478,8 @@ export const useEnrichedCoachingSessionsForUser = (
  * @param toDate End date for the count window
  * @param tz IANA timezone for local-calendar month aggregation on the BE
  * @param relationshipId Optional relationship to narrow counts to one coachee
+ * @param organizationId Optional organization to scope counts to. Part of the
+ *   SWR key so an organization switch refetches rather than reusing the cache.
  * @returns counts, loading/error state, and a refresh fn. On error or 404,
  *   counts is an empty array — caller falls back to "no badge" rendering.
  */
@@ -470,7 +488,8 @@ export const useEnrichedCoachingSessionsForUserCounts = (
   fromDate: DateTime,
   toDate: DateTime,
   tz: string,
-  relationshipId?: Id
+  relationshipId?: Id,
+  organizationId?: Id
 ) => {
   const params = userId
     ? {
@@ -480,6 +499,7 @@ export const useEnrichedCoachingSessionsForUserCounts = (
         group_by: "month",
         tz,
         ...(relationshipId && { coaching_relationship_id: relationshipId }),
+        ...(organizationId && { organization_id: organizationId }),
       }
     : null;
 
@@ -494,7 +514,8 @@ export const useEnrichedCoachingSessionsForUserCounts = (
           fromDate,
           toDate,
           tz,
-          relationshipId
+          relationshipId,
+          organizationId
         )
       : Promise.resolve([]);
 

--- a/src/lib/api/organization-errors.ts
+++ b/src/lib/api/organization-errors.ts
@@ -38,13 +38,18 @@ export const organizationArchivedMessage = (error: unknown): string | null =>
     "This organization is archived and can't accept new changes."
   );
 
+/// Shown both by the lookup pre-check and by the server's 409, so the two
+/// paths cannot drift apart.
+export const USER_ALREADY_IN_ORGANIZATION_MESSAGE =
+  "This user is already a member of this organization.";
+
 export const userAlreadyInOrganizationMessage = (
   error: unknown
 ): string | null =>
   orgErrorMessage(
     error,
     "user_already_in_organization",
-    "This user is already a member of this organization."
+    USER_ALREADY_IN_ORGANIZATION_MESSAGE
   );
 
 export const lastOrganizationAdminMessage = (error: unknown): string | null =>

--- a/src/lib/api/organization-errors.ts
+++ b/src/lib/api/organization-errors.ts
@@ -38,6 +38,31 @@ export const organizationArchivedMessage = (error: unknown): string | null =>
     "This organization is archived and can't accept new changes."
   );
 
+export const userAlreadyInOrganizationMessage = (
+  error: unknown
+): string | null =>
+  orgErrorMessage(
+    error,
+    "user_already_in_organization",
+    "This user is already a member of this organization."
+  );
+
+export const lastOrganizationAdminMessage = (error: unknown): string | null =>
+  orgErrorMessage(
+    error,
+    "last_organization_admin",
+    "This user is the only admin of this organization. Assign another admin before removing them."
+  );
+
+export const userBelongsToMultipleOrganizationsMessage = (
+  error: unknown
+): string | null =>
+  orgErrorMessage(
+    error,
+    "user_belongs_to_multiple_organizations",
+    "This user belongs to other organizations. Remove them from this organization instead of deleting their account."
+  );
+
 /** Longest organization name the backend accepts (characters, trimmed). */
 export const ORGANIZATION_NAME_MAX_LENGTH = 255;
 

--- a/src/lib/api/organization-errors.ts
+++ b/src/lib/api/organization-errors.ts
@@ -59,6 +59,13 @@ export const lastOrganizationAdminMessage = (error: unknown): string | null =>
     "This user is the only admin of this organization. Assign another admin before removing them."
   );
 
+export const userHasCoachingHistoryMessage = (error: unknown): string | null =>
+  orgErrorMessage(
+    error,
+    "user_has_coaching_history",
+    "This member still has coaching sessions in this organization. Remove or reassign those sessions before removing them."
+  );
+
 export const userBelongsToMultipleOrganizationsMessage = (
   error: unknown
 ): string | null =>

--- a/src/lib/api/organizations/users.ts
+++ b/src/lib/api/organizations/users.ts
@@ -1,8 +1,9 @@
 // Interacts with the organizations/{organizationId}/users endpoints
 
+import { useSWRConfig } from "swr";
 import { Id } from "@/types/general";
 import { EntityApi } from "../entity-api";
-import { User, NewUser } from "@/types/user";
+import { User, NewUser, Role } from "@/types/user";
 import { ORGANIZATIONS_BASEURL } from "../organizations";
 
 const ORGANIZATIONS_USERS_BASEURL = (organizationId: Id) =>
@@ -78,6 +79,33 @@ export const UserApi = {
       {}
     );
   },
+
+  /**
+   * Grants an existing user membership of this organization with the given role.
+   * The account itself is shared, not copied.
+   */
+  attachExisting: async (
+    organizationId: Id,
+    userId: Id,
+    role: Role
+  ): Promise<User> =>
+    EntityApi.createFn<{ role: Role }, User>(
+      `${ORGANIZATIONS_USERS_BASEURL(organizationId)}/${userId}/role`,
+      { role }
+    ),
+
+  /**
+   * Removes a user's membership of this organization only. Their account and
+   * any other organizations are left untouched.
+   */
+  removeFromOrganization: async (
+    organizationId: Id,
+    userId: Id
+  ): Promise<void> => {
+    await EntityApi.deleteFn<null, void>(
+      `${ORGANIZATIONS_USERS_BASEURL(organizationId)}/${userId}/role`
+    );
+  },
 };
 
 /**
@@ -101,10 +129,12 @@ export const useUserList = (organizationId: Id) => {
 
 /**
  * Hook for user mutations.
- * Provides methods to create, update, and delete users.
+ * Provides methods to create, update, and delete users, plus the membership
+ * actions (attach an existing user, remove one) that sit outside standard CRUD.
  */
 export const useUserMutation = (organizationId: Id) => {
-  return EntityApi.useEntityMutation<NewUser, User>(
+  const { mutate } = useSWRConfig();
+  const mutation = EntityApi.useEntityMutation<NewUser, User>(
     ORGANIZATIONS_USERS_BASEURL(organizationId),
     {
       create: UserApi.create,
@@ -114,4 +144,20 @@ export const useUserMutation = (organizationId: Id) => {
       deleteNested: UserApi.deleteNested,
     }
   );
+
+  const invalidate = (id: Id) =>
+    EntityApi.invalidateEntityCache(mutate, ORGANIZATIONS_USERS_BASEURL(id));
+
+  return {
+    ...mutation,
+    attachExisting: async (orgId: Id, userId: Id, role: Role) => {
+      const user = await UserApi.attachExisting(orgId, userId, role);
+      invalidate(orgId);
+      return user;
+    },
+    removeFromOrganization: async (orgId: Id, userId: Id) => {
+      await UserApi.removeFromOrganization(orgId, userId);
+      invalidate(orgId);
+    },
+  };
 };

--- a/src/lib/api/organizations/users.ts
+++ b/src/lib/api/organizations/users.ts
@@ -9,6 +9,9 @@ import { ORGANIZATIONS_BASEURL } from "../organizations";
 const ORGANIZATIONS_USERS_BASEURL = (organizationId: Id) =>
   `${ORGANIZATIONS_BASEURL}/${organizationId}/users`;
 
+/// `coach_id` is omitted rather than null when no coach is chosen.
+type AttachRoleBody = { role: Role; coach_id?: Id };
+
 /**
  * API client for user-related operations in the scope of organizations.
  */
@@ -87,11 +90,12 @@ export const UserApi = {
   attachExisting: async (
     organizationId: Id,
     userId: Id,
-    role: Role
+    role: Role,
+    coachId?: Id
   ): Promise<User> =>
-    EntityApi.createFn<{ role: Role }, User>(
+    EntityApi.createFn<AttachRoleBody, User>(
       `${ORGANIZATIONS_USERS_BASEURL(organizationId)}/${userId}/role`,
-      { role }
+      { role, ...(coachId ? { coach_id: coachId } : {}) }
     ),
 
   /**
@@ -150,8 +154,13 @@ export const useUserMutation = (organizationId: Id) => {
 
   return {
     ...mutation,
-    attachExisting: async (orgId: Id, userId: Id, role: Role) => {
-      const user = await UserApi.attachExisting(orgId, userId, role);
+    attachExisting: async (
+      orgId: Id,
+      userId: Id,
+      role: Role,
+      coachId?: Id
+    ) => {
+      const user = await UserApi.attachExisting(orgId, userId, role, coachId);
       invalidate(orgId);
       return user;
     },

--- a/src/lib/api/organizations/users.ts
+++ b/src/lib/api/organizations/users.ts
@@ -92,8 +92,8 @@ export const UserApi = {
     userId: Id,
     role: Role,
     coachId?: Id
-  ): Promise<User> =>
-    EntityApi.createFn<AttachRoleBody, User>(
+  ): Promise<void> =>
+    EntityApi.createFn<AttachRoleBody, void>(
       `${ORGANIZATIONS_USERS_BASEURL(organizationId)}/${userId}/role`,
       { role, ...(coachId ? { coach_id: coachId } : {}) }
     ),
@@ -160,9 +160,8 @@ export const useUserMutation = (organizationId: Id) => {
       role: Role,
       coachId?: Id
     ) => {
-      const user = await UserApi.attachExisting(orgId, userId, role, coachId);
+      await UserApi.attachExisting(orgId, userId, role, coachId);
       invalidate(orgId);
-      return user;
     },
     removeFromOrganization: async (orgId: Id, userId: Id) => {
       await UserApi.removeFromOrganization(orgId, userId);

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -3,7 +3,13 @@
 import { siteConfig } from "@/site.config";
 import { Id } from "@/types/general";
 import { EntityApi } from "./entity-api";
-import { User, NewUserPassword, defaultUser } from "@/types/user";
+import {
+  User,
+  NewUserPassword,
+  UserLookupResult,
+  defaultUser,
+} from "@/types/user";
+import { buildQueryString } from "./query-params";
 
 export const USERS_BASEURL: string = `${siteConfig.env.backendServiceURL}/users`;
 
@@ -12,10 +18,19 @@ export const USERS_BASEURL: string = `${siteConfig.env.backendServiceURL}/users`
  */
 export const UserApi = {
   /**
-   * Fetches a list of users.
+   * Looks up a single user by exact (case-insensitive) email address.
+   *
+   * @param email The email address to look for
+   * @returns The matching user, or null when there is no match or the caller
+   *   may not see them. The backend makes those two cases indistinguishable so
+   *   the endpoint can't be used to enumerate accounts.
    */
-  list: async (): Promise<User[]> =>
-    EntityApi.listFn<User, User>(USERS_BASEURL, {}),
+  lookupByEmail: async (email: string): Promise<UserLookupResult | null> => {
+    const results = await EntityApi.getFn<UserLookupResult[]>(
+      `${USERS_BASEURL}${buildQueryString({ email })}`
+    );
+    return results[0] ?? null;
+  },
 
   /**
    * Fetches a single user by ID.
@@ -58,21 +73,6 @@ export const UserApi = {
   deleteNested: async (_entityId: Id, _userId: Id): Promise<User> => {
     throw new Error("Delete nested operation not implemented");
   },
-};
-
-/**
- * Hook for fetching a list of users.
- */
-export const useUserList = () => {
-  const { entities, isLoading, isError, refresh } =
-    EntityApi.useEntityList<User>(USERS_BASEURL, () => UserApi.list());
-
-  return {
-    users: entities,
-    isLoading,
-    isError,
-    refresh,
-  };
 };
 
 /**

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -10,6 +10,7 @@ import {
   defaultUser,
 } from "@/types/user";
 import { buildQueryString } from "./query-params";
+import { type Option, Some, None } from "@/types/option";
 
 export const USERS_BASEURL: string = `${siteConfig.env.backendServiceURL}/users`;
 
@@ -25,11 +26,11 @@ export const UserApi = {
    *   may not see them. The backend makes those two cases indistinguishable so
    *   the endpoint can't be used to enumerate accounts.
    */
-  lookupByEmail: async (email: string): Promise<UserLookupResult | null> => {
+  lookupByEmail: async (email: string): Promise<Option<UserLookupResult>> => {
     const results = await EntityApi.getFn<UserLookupResult[]>(
       `${USERS_BASEURL}${buildQueryString({ email })}`
     );
-    return results[0] ?? null;
+    return results.length > 0 ? Some(results[0]) : None;
   },
 
   /**

--- a/src/lib/hooks/use-assigned-actions.ts
+++ b/src/lib/hooks/use-assigned-actions.ts
@@ -59,6 +59,9 @@ export function useAssignedActions(
     enrichedSessions: sessions,
     isLoading: sessionsLoading,
     isError: sessionsError,
+  // TODO(rs#374): pass the current organization once GET /users/{id}/actions
+  // accepts one. Scoping these sessions alone would strip context off
+  // out-of-organization actions rather than hide them.
   } = useEnrichedCoachingSessionsForUser(
     userId,
     oneYearAgo,

--- a/src/lib/hooks/use-session-context-fetch.ts
+++ b/src/lib/hooks/use-session-context-fetch.ts
@@ -23,6 +23,9 @@ export function useSessionContextFetch(userId: string | null) {
     enrichedSessions: sessions,
     isLoading,
     isError,
+  // TODO(rs#374): pass the current organization once GET /users/{id}/actions
+  // accepts one. Scoping these sessions alone would strip context off
+  // out-of-organization actions rather than hide them.
   } = useEnrichedCoachingSessionsForUser(userId, oneYearAgo, oneYearFromNow, [
     CoachingSessionInclude.Relationship,
     CoachingSessionInclude.Goal,

--- a/src/lib/hooks/use-todays-sessions.ts
+++ b/src/lib/hooks/use-todays-sessions.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/api/coaching-sessions";
 import { getBrowserTimezone } from "@/lib/timezone-utils";
 import { useInterval } from "@/lib/hooks/use-interval";
+import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
 
 /**
  * Hook to fetch today's coaching sessions.
@@ -31,6 +32,7 @@ export function useTodaysSessions(
 
   const userId = userSession?.id;
   const timezone = userSession?.timezone || getBrowserTimezone();
+  const { currentOrganizationId } = useCurrentOrganization();
 
   // Force re-render every 30 seconds to update urgency messages in real-time
   const [tick, setTick] = useState(0);
@@ -60,7 +62,10 @@ export function useTodaysSessions(
       endOfDayUTC,
       include,
       "date",
-      "asc"
+      "asc",
+      undefined,
+      undefined,
+      currentOrganizationId ?? undefined
     );
 
   return {

--- a/src/lib/hooks/use-todays-sessions.ts
+++ b/src/lib/hooks/use-todays-sessions.ts
@@ -55,9 +55,12 @@ export function useTodaysSessions(
   // Use UTC dates for backend filtering since backend stores timestamps in UTC
   // TypeScript non-null assertion: middleware guarantees userId exists on protected routes
   // If userId is briefly undefined during hydration, SWR will show loading state
+  // A null user id skips the fetch. Waiting for the organization matters as much
+  // as sending it: fetching first returns every organization's sessions and the
+  // cards render them before the scoped result replaces them.
   const { enrichedSessions, isLoading, isError, refresh } =
     useEnrichedCoachingSessionsForUser(
-      userId!,
+      currentOrganizationId ? userId! : null,
       startOfDayUTC,
       endOfDayUTC,
       include,

--- a/src/test-utils/msw-handlers.ts
+++ b/src/test-utils/msw-handlers.ts
@@ -60,4 +60,24 @@ export const handlers = [
     return new HttpResponse(null, { status: 200 });
   }),
 
+  // User lookup by exact email: 0 or 1 results, never a 404. Tests that care
+  // about a match override this with server.use().
+  http.get("*/users", ({ request }) => {
+    const email = new URL(request.url).searchParams.get("email");
+    if (!email) {
+      return new HttpResponse(null, { status: 400 });
+    }
+    return HttpResponse.json({ status_code: 200, data: [] });
+  }),
+
+  // Grant an existing user membership of an organization
+  http.post("*/organizations/:organizationId/users/:userId/role", () => {
+    return HttpResponse.json({ status_code: 200, data: { id: "user-1" } });
+  }),
+
+  // Remove a user's membership of an organization (account untouched)
+  http.delete("*/organizations/:organizationId/users/:userId/role", () => {
+    return HttpResponse.json({ status_code: 200, data: null });
+  }),
+
 ];

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -96,7 +96,9 @@ export function organizationInitials(name: string | undefined): string {
   // back to the word's first two letters ("Acme" -> "AC").
   const parts = words[0].match(/\p{Lu}+\p{Ll}*|\p{Ll}+/gu) ?? [];
   const letters =
-    parts.length > 1 ? parts.map((part) => part[0]) : Array.from(words[0]);
+    parts.length > 1
+      ? parts.map((part) => Array.from(part)[0])
+      : Array.from(words[0]);
 
   return letters.slice(0, 2).join("").toUpperCase();
 }

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -78,17 +78,27 @@ export function defaultOrganizations(): Organization[] {
   return [defaultOrganization()];
 }
 
-/** Up-to-two-letter avatar initials: "Refactor Group" -> "RG", "BigTable" -> "BI", "" -> "?". */
+/** Up-to-two-letter avatar initials: "Refactor Group" -> "RG", "BigTable" -> "BT", "" -> "?". */
 export function organizationInitials(name: string | undefined): string {
   const words = (name ?? "").split(/\s+/).filter(Boolean);
   if (words.length === 0) return "?";
 
-  const letters =
-    words.length === 1
-      ? Array.from(words[0]).slice(0, 2)
-      : words.slice(0, 2).map((word) => Array.from(word)[0]);
+  if (words.length > 1) {
+    return words
+      .slice(0, 2)
+      .map((word) => Array.from(word)[0])
+      .join("")
+      .toUpperCase();
+  }
 
-  return letters.join("").toUpperCase();
+  // A single word may be camel or Pascal case, where a capital starts a new
+  // part ("BigTable" -> "BT"). One part means no internal boundary, so fall
+  // back to the word's first two letters ("Acme" -> "AC").
+  const parts = words[0].match(/\p{Lu}+\p{Ll}*|\p{Ll}+/gu) ?? [];
+  const letters =
+    parts.length > 1 ? parts.map((part) => part[0]) : Array.from(words[0]);
+
+  return letters.slice(0, 2).join("").toUpperCase();
 }
 
 export function organizationToString(organization: Organization): string {

--- a/src/types/organization.ts
+++ b/src/types/organization.ts
@@ -78,6 +78,19 @@ export function defaultOrganizations(): Organization[] {
   return [defaultOrganization()];
 }
 
+/** Up-to-two-letter avatar initials: "Refactor Group" -> "RG", "BigTable" -> "BI", "" -> "?". */
+export function organizationInitials(name: string | undefined): string {
+  const words = (name ?? "").split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+
+  const letters =
+    words.length === 1
+      ? Array.from(words[0]).slice(0, 2)
+      : words.slice(0, 2).map((word) => Array.from(word)[0]);
+
+  return letters.join("").toUpperCase();
+}
+
 export function organizationToString(organization: Organization): string {
   return JSON.stringify(organization);
 }

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -198,6 +198,32 @@ export function isSuperAdmin(roles: UserRole[]): boolean {
 }
 
 /**
+ * Whether adding an *existing* account to an organization can do anything for
+ * this user.
+ *
+ * The lookup behind that flow only returns users who belong to an organization
+ * the requester administers, and adding someone to an organization they are
+ * already in is rejected. An admin of a single organization therefore has a
+ * visible set that is exactly their existing members, so the flow can only ever
+ * conflict. Two or more administered organizations gives them somewhere to move
+ * people from; a SuperAdmin sees every account.
+ *
+ * @param roles - Every role assignment the user holds, across all organizations
+ * @returns true when the add-existing-member flow has candidates to offer
+ */
+export function canAddExistingMembers(roles: UserRole[]): boolean {
+  if (isSuperAdmin(roles)) return true;
+
+  const administered = new Set(
+    roles
+      .filter((r) => r.role === Role.Admin && r.organization_id != null)
+      .map((r) => r.organization_id)
+  );
+
+  return administered.size > 1;
+}
+
+/**
  * Sorts users alphabetically by name, with the option to place a specific user first.
  *
  * @param users - Array of users to sort

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -62,6 +62,8 @@ export interface NewUser {
   email: string;
   password?: string;
   timezone: string;
+  /// Coach to assign in the same request. Omitted when no coach is chosen.
+  coach_id?: Id;
 }
 
 export interface NewUserPassword {

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -43,6 +43,18 @@ export interface User {
   invite_status: InviteStatus | null;
 }
 
+/**
+ * Narrow projection returned by the email lookup. Deliberately not `User`: the
+ * server sends only these fields, so reaching for roles or timezone on a lookup
+ * result fails at compile time instead of rendering undefined.
+ */
+export interface UserLookupResult {
+  id: Id;
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
 export interface NewUser {
   first_name: string;
   last_name: string;


### PR DESCRIPTION
## Description

Frontend for multi-organization membership: adds an existing user to an organization with an explicit role and an optional pre-assigned coach, and fixes the cross-organization leaks that became reachable once a user could belong to two organizations.

Pairs with refactor-group/refactor-platform-rs#376. **They must land together**: the session hooks now send an `organization_id` the backend only accepts after that PR merges.

### Changes

* `add-member-dialog.tsx` becomes two modes, gated on `isAdminOrSuperAdmin`: **Create new member** (unchanged) and **Add existing member** (find by email, confirm, pick a role, add). Copy states the shared-account semantics, since an org admin is less likely than a SuperAdmin to reason about them.
* A **Clear** button discards a found user, for when the wrong person comes back.
* Both modes can **pre-assign a coach**. The coach goes in the same request, so a failed assignment means no membership and no welcome email rather than a half-created member who was already emailed.
* Session hooks take an optional `organizationId`, included in the request **and in the SWR key**. Without it in the key, switching organizations serves the previous one's cached list, which looks exactly like the bug being fixed.
* `organization-switcher.tsx` derives avatar initials from the selected organization instead of a hardcoded `"RG"`, at all three render sites. Internal capitals count as word boundaries, so "BigTable" reads "BT" and "Refactor Group" reads "RG".
* `use-todays-sessions.ts` passes the selected organization, fixing the Upcoming Session and Goals Overview cards.
* Removed the dead `useUserList()` / `UserApi.list()` that called a nonexistent `GET /users`.

### Screenshots / Videos Showing UI Changes (if applicable)

**If you're only 1 organization admin user**
<img width="567" height="674" alt="Screenshot 2026-08-07 at 18 06 10" src="https://github.com/user-attachments/assets/6376e822-c006-4402-a197-a50afba848e3" />

**If you're an organization admin of 2 or more organizations or a super admin**
<img width="566" height="731" alt="Screenshot 2026-08-07 at 18 06 36" src="https://github.com/user-attachments/assets/de7d3198-d7d3-489b-9cad-714c9d4162f3" />

**...you can add existing members to your organization**
<img width="565" height="600" alt="Screenshot 2026-08-07 at 18 06 48" src="https://github.com/user-attachments/assets/2c497928-ccc3-4196-b99f-03ab17535dae" />

They'll be able to switch between these organizations then when logged in.

### Testing Strategy

`npm run lint` (0 errors, 9 pre-existing warnings), `npx tsc --noEmit` clean, `npm test` at **156 files / 1671 tests**.

Two live Playwright specs against a real backend and Chrome, both `LIVE_E2E=1` gated:

* `multi-org-live.spec.ts` walks the whole driving use case. Not idempotent, needs a fresh database.
* `multi-org-scoping-live.spec.ts` is read-only and repeatable: it pins the avatar initials, that session requests carry the selected organization and refetch on switch, and that neither the Upcoming/Previous tabs nor the Upcoming Session card show another organization's sessions.

Every new assertion was sabotage-checked. Two of those checks caught real gaps rather than confirming a guess:

* Keeping `organization_id` in the request but removing it from the SWR key left the request-shape test **passing** while only the cache test failed.
* The live run found the Upcoming Session card still bleeding after the tabs were fixed, because `use-todays-sessions` was a separate unscoped call site. Its existing unit test was named "should fetch sessions from all organizations", pinning the old behavior as correct.

### Concerns

* **Coordinated deploy required.** Shipping this before the backend means `organization_id` is rejected as an unknown field.
* A brand-new organization's admin will find the lookup returns nothing, because they share no administered organization with anyone yet. Pinned as a test so a future scope change is deliberate. Discussion is in the backend PR.
* The Assigned Actions card still shows actions from every organization. It needs `GET /users/{user_id}/actions` to gain an `organization_id` first, tracked in refactor-group/refactor-platform-rs#374.
* `useUserList` was deleted; the members page uses the org-scoped hook of the same name from `lib/api/organizations/users.ts`, which is easy to confuse when reviewing.
