### PR TITLE
Handle revoked org membership on read paths

### DIFF
--- a/__tests__/components/members/member-card-remove.test.tsx
+++ b/__tests__/components/members/member-card-remove.test.tsx
@@ -26,7 +26,10 @@ vi.mock("sonner", () => ({
 }));
 
 vi.mock("@/lib/hooks/use-current-organization", () => ({
-  useCurrentOrganization: () => ({ currentOrganizationId: "org-1" }),
+  useCurrentOrganization: () => ({
+    currentOrganizationId: "org-1",
+    currentOrganization: { id: "org-1", name: "Acme Corp" },
+  }),
 }));
 
 const mockAuthStore = vi.fn();
@@ -131,11 +134,17 @@ describe("MemberCard – remove from organization", () => {
     renderCard();
 
     await openRemoveDialog(user);
+    // Naming the organization matters here: an admin who administers several
+    // should not have to infer which one they are removing someone from.
+    expect(
+      await screen.findByText(/Remove Ada Lovelace from Acme Corp/)
+    ).toBeInTheDocument();
     expect(
       await screen.findByText(
         /They immediately lose access to this organization's coaching sessions, notes and actions\./
       )
     ).toBeInTheDocument();
+    expect(await screen.findByText("Nothing is deleted.")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() => expect(roleCalls).toHaveLength(1));

--- a/__tests__/components/members/member-card-remove.test.tsx
+++ b/__tests__/components/members/member-card-remove.test.tsx
@@ -133,7 +133,7 @@ describe("MemberCard – remove from organization", () => {
     await openRemoveDialog(user);
     expect(
       await screen.findByText(
-        /Remove them from this organization only\. Their account and any other organizations are unaffected\./
+        /They immediately lose access to this organization's coaching sessions, notes and actions\./
       )
     ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Remove" }));

--- a/__tests__/components/organization-switcher-reconcile.test.tsx
+++ b/__tests__/components/organization-switcher-reconcile.test.tsx
@@ -1,0 +1,113 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SidebarState } from "@/types/sidebar";
+
+const h = vi.hoisted(() => ({
+  ORGANIZATIONS: [
+    { id: "org-1", name: "Acme Corp", slug: "acme-corp" },
+    { id: "org-2", name: "Beta Inc", slug: "beta-inc" },
+  ],
+  listState: {
+    organizations: [] as unknown[],
+    isLoading: false,
+    isError: false as unknown,
+  },
+  currentOrganizationId: "",
+  setCurrentOrganizationId: vi.fn(),
+}));
+
+vi.mock("@/lib/api/organizations", () => ({
+  useOrganizationList: () => h.listState,
+  useOrganization: () => ({
+    organization: null,
+    isLoading: false,
+    isError: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/api/coaching-relationships", () => ({
+  useCoachingRelationshipList: () => ({ relationships: [] }),
+}));
+
+vi.mock("@/lib/hooks/use-current-organization", () => ({
+  useCurrentOrganization: () => ({
+    currentOrganizationId: h.currentOrganizationId,
+    currentOrganization: null,
+    setCurrentOrganizationId: h.setCurrentOrganizationId,
+  }),
+}));
+
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ userId: "user-1", isLoggedIn: true, setIsACoach: vi.fn() }),
+}));
+
+vi.mock("@/components/ui/sidebar", () => ({
+  useSidebar: () => ({ state: SidebarState.Expanded }),
+}));
+
+import { OrganizationSwitcher } from "@/components/ui/organization-switcher";
+
+// The switcher decides whether membership is knowable before handing it to the
+// reconciler. Getting that wrong in the "still loading" direction is the
+// dangerous case: an empty list would look like "you belong nowhere" and clear
+// a perfectly valid selection.
+describe("OrganizationSwitcher — membership gating", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.listState = {
+      organizations: h.ORGANIZATIONS,
+      isLoading: false,
+      isError: false,
+    };
+    h.currentOrganizationId = "";
+  });
+
+  it("leaves the selection alone while the organization list is loading", () => {
+    h.listState = { organizations: [], isLoading: true, isError: false };
+    h.currentOrganizationId = "org-1";
+
+    render(<OrganizationSwitcher />);
+
+    expect(h.setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("leaves the selection alone when the organization list errors", () => {
+    h.listState = {
+      organizations: [],
+      isLoading: false,
+      isError: new Error("boom"),
+    };
+    h.currentOrganizationId = "org-1";
+
+    render(<OrganizationSwitcher />);
+
+    expect(h.setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("does not select a default while the list is still loading", () => {
+    h.listState = { organizations: [], isLoading: true, isError: false };
+    h.currentOrganizationId = "";
+
+    render(<OrganizationSwitcher />);
+
+    expect(h.setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("reconciles once the list has genuinely loaded", () => {
+    h.currentOrganizationId = "org-gone";
+
+    render(<OrganizationSwitcher />);
+
+    expect(h.setCurrentOrganizationId).toHaveBeenCalledWith("org-1");
+  });
+
+  it("keeps a selection that is still in the loaded list", () => {
+    h.currentOrganizationId = "org-2";
+
+    render(<OrganizationSwitcher />);
+
+    expect(h.setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/e2e/helpers.ts
+++ b/__tests__/e2e/helpers.ts
@@ -231,11 +231,20 @@ export async function mockCommonApiRoutes(
     })
   })
 
-  await page.route('**/organizations', async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
-    })
-  })
+  // Matched on pathname rather than a glob: the real request carries a
+  // `?user_id=` query that `**/organizations` does not match, which silently
+  // handed this endpoint to the catch-all above and told the app the user
+  // belonged to no organizations. A `**/organizations**` glob would fix that
+  // but would also swallow the `/organizations/{id}/coaching_relationships`
+  // sub-routes that individual specs mock.
+  await page.route(
+    (url) => url.pathname.endsWith('/organizations'),
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: MOCK_ORGANIZATIONS }),
+      })
+    }
+  )
 }

--- a/__tests__/hooks/use-current-user-role.test.tsx
+++ b/__tests__/hooks/use-current-user-role.test.tsx
@@ -192,10 +192,15 @@ describe('useCurrentUserRole', () => {
 
     renderHook(() => useCurrentUserRole());
 
-    expect(mockToast.error).toHaveBeenCalledWith('No roles assigned. Please contact support.');
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'No roles assigned. Please contact support.',
+      { id: 'user-role-no-roles' }
+    );
   });
 
