### PR TITLE
Build without NODE_ENV=test, and stop caches crossing Next.js versions

### DIFF
--- a/.github/workflows/build_and_push_nonproduction_images.yml
+++ b/.github/workflows/build_and_push_nonproduction_images.yml
@@ -15,11 +15,15 @@ concurrency:
 permissions:
   contents: read
 
+# NODE_ENV is deliberately not set here. `next build` is a production build and
+# must run as one; forcing NODE_ENV=test made Turbopack fail to evaluate
+# postcss.config.js ("__turbopack_context__.a is not a function") on a cold
+# cache. Vitest sets NODE_ENV=test for itself, and E2E runs the production
+# standalone server, so nothing needs it at the workflow level.
 env:
   REGISTRY: ghcr.io
   ORG_NAME: refactor-group
   REPO_NAME: refactor-platform-fe
-  NODE_ENV: test
 
 jobs:
   # === LINT JOB ===

--- a/.github/workflows/build_and_push_nonproduction_images.yml
+++ b/.github/workflows/build_and_push_nonproduction_images.yml
@@ -82,8 +82,13 @@ jobs:
       # 🎯 Next.js build cache (job-specific to prevent race conditions).
       # The previous key hashed every .js/.jsx/.ts/.tsx file, which evicted
       # the cache on any non-semantic edit (e.g. comment-only changes).
-      # Now we key on lockfile + Next/TS config; restore-keys still let us
-      # fall back to a same-lockfile-different-config build cache.
+      # Now we key on lockfile + Next/TS config; the one restore-key falls
+      # back to a same-lockfile-different-config build cache.
+      #
+      # Every restore-key must pin the lockfile hash. Turbopack artifacts are
+      # only valid for the Next.js version that wrote them, so a bare prefix
+      # will happily restore a cache from a different Next.js and fail the
+      # build with "__turbopack_context__.a is not a function".
       - name: Cache Next.js build
         uses: actions/cache@v4
         with:
@@ -91,8 +96,6 @@ jobs:
           key: ${{ runner.os }}-nextjs-test-${{ hashFiles('package-lock.json', 'next.config.mjs', 'tsconfig.json') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-test-${{ hashFiles('package-lock.json') }}-
-            ${{ runner.os }}-nextjs-test-
-            ${{ runner.os }}-nextjs-
 
       - name: Install dependencies
         run: npm ci --prefer-offline


### PR DESCRIPTION
## Description

`main` broke immediately after #442 merged. Two CI fixes; the first is the actual repair.

**`NODE_ENV=test` was set workflow-wide**, so `next build` ran as a production build with a test NODE_ENV. On a cold cache, Turbopack failed to evaluate `postcss.config.js`:

```
TypeError: __turbopack_context__.a is not a function
    at mod (postcss.config.js_.loader.mjs:11:31)
```

7 errors, all `.scss.css` files. The Docker job builds the same commit on the same platform with `NODE_ENV` unset and passes, which isolates the variable. `next build` is a production build and must run as one; Vitest sets `NODE_ENV=test` for itself and E2E runs the production standalone server, so nothing needed it here.

**Why #442 was green:** its `Build & Test` restored an Aug 7 `.next/cache`, and a warm cache skips postcss evaluation entirely. The bug was only ever reachable cold. `main` had no readable cache — Actions scopes PR-branch caches away from `main` — so it built cold and hit it.

The second commit removes two bare-prefix `restore-keys` that could restore a cache written by a different Next.js. That is separate hygiene, not the repair: Turbopack artifacts are only valid for the version that wrote them, and the loose keys are what let a 16.2.6 cache into a 16.3.0 build in the first place.

### Changes

* Drop `NODE_ENV: test` from workflow-level `env`.
* Keep only the `restore-keys` entry that pins the lockfile hash.

### Testing Strategy

CI on this branch is green with `Cache not found for input keys` and `⚠ No build cache found` — a genuinely cold build, the condition that fails on `main`. Build & Test, Lint, Docker, CodeQL and Greptile all pass.

### Concerns

* Tightening the cache keys makes cold builds more common, which is what surfaced this. That is the right trade — a cold build is slower, a cross-version warm cache is wrong.
* `node-version: 24.x` still floats, and the npm shipped with it decides lockfile tree shape; that is what forced the `@emnapi` overrides in #442. Pinning it would remove another source of drift.