-  it('should show toast notification for no_org_selected state', () => {
+  // Transient by construction — the switcher settles on an organization a tick
+  // later, so toasting it just flashes noise on every sign-in.
+  it('should stay silent for the no_org_selected state', () => {
     const userRole: UserRole = {
       id: 'role-4',
       user_id: 'user-4',
@@ -221,7 +226,7 @@ describe('useCurrentUserRole', () => {
 
     renderHook(() => useCurrentUserRole());
 
-    expect(mockToast.info).toHaveBeenCalledWith('Please select an organization to continue.');
+    expect(mockToast.info).not.toHaveBeenCalled();
   });
 
   it('should show toast notification for no_access state', () => {
@@ -250,6 +255,43 @@ describe('useCurrentUserRole', () => {
 
     renderHook(() => useCurrentUserRole());
 
-    expect(mockToast.warning).toHaveBeenCalledWith("You don't have access to this organization.");
+    expect(mockToast.warning).toHaveBeenCalledWith(
+      "You don't have access to this organization.",
+      { id: 'user-role-no-access' }
+    );
+  });
+
+  // Every consumer of this hook runs the toast effect, so a shared id is what
+  // keeps one bad state from stacking a toast per mounted component.
+  it('collapses the no_access toast across concurrent consumers', () => {
+    const userRole: UserRole = {
+      id: 'role-6',
+      user_id: 'user-6',
+      role: Role.User,
+      organization_id: 'org-1',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01'
+    };
+
+    mockUseAuthStore.mockReturnValue({
+      userSession: {
+        id: 'user-6',
+        roles: [userRole]
+      } as User,
+      isLoggedIn: true
+    });
+
+    mockUseCurrentOrganization.mockReturnValue({
+      currentOrganizationId: 'org-2',
+      setCurrentOrganizationId: vi.fn(),
+      resetOrganizationState: vi.fn()
+    });
+
+    renderHook(() => useCurrentUserRole());
+    renderHook(() => useCurrentUserRole());
+    renderHook(() => useCurrentUserRole());
+
+    const ids = mockToast.warning.mock.calls.map(([, options]) => options?.id);
+    expect(new Set(ids)).toEqual(new Set(['user-role-no-access']));
   });
 });

--- a/__tests__/lib/hooks/use-fail-fast-retry.test.tsx
+++ b/__tests__/lib/hooks/use-fail-fast-retry.test.tsx
@@ -1,0 +1,116 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AxiosError } from "axios";
+import { SWRConfig, type SWRConfiguration } from "swr";
+import type { ReactNode } from "react";
+import { useFailFastRetry } from "@/lib/hooks/use-fail-fast-retry";
+import { EntityApiError, httpStatusOf } from "@/types/entity-api-error";
+
+function axiosErrorWithStatus(status: number): AxiosError {
+  const error = new AxiosError("request failed");
+  error.response = { status } as AxiosError["response"];
+  return error;
+}
+
+function entityApiError(status: number): EntityApiError {
+  return EntityApiError.from("get", "/organizations", axiosErrorWithStatus(status));
+}
+
+// SWR's default onErrorRetry is what the hook delegates to when a status isn't
+// terminal. Replacing it with a spy makes the delegation observable.
+function renderFailFastRetry(
+  defaultOnErrorRetry: SWRConfiguration["onErrorRetry"],
+  callerOnErrorRetry?: SWRConfiguration["onErrorRetry"]
+) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SWRConfig value={{ onErrorRetry: defaultOnErrorRetry }}>{children}</SWRConfig>
+  );
+  return renderHook(() => useFailFastRetry(callerOnErrorRetry), { wrapper });
+}
+
+const RETRY_ARGS = [
+  "/organizations",
+  {} as never,
+  vi.fn(),
+  { retryCount: 1 },
+] as const;
+
+describe("httpStatusOf", () => {
+  it("reads the status off an EntityApiError", () => {
+    expect(httpStatusOf(entityApiError(403))).toEqual({
+      some: true,
+      none: false,
+      val: 403,
+    });
+  });
+
+  it("falls back to a raw axios response status", () => {
+    expect(httpStatusOf(axiosErrorWithStatus(404))).toEqual({
+      some: true,
+      none: false,
+      val: 404,
+    });
+  });
+
+  it("is None for a non-HTTP failure", () => {
+    expect(httpStatusOf(new Error("network down")).none).toBe(true);
+  });
+});
+
+describe("useFailFastRetry", () => {
+  it.each([401, 403])("stops retrying on %i", (status) => {
+    const defaultRetry = vi.fn();
+    const { result } = renderFailFastRetry(defaultRetry);
+
+    result.current(entityApiError(status), ...RETRY_ARGS);
+
+    expect(defaultRetry).not.toHaveBeenCalled();
+  });
+
+  it("stops on a 403 delivered as a raw axios error", () => {
+    const defaultRetry = vi.fn();
+    const { result } = renderFailFastRetry(defaultRetry);
+
+    result.current(axiosErrorWithStatus(403), ...RETRY_ARGS);
+
+    expect(defaultRetry).not.toHaveBeenCalled();
+  });
+
+  it.each([404, 500, 503])("delegates a retryable %i to SWR", (status) => {
+    const defaultRetry = vi.fn();
+    const { result } = renderFailFastRetry(defaultRetry);
+
+    result.current(entityApiError(status), ...RETRY_ARGS);
+
+    expect(defaultRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("delegates a network error with no status", () => {
+    const defaultRetry = vi.fn();
+    const { result } = renderFailFastRetry(defaultRetry);
+
+    result.current(new Error("network down"), ...RETRY_ARGS);
+
+    expect(defaultRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers the caller's policy over SWR's for retryable failures", () => {
+    const defaultRetry = vi.fn();
+    const callerRetry = vi.fn();
+    const { result } = renderFailFastRetry(defaultRetry, callerRetry);
+
+    result.current(entityApiError(503), ...RETRY_ARGS);
+
+    expect(callerRetry).toHaveBeenCalledTimes(1);
+    expect(defaultRetry).not.toHaveBeenCalled();
+  });
+
+  it("overrides the caller's policy on a terminal status", () => {
+    const callerRetry = vi.fn();
+    const { result } = renderFailFastRetry(vi.fn(), callerRetry);
+
+    result.current(entityApiError(403), ...RETRY_ARGS);
+
+    expect(callerRetry).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/hooks/use-logout-user.test.tsx
+++ b/__tests__/lib/hooks/use-logout-user.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  logout: vi.fn(),
+  deleteUserSession: vi.fn().mockResolvedValue(undefined),
+  resetCoachingRelationshipState: vi.fn(),
+  resetCoachingSessionsCardFilters: vi.fn(),
+  resetOrganizationState: vi.fn(),
+  clearCache: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock("@/lib/api/user-sessions", () => ({
+  useUserSessionMutation: () => ({ delete: mocks.deleteUserSession }),
+}));
+
+vi.mock("@/lib/providers/auth-store-provider", () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({ logout: mocks.logout, userSession: { id: "user-1" } }),
+}));
+
+vi.mock("@/lib/providers/coaching-relationship-state-store-provider", () => ({
+  useCoachingRelationshipStateStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      resetCoachingRelationshipState: mocks.resetCoachingRelationshipState,
+    }),
+}));
+
+vi.mock("@/lib/providers/coaching-sessions-card-filter-store-provider", () => ({
+  useCoachingSessionsCardFilterStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      resetCoachingSessionsCardFilters: mocks.resetCoachingSessionsCardFilters,
+    }),
+}));
+
+vi.mock("@/lib/providers/organization-state-store-provider", () => ({
+  useOrganizationStateStore: (selector: (s: unknown) => unknown) =>
+    selector({ resetOrganizationState: mocks.resetOrganizationState }),
+}));
+
+vi.mock("@/lib/api/entity-api", () => ({
+  EntityApi: { useClearCache: () => mocks.clearCache },
+}));
+
+import { useLogoutUser } from "@/lib/hooks/use-logout-user";
+
+describe("useLogoutUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteUserSession.mockResolvedValue(undefined);
+  });
+
+  // The organization selection is persisted to localStorage, so leaving it
+  // behind hands the next user to sign in on this browser an organization they
+  // may not belong to.
+  it("clears the persisted organization selection", async () => {
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the organization selection even when the backend logout fails", async () => {
+    mocks.deleteUserSession.mockRejectedValue(new Error("network down"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+    expect(mocks.replace).toHaveBeenCalledWith("/");
+  });
+
+  it("resets the other client-side stores alongside it", async () => {
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.logout).toHaveBeenCalled();
+    expect(mocks.clearCache).toHaveBeenCalledTimes(1);
+    expect(mocks.resetCoachingRelationshipState).toHaveBeenCalledTimes(1);
+    expect(mocks.resetCoachingSessionsCardFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/hooks/use-logout-user.test.tsx
+++ b/__tests__/lib/hooks/use-logout-user.test.tsx
@@ -131,6 +131,37 @@ describe("useLogoutUser", () => {
     expect(mocks.replace).toHaveBeenCalledWith("/");
   });
 
+  // Teardown must not be sequenced behind the backend round trip. If it is, a
+  // slow request leaves the organization in localStorage for its whole
+  // duration, and a tab closed mid-logout leaves it there permanently.
+  it("clears local state before awaiting the backend session delete", async () => {
+    const order: string[] = [];
+    mocks.resetOrganizationState.mockImplementation(() => {
+      order.push("resetOrganizationState");
+    });
+    mocks.deleteUserSession.mockImplementation(async () => {
+      order.push("deleteUserSession");
+    });
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(order).toEqual(["resetOrganizationState", "deleteUserSession"]);
+  });
+
+  it("clears local state even when the backend session delete never settles", async () => {
+    mocks.deleteUserSession.mockImplementation(() => new Promise(() => {}));
+    const { result } = renderHook(() => useLogoutUser());
+
+    void result.current();
+    // Let the microtask queue drain; the teardown must already have run even
+    // though the request is still outstanding.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+  });
+
   it("tears down local state even when component cleanup rejects", async () => {
     mocks.executeAll.mockRejectedValue(new Error("cleanup blew up"));
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/__tests__/lib/hooks/use-logout-user.test.tsx
+++ b/__tests__/lib/hooks/use-logout-user.test.tsx
@@ -9,10 +9,15 @@ const mocks = vi.hoisted(() => ({
   resetOrganizationState: vi.fn(),
   clearCache: vi.fn(),
   replace: vi.fn(),
+  executeAll: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mocks.replace }),
+}));
+
+vi.mock("@/lib/hooks/logout-cleanup-registry", () => ({
+  logoutCleanupRegistry: { executeAll: mocks.executeAll },
 }));
 
 vi.mock("@/lib/api/user-sessions", () => ({
@@ -51,8 +56,15 @@ import { useLogoutUser } from "@/lib/hooks/use-logout-user";
 
 describe("useLogoutUser", () => {
   beforeEach(() => {
+    // clearAllMocks only clears recorded calls, so implementations set by a
+    // throwing test would otherwise leak into the next one.
     vi.clearAllMocks();
     mocks.deleteUserSession.mockResolvedValue(undefined);
+    mocks.executeAll.mockResolvedValue(undefined);
+    mocks.clearCache.mockImplementation(() => {});
+    mocks.resetCoachingRelationshipState.mockImplementation(() => {});
+    mocks.resetCoachingSessionsCardFilters.mockImplementation(() => {});
+    mocks.resetOrganizationState.mockImplementation(() => {});
   });
 
   // The organization selection is persisted to localStorage, so leaving it
@@ -86,5 +98,47 @@ describe("useLogoutUser", () => {
     expect(mocks.clearCache).toHaveBeenCalledTimes(1);
     expect(mocks.resetCoachingRelationshipState).toHaveBeenCalledTimes(1);
     expect(mocks.resetCoachingSessionsCardFilters).toHaveBeenCalledTimes(1);
+  });
+
+  // A teardown step that throws must not strand the ones after it — otherwise
+  // the organization selection survives in localStorage and the next user on
+  // this browser inherits it.
+  it("clears the organization selection even when another teardown step throws", async () => {
+    mocks.resetCoachingRelationshipState.mockImplementation(() => {
+      throw new Error("subscriber blew up");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+    expect(mocks.resetCoachingSessionsCardFilters).toHaveBeenCalledTimes(1);
+    expect(mocks.clearCache).toHaveBeenCalledTimes(1);
+    expect(mocks.replace).toHaveBeenCalledWith("/");
+  });
+
+  it("still navigates away when the cache clear throws", async () => {
+    mocks.clearCache.mockImplementation(() => {
+      throw new Error("cache walk blew up");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+    expect(mocks.replace).toHaveBeenCalledWith("/");
+  });
+
+  it("tears down local state even when component cleanup rejects", async () => {
+    mocks.executeAll.mockRejectedValue(new Error("cleanup blew up"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+    expect(mocks.replace).toHaveBeenCalledWith("/");
   });
 });

--- a/__tests__/lib/hooks/use-reconcile-current-organization.test.ts
+++ b/__tests__/lib/hooks/use-reconcile-current-organization.test.ts
@@ -1,0 +1,100 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { DateTime } from "ts-luxon";
+import {
+  useReconcileCurrentOrganization,
+  type OrganizationMembership,
+} from "@/lib/hooks/use-reconcile-current-organization";
+import type { Organization } from "@/types/organization";
+
+function organization(id: string, name: string): Organization {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    created_at: DateTime.now(),
+    updated_at: DateTime.now(),
+  };
+}
+
+const ACME = organization("org-1", "Acme Corp");
+const BETA = organization("org-2", "Beta Inc");
+
+function renderReconciler(
+  membership: OrganizationMembership,
+  currentOrganizationId: string
+) {
+  const setCurrentOrganizationId = vi.fn();
+  const rendered = renderHook(
+    ({ membership, currentOrganizationId }) =>
+      useReconcileCurrentOrganization(
+        membership,
+        currentOrganizationId,
+        setCurrentOrganizationId
+      ),
+    { initialProps: { membership, currentOrganizationId } }
+  );
+  return { ...rendered, setCurrentOrganizationId };
+}
+
+const loaded = (organizations: Organization[]): OrganizationMembership => ({
+  kind: "loaded",
+  organizations,
+});
+
+describe("useReconcileCurrentOrganization", () => {
+  it("clears a selection the user is no longer a member of", () => {
+    const { setCurrentOrganizationId } = renderReconciler(
+      loaded([BETA]),
+      ACME.id
+    );
+
+    expect(setCurrentOrganizationId).toHaveBeenCalledWith(BETA.id);
+  });
+
+  it("clears to empty when no organizations remain", () => {
+    const { setCurrentOrganizationId } = renderReconciler(loaded([]), ACME.id);
+
+    expect(setCurrentOrganizationId).toHaveBeenCalledWith("");
+  });
+
+  it("leaves a still-valid selection alone", () => {
+    const { setCurrentOrganizationId } = renderReconciler(
+      loaded([ACME, BETA]),
+      BETA.id
+    );
+
+    expect(setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("selects the first organization when none is set", () => {
+    const { setCurrentOrganizationId } = renderReconciler(
+      loaded([ACME, BETA]),
+      ""
+    );
+
+    expect(setCurrentOrganizationId).toHaveBeenCalledWith(ACME.id);
+  });
+
+  it("stays inert while membership is unknown", () => {
+    const { setCurrentOrganizationId } = renderReconciler(
+      { kind: "unknown" },
+      ACME.id
+    );
+
+    expect(setCurrentOrganizationId).not.toHaveBeenCalled();
+  });
+
+  it("does not fight code that re-selects a revoked organization", () => {
+    const { rerender, setCurrentOrganizationId } = renderReconciler(
+      loaded([BETA]),
+      ACME.id
+    );
+    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
+
+    rerender({ membership: loaded([BETA]), currentOrganizationId: BETA.id });
+    rerender({ membership: loaded([BETA]), currentOrganizationId: ACME.id });
+
+    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/hooks/use-reconcile-current-organization.test.ts
+++ b/__tests__/lib/hooks/use-reconcile-current-organization.test.ts
@@ -86,15 +86,33 @@ describe("useReconcileCurrentOrganization", () => {
   });
 
   it("does not fight code that re-selects a revoked organization", () => {
+    const membership = loaded([BETA]);
+    const { rerender, setCurrentOrganizationId } = renderReconciler(
+      membership,
+      ACME.id
+    );
+    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
+
+    // Same snapshot object throughout — no new evidence has arrived.
+    rerender({ membership, currentOrganizationId: BETA.id });
+    rerender({ membership, currentOrganizationId: ACME.id });
+
+    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
+  });
+
+  // Without this, a route that writes a revoked id back into global state
+  // (the members page syncs it from the URL) pins that id until the component
+  // unmounts, and every organization-scoped read keeps aiming at it.
+  it("reconsiders a written-back id once a fresh membership snapshot arrives", () => {
     const { rerender, setCurrentOrganizationId } = renderReconciler(
       loaded([BETA]),
       ACME.id
     );
     expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
 
-    rerender({ membership: loaded([BETA]), currentOrganizationId: BETA.id });
     rerender({ membership: loaded([BETA]), currentOrganizationId: ACME.id });
 
-    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(1);
+    expect(setCurrentOrganizationId).toHaveBeenCalledTimes(2);
+    expect(setCurrentOrganizationId).toHaveBeenLastCalledWith(BETA.id);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,6 +47,33 @@ const eslintConfig = defineConfig([
     },
   },
 
+  // Reads go through useApiSWR so they inherit the fail-fast retry policy (see
+  // use-fail-fast-retry.ts). A bare `useSWR` silently opts out of it, which is
+  // invisible in review, so route new call sites through the wrapper. The two
+  // files that legitimately own SWR plumbing are exempted below.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: [
+      "src/lib/hooks/use-api-swr.ts",
+      "src/lib/hooks/use-swr-with-backoff.ts",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "swr",
+              importNames: ["default"],
+              message:
+                "Use useApiSWR from @/lib/hooks/use-api-swr so the read inherits the fail-fast retry policy. Named exports (useSWRConfig, types) are fine.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // React Compiler rules added in eslint-config-next@16 (new in v16, not present in v15).
   // Enabled as warnings for visibility; address incrementally.
   {

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -135,6 +135,8 @@ export function MemberCard({
     } catch (error) {
       console.error("Error removing member from organization:", error);
       toast.error(
+        // TODO(rs#377): drop this first entry once the backend merges — the
+        // 409 it handles is deleted there and removal returns 204.
         userHasCoachingHistoryMessage(error) ??
           lastOrganizationAdminMessage(error) ??
           organizationArchivedMessage(error) ??
@@ -332,8 +334,10 @@ export function MemberCard({
               Remove {firstName} {lastName} from this organization
             </AlertDialogTitle>
             <AlertDialogDescription>
-              Remove them from this organization only. Their account and any
-              other organizations are unaffected.
+              They immediately lose access to this organization&apos;s coaching
+              sessions, notes and actions. Nothing is deleted — their coaching
+              history stays, and the people they work with here keep access to
+              it. Their account and any other organizations are unaffected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -80,7 +80,8 @@ export function MemberCard({
   users,
   currentUserRoleState,
 }: MemberCardProps) {
-  const { currentOrganizationId } = useCurrentOrganization();
+  const { currentOrganizationId, currentOrganization } =
+    useCurrentOrganization();
   const { userSession } = useAuthStore((state: AuthStore) => state);
 
   // Extract user properties
@@ -331,13 +332,25 @@ export function MemberCard({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Remove {firstName} {lastName} from this organization
+              Remove {firstName} {lastName} from{" "}
+              {currentOrganization?.name ?? "this organization"}
             </AlertDialogTitle>
-            <AlertDialogDescription>
-              They immediately lose access to this organization&apos;s coaching
-              sessions, notes and actions. Nothing is deleted: their coaching
-              history stays with the people they work with here. Their account
-              and other organizations are unaffected.
+            {/* asChild because the description holds two paragraphs, and
+                AlertDialogDescription renders a <p> that cannot nest them. */}
+            <AlertDialogDescription asChild>
+              <div className="space-y-2">
+                <p>
+                  They immediately lose access to this organization&apos;s
+                  coaching sessions, notes and actions.
+                </p>
+                <p>
+                  <span className="italic text-foreground">
+                    Nothing is deleted.
+                  </span>{" "}
+                  Their coaching history stays with the people they work with
+                  here. Their account and other organizations are unaffected.
+                </p>
+              </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/ui/members/member-card.tsx
+++ b/src/components/ui/members/member-card.tsx
@@ -335,9 +335,9 @@ export function MemberCard({
             </AlertDialogTitle>
             <AlertDialogDescription>
               They immediately lose access to this organization&apos;s coaching
-              sessions, notes and actions. Nothing is deleted — their coaching
-              history stays, and the people they work with here keep access to
-              it. Their account and any other organizations are unaffected.
+              sessions, notes and actions. Nothing is deleted: their coaching
+              history stays with the people they work with here. Their account
+              and other organizations are unaffected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/ui/organization-switcher.tsx
+++ b/src/components/ui/organization-switcher.tsx
@@ -21,6 +21,10 @@ import {
 import { useOrganizationList } from "@/lib/api/organizations";
 import { useCoachingRelationshipList } from "@/lib/api/coaching-relationships";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
+import {
+  useReconcileCurrentOrganization,
+  type OrganizationMembership,
+} from "@/lib/hooks/use-reconcile-current-organization";
 import type { PopoverProps } from "@radix-ui/react-popover";
 import type { Id } from "@/types/general";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
@@ -74,27 +78,25 @@ export function OrganizationSwitcher({
     setIsACoach(isUserCoach(userId, relationships));
   }, [userId, relationships, setIsACoach]);
 
-  // Initialize with first organization if none is selected (only when logged in)
+  // Selects a default organization when none is set, and drops a persisted
+  // selection the user is no longer a member of.
   //
-  // Note: This logic can and should change once we add the notion of a user having a default Organization.
-  //       When this happens, the useEffect here should be able to go away and the currentOrganizationId should
-  //       just start off being equal to their default organization's id.
-  useEffect(() => {
-    if (
-      isLoggedIn &&
-      !currentOrganizationId &&
-      organizations &&
-      organizations.length > 0
-    ) {
-      console.trace(
-        "Initializing current organization to: ",
-        organizationToString(organizations[0])
-      );
-      setCurrentOrganizationId(organizations[0].id);
-    }
-    // setCurrentOrganizationId is stable and doesn't need to be in deps
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoggedIn, organizations, currentOrganizationId]);
+  // Note: the default-selection half can go away once a user has the notion of
+  //       a default Organization and currentOrganizationId can start out equal
+  //       to it.
+  const membership = React.useMemo<OrganizationMembership>(
+    () =>
+      isLoggedIn && userId && !isLoading && !isError
+        ? { kind: "loaded", organizations }
+        : { kind: "unknown" },
+    [isLoggedIn, userId, isLoading, isError, organizations]
+  );
+
+  useReconcileCurrentOrganization(
+    membership,
+    currentOrganizationId,
+    setCurrentOrganizationId
+  );
 
   // Filter organizations based on search query
   const filteredOrganizations = React.useMemo(() => {

--- a/src/components/ui/organization-switcher.tsx
+++ b/src/components/ui/organization-switcher.tsx
@@ -33,7 +33,7 @@ import {
   organizationToString,
 } from "@/types/organization";
 import { isUserCoach } from "@/types/coaching-relationship";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 interface OrganizationSelectorProps extends PopoverProps {
   /// Called when an Organization is selected
@@ -84,7 +84,7 @@ export function OrganizationSwitcher({
   // Note: the default-selection half can go away once a user has the notion of
   //       a default Organization and currentOrganizationId can start out equal
   //       to it.
-  const membership = React.useMemo<OrganizationMembership>(
+  const membership = useMemo<OrganizationMembership>(
     () =>
       isLoggedIn && userId && !isLoading && !isError
         ? { kind: "loaded", organizations }

--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -1,12 +1,13 @@
 import { Id, EntityApiError, EMPTY_ARRAY } from "@/types/general";
 import { useState } from "react";
-import useSWR, {
+import {
   KeyedMutator,
   ScopedMutator,
   SWRConfiguration,
   useSWRConfig,
 } from "swr";
 import { sessionGuard } from "@/lib/auth/session-guard";
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
 import axios, { type AxiosRequestConfig } from "axios";
 
 // Re-export EntityApiError for easy access
@@ -370,7 +371,7 @@ export namespace EntityApi {
     // Use SWR's conditional fetching via key nullification
     const key = actualParams ? [url, actualParams] : null;
 
-    const { data, error, isLoading, mutate } = useSWR<T[]>(key, fetcher, {
+    const { data, error, isLoading, mutate } = useApiSWR<T[]>(key, fetcher, {
       revalidateOnMount: true,
       ...swrOptions,
     });
@@ -424,7 +425,7 @@ export namespace EntityApi {
     defaultValue: T,
     options?: SWRConfiguration
   ) => {
-    const { data, error, isLoading, mutate } = useSWR<T>(url, fetcher, {
+    const { data, error, isLoading, mutate } = useApiSWR<T>(url, fetcher, {
       revalidateIfStale: false,
       revalidateOnFocus: false,
       revalidateOnReconnect: false,

--- a/src/lib/api/goals.ts
+++ b/src/lib/api/goals.ts
@@ -1,5 +1,6 @@
 // Interacts with the goal endpoints
 
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
 import { ResultAsync } from "neverthrow";
 import { siteConfig } from "@/site.config";
 import { Id, EntityApiError } from "@/types/general";
@@ -9,7 +10,6 @@ import {
 } from "@/types/goal";
 import { ApiSortOrder, GoalSortField } from "@/types/sorting";
 import { EntityApi, ApiResponse } from "./entity-api";
-import useSWR from "swr";
 import { sessionGuard } from "@/lib/auth/session-guard";
 
 const GOALS_BASEURL: string = `${siteConfig.env.backendServiceURL}/goals`;
@@ -214,7 +214,7 @@ export const useBatchSessionGoals = (coachingRelationshipId: Id | null) => {
     ? `${COACHING_SESSIONS_BASEURL}/goals?coaching_relationship_id=${coachingRelationshipId}`
     : null;
 
-  const { data, error, isLoading, mutate } = useSWR<Record<Id, Goal[]>>(
+  const { data, error, isLoading, mutate } = useApiSWR<Record<Id, Goal[]>>(
     key,
     () => fetchBatchSessionGoals(coachingRelationshipId!),
     { revalidateOnMount: true }

--- a/src/lib/api/meeting-recordings.ts
+++ b/src/lib/api/meeting-recordings.ts
@@ -1,4 +1,5 @@
-import useSWR, { type KeyedMutator } from "swr";
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
+import { type KeyedMutator } from "swr";
 import { siteConfig } from "@/site.config";
 import { EntityApi } from "@/lib/api/entity-api";
 import type { Id } from "@/types/general";
@@ -54,7 +55,7 @@ export function useMeetingRecording(sessionId: Id | null): UseMeetingRecording {
     ? `${COACHING_SESSIONS_BASEURL}/${sessionId}/meeting_recording`
     : null;
 
-  const { data, error, isLoading, mutate } = useSWR<MeetingRecording | null>(
+  const { data, error, isLoading, mutate } = useApiSWR<MeetingRecording | null>(
     url,
     () => MeetingRecordingApi.get(sessionId!),
     { revalidateOnFocus: true }

--- a/src/lib/api/oauth-connection.ts
+++ b/src/lib/api/oauth-connection.ts
@@ -1,9 +1,9 @@
 // Interacts with the OAuth connection endpoints
 
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
 import { siteConfig } from "@/site.config";
 import { OAuthConnection, OAuthProvider } from "@/types/oauth-connection";
 import { EntityApi, EntityApiError } from "./entity-api";
-import useSWR from "swr";
 
 const OAUTH_CONNECTIONS_URL = `${siteConfig.env.backendServiceURL}/oauth/connections`;
 
@@ -55,7 +55,7 @@ export const OAuthConnectionApi = {
  * when connected. Does not surface 404 as an error.
  */
 export const useOAuthConnection = (provider: OAuthProvider) => {
-  const { data, error, isLoading, mutate } = useSWR<OAuthConnection | null>(
+  const { data, error, isLoading, mutate } = useApiSWR<OAuthConnection | null>(
     `${OAUTH_CONNECTIONS_URL}/${provider}`,
     () => OAuthConnectionApi.getByProvider(provider),
     {
@@ -78,7 +78,7 @@ export const useOAuthConnection = (provider: OAuthProvider) => {
  *
  */
 export const useOAuthConnections = () => {
-  const { data, error, isLoading, mutate } = useSWR(
+  const { data, error, isLoading, mutate } = useApiSWR(
     `${OAUTH_CONNECTIONS_URL}`,
     () => OAuthConnectionApi.list(),
     {

--- a/src/lib/api/organization-errors.ts
+++ b/src/lib/api/organization-errors.ts
@@ -59,6 +59,9 @@ export const lastOrganizationAdminMessage = (error: unknown): string | null =>
     "This user is the only admin of this organization. Assign another admin before removing them."
   );
 
+// TODO(rs#377): dead once the backend merges — that 409 variant is deleted and
+// removal returns 204 instead. Remove this, its call site in member-card.tsx,
+// and its test. Branch: chore/remove-dead-user-has-coaching-history-409.
 export const userHasCoachingHistoryMessage = (error: unknown): string | null =>
   orgErrorMessage(
     error,

--- a/src/lib/api/relationship-actions.ts
+++ b/src/lib/api/relationship-actions.ts
@@ -2,6 +2,7 @@
 //   - Single relationship: GET /organizations/{org}/coaching_relationships/{rel}/actions
 //   - Batch (all relationships): GET /organizations/{org}/coaching_relationships/actions?assignee=...
 
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
 import { siteConfig } from "@/site.config";
 import { Id } from "@/types/general";
 import {
@@ -17,7 +18,6 @@ import {
 import { ApiResponse } from "./entity-api";
 import { buildQueryString } from "./query-params";
 import { sessionGuard } from "@/lib/auth/session-guard";
-import useSWR from "swr";
 
 const ORGANIZATIONS_BASEURL = `${siteConfig.env.backendServiceURL}/organizations`;
 const COACHING_RELATIONSHIPS_PATH = "coaching_relationships";
@@ -85,7 +85,7 @@ export function useBatchRelationshipActions(
   const url = orgId ? relationshipActionsUrl(orgId, params) : null;
   const isSingleRelationship = !!params.coaching_relationship_id;
 
-  const { data, error, isLoading, mutate } = useSWR<Action[]>(
+  const { data, error, isLoading, mutate } = useApiSWR<Action[]>(
     url,
     // SWR only invokes the fetcher when key (url) is non-null
     () =>

--- a/src/lib/api/transcriptions.ts
+++ b/src/lib/api/transcriptions.ts
@@ -1,4 +1,5 @@
-import useSWR, { type KeyedMutator } from "swr";
+import { useApiSWR } from "@/lib/hooks/use-api-swr";
+import { type KeyedMutator } from "swr";
 import { siteConfig } from "@/site.config";
 import { EntityApi } from "@/lib/api/entity-api";
 import type { Id } from "@/types/general";
@@ -50,7 +51,7 @@ export function useTranscription(sessionId: Id | null): UseTranscription {
     ? `${COACHING_SESSIONS_BASEURL}/${sessionId}/${TRANSCRIPTIONS_PATH}`
     : null;
 
-  const { data, error, isLoading, mutate } = useSWR<Transcription | null>(
+  const { data, error, isLoading, mutate } = useApiSWR<Transcription | null>(
     url,
     () => TranscriptionApi.get(sessionId!),
   );
@@ -78,7 +79,7 @@ export function useTranscriptionSegments(
       ? `${COACHING_SESSIONS_BASEURL}/${sessionId}/${TRANSCRIPTIONS_PATH}/${transcriptionId}/${SEGMENTS_PATH}`
       : null;
 
-  const { data, error, isLoading } = useSWR<TranscriptSegment[]>(
+  const { data, error, isLoading } = useApiSWR<TranscriptSegment[]>(
     url,
     () => TranscriptionApi.listNested(sessionId!, transcriptionId!),
     {

--- a/src/lib/hooks/use-api-swr.ts
+++ b/src/lib/hooks/use-api-swr.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import useSWR, {
+  type BareFetcher,
+  type Key,
+  type SWRConfiguration,
+  type SWRResponse,
+} from "swr";
+import { useFailFastRetry } from "@/lib/hooks/use-fail-fast-retry";
+
+/**
+ * `useSWR` with this codebase's retry policy applied — see
+ * {@link useFailFastRetry}. Use this instead of `useSWR` directly for any
+ * backend read, so a permanently-denied endpoint stops being retried rather
+ * than being hammered on SWR's unbounded backoff.
+ *
+ * Identical to `useSWR` in every other respect; a caller's own `onErrorRetry`
+ * still governs the failures the policy doesn't treat as terminal.
+ */
+// `Data`/`Err` default to `any` to mirror `useSWR`'s own signature — callers
+// that don't parameterize keep the error type they had before this seam existed.
+export function useApiSWR<Data = any, Err = any>(
+  key: Key,
+  fetcher: BareFetcher<Data> | null,
+  options?: SWRConfiguration<Data, Err>
+): SWRResponse<Data, Err> {
+  const onErrorRetry = useFailFastRetry(options?.onErrorRetry);
+
+  return useSWR<Data, Err>(key, fetcher, { ...options, onErrorRetry });
+}

--- a/src/lib/hooks/use-current-user-role.ts
+++ b/src/lib/hooks/use-current-user-role.ts
@@ -100,15 +100,25 @@ export const useCurrentUserRole = (): UserRoleState => {
   // Show toast notifications for error states (only once per state change).
   // Skip toasts when logged out — userSession going null during logout
   // triggers 'no_roles' which is not a real error.
+  //
+  // The stable ids matter: this hook runs once per consuming component, so
+  // without them every mounted consumer stacks its own copy of the same toast.
+  //
+  // 'no_org_selected' deliberately stays silent. It is the momentary gap
+  // between signing in and the switcher settling on an organization, not
+  // something the user can act on; a user with no organizations at all
+  // surfaces as 'no_roles' instead.
   useEffect(() => {
     if (!isLoggedIn) return;
 
     if (roleState.status === 'no_roles') {
-      toast.error('No roles assigned. Please contact support.');
-    } else if (roleState.status === 'no_org_selected') {
-      toast.info('Please select an organization to continue.');
+      toast.error('No roles assigned. Please contact support.', {
+        id: 'user-role-no-roles',
+      });
     } else if (roleState.status === 'no_access') {
-      toast.warning(`You don't have access to this organization.`);
+      toast.warning(`You don't have access to this organization.`, {
+        id: 'user-role-no-access',
+      });
     }
   }, [roleState.status, isLoggedIn]);
 

--- a/src/lib/hooks/use-fail-fast-retry.ts
+++ b/src/lib/hooks/use-fail-fast-retry.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback } from "react";
+import { useSWRConfig, type SWRConfiguration } from "swr";
+import { httpStatusOf } from "@/types/entity-api-error";
+
+/**
+ * Statuses no amount of retrying can fix. 403 means the caller lacks
+ * permission (e.g. their organization membership was revoked mid-session);
+ * 401 is already being handled by the session guard logging them out.
+ */
+export const TERMINAL_RETRY_STATUSES: readonly number[] = [401, 403];
+
+type OnErrorRetry = NonNullable<SWRConfiguration["onErrorRetry"]>;
+
+/**
+ * SWR retry policy that stops immediately on a terminal status instead of
+ * inheriting SWR's unbounded exponential-backoff retry, which would otherwise
+ * hammer an endpoint that will never start returning 200.
+ *
+ * Every other failure delegates to the caller's own `onErrorRetry` when it
+ * supplies one, or to SWR's default policy.
+ */
+export function useFailFastRetry(
+  callerOnErrorRetry?: SWRConfiguration["onErrorRetry"]
+): OnErrorRetry {
+  const { onErrorRetry: defaultOnErrorRetry } = useSWRConfig();
+
+  return useCallback<OnErrorRetry>(
+    (error, key, config, revalidate, revalidateOpts) => {
+      const status = httpStatusOf(error);
+      if (status.some && TERMINAL_RETRY_STATUSES.includes(status.val)) return;
+
+      const delegate = callerOnErrorRetry ?? defaultOnErrorRetry;
+      delegate?.(error, key, config, revalidate, revalidateOpts);
+    },
+    [callerOnErrorRetry, defaultOnErrorRetry]
+  );
+}

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -33,14 +33,6 @@ export function useLogoutUser() {
       // Execute component cleanup (TipTap providers, etc.)
       await logoutCleanupRegistry.executeAll();
 
-      // Clear cached data
-      clearCache();
-      resetCoachingRelationshipState();
-      resetCoachingSessionsCardFilters();
-      // Persisted to localStorage, so without this the next user to sign in on
-      // this browser inherits the previous user's organization.
-      resetOrganizationState();
-
       // Clean up backend session
       await deleteUserSession(userSession.id);
     } catch (err) {
@@ -48,6 +40,25 @@ export function useLogoutUser() {
       // Ensure frontend state is cleared even if backend cleanup fails
       logout();
     } finally {
+      // Local teardown is not conditional on anything above it, and no step
+      // may strand the ones after it. The organization selection is the one
+      // that matters most: it is persisted to localStorage, so failing to
+      // clear it hands the next user on this browser the previous user's
+      // organization. Ordered cheapest-and-most-important first, with the
+      // cache walk — the step most able to throw — last.
+      for (const teardown of [
+        resetOrganizationState,
+        resetCoachingRelationshipState,
+        resetCoachingSessionsCardFilters,
+        clearCache,
+      ]) {
+        try {
+          teardown();
+        } catch (err) {
+          console.error('Logout teardown step failed:', err);
+        }
+      }
+
       router.replace("/");
     }
   };

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -2,6 +2,7 @@ import { useUserSessionMutation } from "@/lib/api/user-sessions";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
 import { useCoachingSessionsCardFilterStore } from "@/lib/providers/coaching-sessions-card-filter-store-provider";
+import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
 import { EntityApi } from "@/lib/api/entity-api";
 import { useRouter } from "next/navigation";
 import { logoutCleanupRegistry } from "./logout-cleanup-registry";
@@ -19,6 +20,9 @@ export function useLogoutUser() {
   const resetCoachingSessionsCardFilters = useCoachingSessionsCardFilterStore(
     (s) => s.resetCoachingSessionsCardFilters
   );
+  const resetOrganizationState = useOrganizationStateStore(
+    (s) => s.resetOrganizationState
+  );
   const clearCache = EntityApi.useClearCache();
 
   return async () => {
@@ -33,6 +37,9 @@ export function useLogoutUser() {
       clearCache();
       resetCoachingRelationshipState();
       resetCoachingSessionsCardFilters();
+      // Persisted to localStorage, so without this the next user to sign in on
+      // this browser inherits the previous user's organization.
+      resetOrganizationState();
 
       // Clean up backend session
       await deleteUserSession(userSession.id);

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -26,39 +26,44 @@ export function useLogoutUser() {
   const clearCache = EntityApi.useClearCache();
 
   return async () => {
+    // Clear authentication state to prevent re-initialization
+    logout();
+
+    // Component cleanup (TipTap providers, etc.). Isolated so that a failure
+    // here cannot skip the state teardown below.
     try {
-      // Clear authentication state to prevent re-initialization
-      logout();
-
-      // Execute component cleanup (TipTap providers, etc.)
       await logoutCleanupRegistry.executeAll();
+    } catch (err) {
+      console.error('Component cleanup failed during logout:', err);
+    }
 
+    // Local teardown runs before the backend round trip, not after it: it must
+    // not be deferred by a slow request or lost entirely if the tab closes
+    // mid-logout. The organization selection is the one that matters most —
+    // it is persisted to localStorage, so leaving it behind hands the next
+    // user on this browser the previous user's organization.
+    //
+    // Each step is isolated as well as unconditional; the cache walk is the
+    // one most able to throw, and it must not strand the resets.
+    for (const teardown of [
+      resetOrganizationState,
+      resetCoachingRelationshipState,
+      resetCoachingSessionsCardFilters,
+      clearCache,
+    ]) {
+      try {
+        teardown();
+      } catch (err) {
+        console.error('Logout teardown step failed:', err);
+      }
+    }
+
+    try {
       // Clean up backend session
       await deleteUserSession(userSession.id);
     } catch (err) {
       console.error('Logout process failed:', err);
-      // Ensure frontend state is cleared even if backend cleanup fails
-      logout();
     } finally {
-      // Local teardown is not conditional on anything above it, and no step
-      // may strand the ones after it. The organization selection is the one
-      // that matters most: it is persisted to localStorage, so failing to
-      // clear it hands the next user on this browser the previous user's
-      // organization. Ordered cheapest-and-most-important first, with the
-      // cache walk — the step most able to throw — last.
-      for (const teardown of [
-        resetOrganizationState,
-        resetCoachingRelationshipState,
-        resetCoachingSessionsCardFilters,
-        clearCache,
-      ]) {
-        try {
-          teardown();
-        } catch (err) {
-          console.error('Logout teardown step failed:', err);
-        }
-      }
-
       router.replace("/");
     }
   };

--- a/src/lib/hooks/use-reconcile-current-organization.ts
+++ b/src/lib/hooks/use-reconcile-current-organization.ts
@@ -13,6 +13,10 @@ export type OrganizationMembership =
   | { kind: "unknown" }
   | { kind: "loaded"; organizations: readonly Organization[] };
 
+// Sentinel for "no snapshot reconciled yet". A module constant rather than a
+// fresh array so the first real snapshot always compares as different.
+const EMPTY_ORGANIZATIONS: readonly Organization[] = [];
+
 /**
  * Keeps the persisted `currentOrganizationId` consistent with the
  * organizations the caller is actually a member of.
@@ -21,9 +25,13 @@ export type OrganizationMembership =
  * would otherwise survive re-renders, reloads and new browser sessions while
  * every organization-scoped read 403s against the dead id.
  *
- * A revoked id is reconciled at most once per mount. Other code deliberately
- * re-selects an organization (the members route syncs it from the URL), and
- * re-clearing that on every render would spin.
+ * A revoked id is reconciled at most once per membership snapshot. Other code
+ * deliberately re-selects an organization (the members route syncs it from the
+ * URL), and re-clearing that on every render would spin.
+ *
+ * The snapshot is what re-arms it: a fresh organization list is new evidence,
+ * so an id that was written back after being reconciled gets reconsidered
+ * rather than staying pinned until the component happens to unmount.
  */
 export function useReconcileCurrentOrganization(
   membership: OrganizationMembership,
@@ -31,11 +39,18 @@ export function useReconcileCurrentOrganization(
   setCurrentOrganizationId: (organizationId: Id) => void
 ): void {
   const reconciledIds = useRef<Set<Id>>(new Set());
+  const reconciledAgainst = useRef<readonly Organization[]>(EMPTY_ORGANIZATIONS);
 
   useEffect(() => {
     if (membership.kind !== "loaded") return;
 
     const { organizations } = membership;
+
+    if (reconciledAgainst.current !== organizations) {
+      reconciledAgainst.current = organizations;
+      reconciledIds.current.clear();
+    }
+
     const fallbackId = organizations[0]?.id ?? "";
 
     if (!currentOrganizationId) {

--- a/src/lib/hooks/use-reconcile-current-organization.ts
+++ b/src/lib/hooks/use-reconcile-current-organization.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { Id } from "@/types/general";
+import type { Organization } from "@/types/organization";
+
+/**
+ * The caller's membership as far as we can currently tell. Anything short of
+ * `loaded` cannot distinguish a revoked organization from one that simply
+ * hasn't been fetched, so the reconciler stays inert until then.
+ */
+export type OrganizationMembership =
+  | { kind: "unknown" }
+  | { kind: "loaded"; organizations: readonly Organization[] };
+
+/**
+ * Keeps the persisted `currentOrganizationId` consistent with the
+ * organizations the caller is actually a member of.
+ *
+ * The selection lives in localStorage, so a membership revoked server-side
+ * would otherwise survive re-renders, reloads and new browser sessions while
+ * every organization-scoped read 403s against the dead id.
+ *
+ * A revoked id is reconciled at most once per mount. Other code deliberately
+ * re-selects an organization (the members route syncs it from the URL), and
+ * re-clearing that on every render would spin.
+ */
+export function useReconcileCurrentOrganization(
+  membership: OrganizationMembership,
+  currentOrganizationId: Id,
+  setCurrentOrganizationId: (organizationId: Id) => void
+): void {
+  const reconciledIds = useRef<Set<Id>>(new Set());
+
+  useEffect(() => {
+    if (membership.kind !== "loaded") return;
+
+    const { organizations } = membership;
+    const fallbackId = organizations[0]?.id ?? "";
+
+    if (!currentOrganizationId) {
+      if (fallbackId) setCurrentOrganizationId(fallbackId);
+      return;
+    }
+
+    const isStillAMember = organizations.some(
+      (organization) => organization.id === currentOrganizationId
+    );
+    if (isStillAMember || reconciledIds.current.has(currentOrganizationId)) {
+      return;
+    }
+
+    reconciledIds.current.add(currentOrganizationId);
+    setCurrentOrganizationId(fallbackId);
+  }, [membership, currentOrganizationId, setCurrentOrganizationId]);
+}

--- a/src/lib/hooks/use-swr-with-backoff.ts
+++ b/src/lib/hooks/use-swr-with-backoff.ts
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import useSWR, { type Fetcher, type SWRConfiguration } from "swr";
+import { httpStatusOf } from "@/types/entity-api-error";
+import { TERMINAL_RETRY_STATUSES } from "@/lib/hooks/use-fail-fast-retry";
 
 // Narrower than SWR's `Key` (which also accepts functions, BigInts, and
 // arbitrary records). The render-time reset hashes the key with
@@ -16,7 +18,6 @@ type SupportedKey = string | readonly unknown[] | null;
 // sync timeout. Other callers can override per call site.
 const DEFAULT_MAX_RETRIES = 5;
 const DEFAULT_BASE_MS = 300;
-const DEFAULT_SKIP_STATUSES: readonly number[] = [401, 403];
 
 // `onErrorRetry` is owned by this hook — it implements the skip/backoff/
 // exhaustion policy. Allowing callers to override it would silently
@@ -55,7 +56,7 @@ export function useSwrWithBackoff<Data, K extends SupportedKey = SupportedKey>(
   const {
     maxRetries = DEFAULT_MAX_RETRIES,
     baseMs = DEFAULT_BASE_MS,
-    skipStatuses = DEFAULT_SKIP_STATUSES,
+    skipStatuses = TERMINAL_RETRY_STATUSES,
     ...swrConfig
   } = options;
 
@@ -77,9 +78,8 @@ export function useSwrWithBackoff<Data, K extends SupportedKey = SupportedKey>(
       swrConfig.onSuccess?.(d, k, cfg);
     },
     onErrorRetry: (err, _k, _cfg, revalidate, { retryCount }) => {
-      const status = (err as { response?: { status?: number } })?.response
-        ?.status;
-      if (status !== undefined && skipStatuses.includes(status)) {
+      const status = httpStatusOf(err);
+      if (status.some && skipStatuses.includes(status.val)) {
         setRetriesExhausted(true);
         return;
       }

--- a/src/types/entity-api-error.ts
+++ b/src/types/entity-api-error.ts
@@ -1,5 +1,6 @@
 import { AxiosError, AxiosResponse } from "axios";
 import axios from "axios";
+import { None, Some, type Option } from "@/types/option";
 
 /**
  * Enhanced error type for Entity API operations that preserves axios error information
@@ -157,4 +158,19 @@ export const viewPermissionDeniedMessage = (resource: string): string =>
  */
 export function isForbiddenError(error: unknown): error is EntityApiError {
   return error instanceof EntityApiError && error.isForbidden();
+}
+
+/**
+ * Extracts the HTTP status from an arbitrary thrown value. Reads
+ * {@link EntityApiError.status} first, then falls back to the raw axios
+ * `response.status` for call sites whose fetcher doesn't wrap its errors.
+ * `None` for network errors, aborts, and anything non-HTTP.
+ */
+export function httpStatusOf(error: unknown): Option<number> {
+  if (error instanceof EntityApiError) {
+    return error.status === undefined ? None : Some(error.status);
+  }
+  const status = (error as { response?: { status?: unknown } })?.response
+    ?.status;
+  return typeof status === "number" ? Some(status) : None;
 }


### PR DESCRIPTION
## Description
rs#377 makes removing a member from an organization actually revoke their access, so a member removed mid-session now gets 403 on org-scoped reads that previously returned 200 — a state that was impossible before. Two things degraded badly in that state. Also states what removal takes away in the confirm dialog, which previously only reassured.

#### GitHub Issue: Part of #435

### Changes
* **Reconcile the persisted organization selection.** `currentOrganizationId` is persisted to localStorage, and the switcher only assigned a default when it was empty — so a revoked (or deleted) org id survived re-render, reload and new browser sessions while every org-scoped read fired at it. New `useReconcileCurrentOrganization` falls back to the first remaining org, or clears when none remain. Each revoked id is reconciled at most once per mount so the members route's URL sync can't spin against it.
* **Stop retrying permanently-denied reads.** The fail-fast policy lived only in `use-swr-with-backoff` (used by the collab-token path); the general read hooks used plain `useSWR` with SWR's unbounded exponential backoff, so a removed member produced continuous background 403 churn. New `useApiSWR` carries the policy and all nine read sites now route through it — including seven that bypassed `EntityApi` entirely (`transcriptions`, `oauth-connection`, `relationship-actions`, `goals`, `meeting-recordings`).
* **`httpStatusOf`** consolidates the two divergent error shapes the two paths disagreed on: `EntityApiError.status` and raw axios `response.status`.
* **Remove-member dialog copy** now names what the admin is taking away, not just what is safe.
* **Clear the organization selection on logout**, and collapse the per-consumer duplicate toasts it caused (see Concerns).
* **Re-arm reconciliation on each membership snapshot.** The skip-once guard was scoped to the component lifetime, so a route that writes a revoked id back into global state (the members page syncs one from the URL) pinned it until that section unmounted. Scoped to the membership snapshot instead, so a fresh organization list reconsiders it.
* **Lint rule** steering new reads to `useApiSWR`; a bare `useSWR` silently opts out of the retry policy.

### Screenshots / Videos Showing UI Changes (if applicable)

**Remove from organization confirmation dialog box:**

<img width="564" height="253" alt="Screenshot 2026-08-09 at 18 03 01" src="https://github.com/user-attachments/assets/0bbcfb4f-eb26-4be7-83a3-c8ee659bfd1e" />

### Testing Strategy
`npx tsc --noEmit` clean, eslint clean, full suite green (158 files / 1701 tests), including 18 new tests across the two new hooks.

Verified end-to-end against a local backend running the rs#377 branch (`3375d389`), driving the real UI:
1. Log in as a member of an org, select it, confirm a session page loads (topics, notes, collab connected).
2. As an org admin, remove that member via `DELETE /organizations/{org}/users/{user}/role` while their app is open — returns **204** for a member with coaching sessions, confirming the `user_has_coaching_history` 409 is gone. DB shows exactly one `user_roles` row deleted; relationship and sessions intact.
3. Removed member reloads the session page → clean "Coaching Session Access Denied", no crash. Sidebar has already moved off the revoked org and localStorage was rewritten, with no manual switch and no reload.
4. Network log shows 8 distinct endpoints 403'ing **exactly once each**, unchanged after a 10s wait — previously each would retry on unbounded backoff. To be precise about the scope: this eliminates the *retry storm*, not every repeat request. `revalidateOnFocus` still re-requests a permanently-403 endpoint once per focus (measured: one extra request per endpoint after a blur/focus cycle past the 10s throttle). That is deliberate — it is also how a removed-then-readded member recovers without a reload.
5. Re-add the member with their original coach → 200, reusing the original relationship (no duplicate row), full access restored.

The reconciler also self-healed a pre-existing stale localStorage id pointing at an organization that no longer exists in the database.

Separately, for the logout fix: sign in as user A, pick an organization, sign out, sign in as user B on the same browser. B now lands on one of their own organizations with no toasts, where previously they inherited A's organization and got one "You don't have access to this organization." toast per mounted consumer.

### Concerns
* The E2E run surfaced four **pre-existing** issues outside the original diff, none of them regressions from it.
  1. **Fixed here** — signing in as a second user on the same browser inherited the previous user's organization and toasted about it. `resetOrganizationState` existed and was wired through the hook but had no caller, so logout never cleared it; and the toast effect lives in a hook that runs once per consuming component, so one bad state stacked one toast per consumer. Included because it is the user-visible half of the same persisted-state bug this PR already fixes.
  2. refactor-group/refactor-platform-fe#438 + refactor-group/refactor-platform-rs#380 — an admin of a single organization cannot re-add someone they removed. The "Add existing member" tab is hidden from them, and the backend's people-search does not return former members, so the app-side gate cannot be relaxed on its own.
  3. refactor-group/refactor-platform-fe#437 — that create-member 409 produces no toast at all.
  4. refactor-group/refactor-platform-rs#381 — a removed member can still read an individual coaching relationship by id, while the list of the same resource is correctly refused. Filed publicly rather than as a security advisory: only a former participant can trigger it, what leaks is their own coach's name and ids, and the branch has not shipped.
* Removal of the now-dead `user_has_coaching_history` 409 handling is deliberately **not** in this PR — it is staged on `chore/remove-dead-user-has-coaching-history-409` and must not land until rs#377 is merged, or a still-emitting backend would meet a frontend that no longer handles it. The three sites carry `TODO(rs#377)` markers.
* `useApiSWR` uses `Data = any, Err = any` to mirror `useSWR`'s own signature. `unknown` would be stricter but breaks five existing call sites that assign `isError` to typed fields — a wider refactor than belongs here.
