### PR TITLE
Add Terms of Service and Privacy Policy pages

### DIFF
--- a/__tests__/e2e/legal-pages-public.spec.ts
+++ b/__tests__/e2e/legal-pages-public.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+// Deliberately no setupAuthentication: these routes must render for a signed-out
+// visitor. Google's OAuth verification reviewers reach them without a session,
+// so an auth gate added later would silently fail verification.
+
+const LIMITED_USE_SENTENCE =
+  "Refactor's use and transfer of information received from Google APIs to any " +
+  'other app will adhere to the Google API Services User Data Policy, including ' +
+  'the Limited Use requirements.'
+
+test.describe('Legal pages are publicly reachable', () => {
+  test('privacy policy renders anonymously and carries the Limited Use disclosure', async ({
+    page,
+  }) => {
+    const response = await page.goto('/privacy')
+
+    expect(response?.status()).toBe(200)
+    await expect(page).toHaveURL(/\/privacy$/)
+    await expect(
+      page.getByRole('heading', { name: 'Privacy Policy', level: 1 })
+    ).toBeVisible()
+
+    await expect(page.getByText(LIMITED_USE_SENTENCE)).toBeVisible()
+  })
+
+  test('terms of service renders anonymously', async ({ page }) => {
+    const response = await page.goto('/terms')
+
+    expect(response?.status()).toBe(200)
+    await expect(page).toHaveURL(/\/terms$/)
+    await expect(
+      page.getByRole('heading', { name: 'Terms of Service', level: 1 })
+    ).toBeVisible()
+  })
+
+  test('the login page links resolve to both documents', async ({ page }) => {
+    await page.goto('/')
+
+    await page.getByRole('link', { name: 'Terms of Service' }).click()
+    await expect(page).toHaveURL(/\/terms$/)
+
+    await page.goto('/')
+
+    await page.getByRole('link', { name: 'Privacy Policy' }).click()
+    await expect(page).toHaveURL(/\/privacy$/)
+  })
+})

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -172,30 +172,37 @@ export default function PrivacyPolicyPage() {
 
       <h2>Service providers</h2>
       <p>
-        We use the following providers to operate the Platform. Each receives
-        only the information necessary for its function.
+        We rely on the following categories of service provider to operate the
+        Platform. Each receives only the information necessary for its function,
+        and none is permitted to use it for its own purposes.
       </p>
       <ul>
         <li>
-          <strong>DigitalOcean</strong> hosts the application servers and
-          database.
+          <strong>Cloud hosting and database providers</strong>, which run the
+          application servers and store the Platform&rsquo;s data.
         </li>
         <li>
-          <strong>Cloudflare</strong> proxies traffic, terminates TLS, and
-          provides denial-of-service and bot protection.
+          <strong>A content delivery and security provider</strong>, which
+          proxies traffic, terminates TLS, and provides denial-of-service and
+          bot protection.
         </li>
         <li>
-          <strong>Resend</strong> delivers transactional email.
+          <strong>A transactional email provider</strong>, which delivers
+          invitations, password resets, and notifications.
         </li>
         <li>
-          <strong>Google</strong> provides the optional Google Meet integration
-          described above, when you connect a Google account.
+          <strong>A collaborative editing provider</strong>, which powers shared
+          session notes.
         </li>
         <li>
-          <strong>Tiptap</strong> provides the collaborative editing service
-          behind shared session notes.
+          <strong>Google</strong>, which provides the optional Google Meet
+          integration described above, when you connect a Google account.
         </li>
       </ul>
+      <p>
+        A current list of the specific providers we use is available on request
+        at <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
       <p>
         We may also disclose information when required by law, in response to
         valid legal process, or to protect the rights, safety, or property of

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -185,7 +185,7 @@ export default function PrivacyPolicyPage() {
           provides denial-of-service and bot protection.
         </li>
         <li>
-          <strong>MailerSend</strong> delivers transactional email.
+          <strong>Resend</strong> delivers transactional email.
         </li>
         <li>
           <strong>Google</strong> provides the optional Google Meet integration

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,276 @@
+import type { Metadata } from "next";
+
+import { LegalPage } from "@/components/ui/legal/legal-page";
+import { siteConfig } from "@/site.config";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Refactor Coach",
+  description:
+    "How the Refactor coaching platform collects, uses, stores, and shares information, including data received from Google APIs.",
+};
+
+const LAST_UPDATED = "August 11, 2026";
+
+/** Verbatim disclosure Google requires of apps using sensitive OAuth scopes. */
+const LIMITED_USE_STATEMENT =
+  "Refactor's use and transfer of information received from Google APIs to any " +
+  "other app will adhere to the Google API Services User Data Policy, including " +
+  "the Limited Use requirements.";
+
+const GOOGLE_USER_DATA_POLICY_URL =
+  "https://developers.google.com/terms/api-services-user-data-policy";
+const GOOGLE_PERMISSIONS_URL = "https://myaccount.google.com/permissions";
+
+export default function PrivacyPolicyPage() {
+  const { entity, contactEmail } = siteConfig.legal;
+
+  return (
+    <LegalPage title="Privacy Policy" lastUpdated={LAST_UPDATED}>
+      <p>
+        {entity} (&ldquo;Refactor,&rdquo; &ldquo;we,&rdquo; &ldquo;us&rdquo;)
+        operates the Refactor coaching platform at myrefactor.com (the
+        &ldquo;Platform&rdquo;). This policy explains what information the
+        Platform collects, how we use it, who we share it with, how long we keep
+        it, and the choices you have.
+      </p>
+      <p>
+        This policy governs the Platform only. Our marketing websites at
+        refactorgroup.com and refactorcoach.com are covered by a separate privacy
+        policy.
+      </p>
+
+      <h2>Information we collect</h2>
+
+      <h3>Account information</h3>
+      <p>
+        When an account is created for you, we collect your first and last name,
+        email address, and the organization and coaching relationships you belong
+        to. Accounts on the Platform are created by invitation from an
+        organization administrator or coach; there is no public self-signup. We
+        store a salted hash of your password, never the password itself.
+      </p>
+
+      <h3>Coaching content</h3>
+      <p>
+        The Platform exists to hold the working record of a coaching
+        relationship. Depending on how you and your coach use it, that includes
+        coaching session titles, dates, and topics; collaborative session notes;
+        agreements; action items and their due dates and status; and goals and
+        their progress. This content is visible to the coach and client in the
+        relationship it belongs to, and to administrators of the organization
+        that owns the relationship.
+      </p>
+
+      <h3>Technical information</h3>
+      <p>
+        Our servers and network provider record technical information about each
+        request: IP address, user agent, the resource requested, and a timestamp.
+        We use this to operate the Platform, keep sessions secure, prevent abuse,
+        and debug errors.
+      </p>
+
+      <h3>Cookies</h3>
+      <p>
+        We set a first-party session cookie so you stay signed in. We do not run
+        third-party analytics, advertising, or cross-site tracking on the
+        Platform.
+      </p>
+
+      <h2>Google user data</h2>
+      <p>
+        Connecting a Google account is optional. Nothing in this section applies
+        unless you choose to connect one under Settings &rarr; Integrations.
+      </p>
+      <p>
+        When you connect your Google account, you are asked to grant the
+        following scopes, and we use the data they return only as described here:
+      </p>
+      <ul>
+        <li>
+          <strong>openid</strong>, <strong>userinfo.email</strong>, and{" "}
+          <strong>userinfo.profile</strong> &mdash; we receive your Google
+          account identifier, email address, and basic profile information. We
+          use these to identify which Google account is connected and to display
+          it back to you on the integrations screen so you can confirm the right
+          account is linked.
+        </li>
+        <li>
+          <strong>meetings.space.created</strong> &mdash; we use this solely to
+          create a Google Meet space for a coaching session and to read back that
+          space&rsquo;s meeting URI. We store the meeting URI on the coaching
+          relationship and display it as a &ldquo;Join Meet&rdquo; link to the
+          coach and their client.
+        </li>
+      </ul>
+      <p>
+        We only interact with Meet spaces that the Platform itself created. We do
+        not read, list, or modify your existing meetings, and we do not request
+        or receive access to your Google Calendar, Gmail, Drive, or contacts. We
+        do not access meeting recordings, transcripts, or participant data.
+      </p>
+      <p>
+        <strong>Storage.</strong> Google access and refresh tokens are stored
+        encrypted on our servers and are used only to perform the actions
+        described above on your behalf.
+      </p>
+      <p>
+        <strong>Sharing.</strong> We do not sell Google user data, use it for
+        advertising, use it to train generalized artificial intelligence or
+        machine learning models, or transfer it to third parties except as
+        strictly necessary to provide the features described above, to comply
+        with applicable law, or as part of a merger or acquisition in which the
+        Platform is transferred. Human beings do not read your Google user data
+        except where you have given affirmative consent for a specific support
+        request, where it is necessary for security purposes such as
+        investigating abuse, or where required by law.
+      </p>
+      <p>
+        <strong>Revoking access.</strong> You can disconnect your Google account
+        at any time under Settings &rarr; Integrations. Disconnecting revokes our
+        tokens with Google and deletes them from our systems. You can also review
+        and revoke access directly from your{" "}
+        <a
+          href={GOOGLE_PERMISSIONS_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google Account permissions page
+        </a>
+        .
+      </p>
+      <p>{LIMITED_USE_STATEMENT}</p>
+      <p>
+        You can read the{" "}
+        <a
+          href={GOOGLE_USER_DATA_POLICY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Google API Services User Data Policy
+        </a>{" "}
+        in full.
+      </p>
+
+      <h2>How we use information</h2>
+      <ul>
+        <li>To provide the Platform and the coaching features you use.</li>
+        <li>
+          To authenticate you, keep your session secure, and protect accounts
+          from unauthorized access.
+        </li>
+        <li>
+          To send transactional email &mdash; invitations, password resets, and
+          notifications about actions assigned to you.
+        </li>
+        <li>To operate, secure, debug, and improve the Platform.</li>
+        <li>To comply with legal obligations and enforce our Terms.</li>
+      </ul>
+      <p>
+        We do not sell or rent personal information, and we do not use your
+        coaching content for advertising.
+      </p>
+
+      <h2>Service providers</h2>
+      <p>
+        We use the following providers to operate the Platform. Each receives
+        only the information necessary for its function.
+      </p>
+      <ul>
+        <li>
+          <strong>DigitalOcean</strong> hosts the application servers and
+          database.
+        </li>
+        <li>
+          <strong>Cloudflare</strong> proxies traffic, terminates TLS, and
+          provides denial-of-service and bot protection.
+        </li>
+        <li>
+          <strong>MailerSend</strong> delivers transactional email.
+        </li>
+        <li>
+          <strong>Google</strong> provides the optional Google Meet integration
+          described above, when you connect a Google account.
+        </li>
+        <li>
+          <strong>Tiptap</strong> provides the collaborative editing service
+          behind shared session notes.
+        </li>
+      </ul>
+      <p>
+        We may also disclose information when required by law, in response to
+        valid legal process, or to protect the rights, safety, or property of
+        Refactor, our users, or others.
+      </p>
+
+      <h2>How long we keep information</h2>
+      <p>
+        We keep your account information and coaching content for as long as your
+        account is active, and afterward for a reasonable period to satisfy
+        legal, accounting, or reporting obligations. Google tokens are deleted
+        when you disconnect the integration or delete your account. Server logs
+        are kept for a short rolling window, typically up to 90 days, for
+        security and operational purposes.
+      </p>
+
+      <h2>Your rights and choices</h2>
+      <p>
+        Depending on where you live, you may have the right to request access to
+        the personal information we hold about you, to correct it, to ask us to
+        delete it, or to object to certain uses. To exercise any of these rights,
+        email <a href={`mailto:${contactEmail}`}>{contactEmail}</a>. We will
+        respond within a reasonable timeframe and will not discriminate against
+        you for making a request.
+      </p>
+      <p>
+        Because coaching content is shared between a coach and a client, deleting
+        your account does not automatically delete content the other party
+        contributed to a shared record. Contact us and we will explain what can
+        be removed in your situation.
+      </p>
+      <p>
+        <strong>California residents.</strong> California law gives you specific
+        rights regarding your personal information, including the right to know
+        what we collect and how we use it, the right to request deletion, and the
+        right to opt out of the sale or sharing of personal information. We do
+        not sell or share personal information for cross-context behavioral
+        advertising. Use the email address above to exercise these rights.
+      </p>
+
+      <h2>Security</h2>
+      <p>
+        We use TLS encryption in transit, encrypt OAuth tokens at rest, hash
+        passwords, and restrict access to production systems. No method of
+        transmission or storage is fully secure, so we cannot guarantee absolute
+        security.
+      </p>
+
+      <h2>Children&rsquo;s privacy</h2>
+      <p>
+        The Platform is intended for adults in a professional coaching
+        relationship. We do not knowingly collect personal information from
+        children under 13. If you believe a child has provided us with personal
+        information, contact us and we will delete it.
+      </p>
+
+      <h2>International users</h2>
+      <p>
+        Refactor is based in the United States and processes information there.
+        If you use the Platform from outside the United States, you consent to
+        that processing.
+      </p>
+
+      <h2>Changes to this policy</h2>
+      <p>
+        We may update this policy from time to time. The &ldquo;Last
+        updated&rdquo; date above reflects the most recent revision, and we will
+        highlight material changes on this page.
+      </p>
+
+      <h2>Contact us</h2>
+      <p>
+        Questions about this policy or your information? Email{" "}
+        <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,191 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { LegalPage } from "@/components/ui/legal/legal-page";
+import { siteConfig } from "@/site.config";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Refactor Coach",
+  description:
+    "The terms governing use of the Refactor coaching platform at myrefactor.com.",
+};
+
+const LAST_UPDATED = "August 11, 2026";
+
+export default function TermsOfServicePage() {
+  const { entity, contactEmail, governingState } = siteConfig.legal;
+
+  return (
+    <LegalPage title="Terms of Service" lastUpdated={LAST_UPDATED}>
+      <p>
+        These Terms of Service (the &ldquo;Terms&rdquo;) govern your use of the
+        Refactor coaching platform at myrefactor.com (the
+        &ldquo;Platform&rdquo;), operated by {entity} (&ldquo;Refactor,&rdquo;
+        &ldquo;we,&rdquo; &ldquo;us&rdquo;). By accessing or using the Platform,
+        you agree to these Terms. If you do not agree, do not use the Platform.
+      </p>
+
+      <h2>1. Who may use the Platform</h2>
+      <p>
+        You must be at least 18 years old to use the Platform. Accounts are
+        created by invitation from an organization administrator or a coach;
+        there is no public self-signup. You may use the Platform only as
+        permitted by these Terms and by applicable law.
+      </p>
+
+      <h2>2. Accounts and organizations</h2>
+      <p>
+        You are responsible for keeping your credentials confidential and for all
+        activity that occurs under your account. Notify us promptly at{" "}
+        <a href={`mailto:${contactEmail}`}>{contactEmail}</a> if you believe your
+        account has been compromised.
+      </p>
+      <p>
+        If you access the Platform through an organization, that organization
+        administers your account. It can create and remove coaching
+        relationships, add and remove members, and access coaching content
+        belonging to relationships it owns. A separate agreement between Refactor
+        and that organization may govern fees, service levels, and data handling;
+        where that agreement conflicts with these Terms, it controls for that
+        organization&rsquo;s users.
+      </p>
+
+      <h2>3. Coaching content and confidentiality</h2>
+      <p>
+        You retain ownership of the content you contribute to the Platform,
+        including session notes, agreements, actions, and goals. You grant
+        Refactor a limited, non-exclusive license to host, store, transmit, and
+        display that content solely to operate and provide the Platform to you
+        and to the other participants in your coaching relationship.
+      </p>
+      <p>
+        Coaching content is shared by design. Content in a coaching relationship
+        is visible to both the coach and the client in that relationship, and to
+        administrators of the organization that owns it. Do not enter information
+        into the Platform that you are not willing to share with those parties.
+      </p>
+      <p>
+        Refactor does not sell your coaching content and does not use it for
+        advertising. Our handling of personal information is described in our{" "}
+        <Link href="/privacy">Privacy Policy</Link>.
+      </p>
+
+      <h2>4. Acceptable use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>
+          Access accounts, organizations, or coaching relationships you have not
+          been granted access to.
+        </li>
+        <li>
+          Probe, scan, or test the vulnerability of the Platform, or circumvent
+          any authentication or rate-limiting measure.
+        </li>
+        <li>
+          Upload malicious code, or content that is unlawful, harassing, or
+          infringes another party&rsquo;s rights.
+        </li>
+        <li>
+          Scrape, resell, or redistribute the Platform or its content, or use it
+          to build a competing service.
+        </li>
+        <li>
+          Interfere with the operation of the Platform or the use of it by
+          others.
+        </li>
+      </ul>
+
+      <h2>5. Third-party integrations</h2>
+      <p>
+        The Platform offers optional integrations with third-party services,
+        including Google Meet. Connecting an integration is your choice. Your use
+        of a third-party service is governed by that provider&rsquo;s own terms
+        and privacy policy, and we are not responsible for its availability,
+        behavior, or content. You can disconnect an integration at any time under
+        Settings &rarr; Integrations.
+      </p>
+
+      <h2>6. Not professional advice</h2>
+      <p>
+        The Platform is software that supports a professional coaching
+        relationship. It does not provide coaching, and Refactor does not provide
+        medical, psychological, legal, financial, or other licensed professional
+        advice through it. Coaching is not a substitute for therapy or medical
+        care. Decisions you make based on coaching conversations or content
+        stored in the Platform are your own.
+      </p>
+
+      <h2>7. Availability and changes</h2>
+      <p>
+        We may modify, suspend, or discontinue any part of the Platform at any
+        time. We aim to give reasonable notice of material changes that affect
+        you, but we do not guarantee uninterrupted or error-free operation.
+      </p>
+
+      <h2>8. Termination</h2>
+      <p>
+        You may stop using the Platform at any time and ask us to close your
+        account. We may suspend or terminate your access if you violate these
+        Terms, if your organization&rsquo;s agreement with us ends, or if we are
+        required to do so by law. Sections that by their nature should survive
+        termination &mdash; ownership, disclaimers, limitation of liability,
+        indemnification, and governing law &mdash; survive.
+      </p>
+
+      <h2>9. Disclaimers</h2>
+      <p>
+        The Platform is provided &ldquo;as is&rdquo; and &ldquo;as
+        available,&rdquo; without warranties of any kind, whether express,
+        implied, or statutory, including any implied warranties of
+        merchantability, fitness for a particular purpose, title, and
+        non-infringement. We do not warrant that the Platform will meet your
+        requirements, be uninterrupted, or be free of errors or data loss.
+      </p>
+
+      <h2>10. Limitation of liability</h2>
+      <p>
+        To the maximum extent permitted by law, Refactor will not be liable for
+        any indirect, incidental, special, consequential, exemplary, or punitive
+        damages, or for lost profits, revenue, data, or goodwill, arising out of
+        or relating to your use of the Platform. Our total liability for any
+        claim relating to the Platform will not exceed the greater of the amounts
+        you or your organization paid us for the Platform in the twelve months
+        before the claim arose, or one hundred U.S. dollars.
+      </p>
+
+      <h2>11. Indemnification</h2>
+      <p>
+        You agree to indemnify and hold harmless Refactor and its officers,
+        directors, employees, and agents from any claim, demand, loss, or expense
+        (including reasonable attorneys&rsquo; fees) arising out of your content,
+        your use of the Platform, or your violation of these Terms or of
+        applicable law.
+      </p>
+
+      <h2>12. Governing law and disputes</h2>
+      <p>
+        These Terms are governed by the laws of the State of {governingState},
+        without regard to its conflict-of-laws rules. You and Refactor agree to
+        try in good faith to resolve any dispute informally by contacting{" "}
+        <a href={`mailto:${contactEmail}`}>{contactEmail}</a> first. If that does
+        not resolve it, the state and federal courts located in {governingState}{" "}
+        will have exclusive jurisdiction, and you consent to venue there.
+      </p>
+
+      <h2>13. Changes to these Terms</h2>
+      <p>
+        We may update these Terms from time to time. The &ldquo;Last
+        updated&rdquo; date above reflects the most recent revision. If a change
+        is material, we will make reasonable efforts to notify you. Continuing to
+        use the Platform after a change takes effect means you accept the revised
+        Terms.
+      </p>
+
+      <h2>14. Contact</h2>
+      <p>
+        Questions about these Terms? Email{" "}
+        <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+      </p>
+    </LegalPage>
+  );
+}

--- a/src/components/ui/legal/legal-page.tsx
+++ b/src/components/ui/legal/legal-page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
+import { cn } from "@/components/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+import { Icons } from "@/components/ui/icons";
+
+interface LegalPageProps {
+  title: string;
+  lastUpdated: string;
+  children: ReactNode;
+}
+
+export const LegalPage = ({ title, lastUpdated, children }: LegalPageProps) => (
+  <main className="mx-auto w-full max-w-3xl px-6 py-12 sm:py-16">
+    <header className="mb-10">
+      <Link href="/" className="inline-flex items-center gap-2">
+        <div className={cn(buttonVariants({ variant: "ghost" }), "w-9 px-0")}>
+          <Icons.refactor_logo className="h-7 w-7" />
+          <span className="sr-only">Refactor</span>
+        </div>
+        <span className="text-sm font-medium">Refactor Coach</span>
+      </Link>
+
+      <h1 className="mt-6 text-xl font-semibold tracking-tight sm:text-2xl">
+        {title}
+      </h1>
+      <p className="mt-1 text-sm text-muted-foreground tabular-nums">
+        Last updated: {lastUpdated}
+      </p>
+    </header>
+
+    <div
+      className={cn(
+        "prose prose-neutral max-w-none dark:prose-invert",
+        "prose-headings:font-semibold prose-headings:tracking-tight",
+        "prose-h2:text-base prose-h2:mt-10 prose-h3:text-sm",
+        "prose-p:text-sm prose-li:text-sm prose-td:text-sm prose-th:text-sm",
+        "prose-a:underline prose-a:underline-offset-4"
+      )}
+    >
+      {children}
+    </div>
+
+    <footer className="mt-16 border-t pt-6 text-sm text-muted-foreground">
+      <nav className="flex flex-wrap gap-x-6 gap-y-2">
+        <Link href="/terms" className="hover:text-foreground">
+          Terms of Service
+        </Link>
+        <Link href="/privacy" className="hover:text-foreground">
+          Privacy Policy
+        </Link>
+        <Link href="/" className="hover:text-foreground">
+          Sign in
+        </Link>
+      </nav>
+    </footer>
+  </main>
+);

--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -10,6 +10,11 @@ export const siteConfig = {
     twitter: "https://www.linkedin.com/company/refactor-group/",
     github: "https://github.com/refactor-group/",
   },
+  legal: {
+    entity: "Refactor Group, Inc.",
+    contactEmail: "hello@mail.myrefactor.com",
+    governingState: "Illinois",
+  },
   // Configuration items set via a mix of build-time and run-time environment variables
   env: {
     backendServicePort: process.env.NEXT_PUBLIC_BACKEND_SERVICE_PORT,


### PR DESCRIPTION
## Description
Adds the `/terms` and `/privacy` pages. Both were already linked from the login page (`src/app/page.tsx`) but returned 404. The Privacy Policy is app-specific and carries the Google user data and Limited Use disclosures required for Google OAuth production verification — our existing policy at refactorcoach.com covers only the marketing sites and explicitly scopes itself to them.

### Changes
* `/privacy` — app-specific policy: coaching content, Google user data (per-scope use of `openid`/`userinfo.*`/`meetings.space.created`), Limited Use statement, revocation, retention, CCPA
* `/terms` — 14 sections; Refactor Group, Inc., Illinois governing law, coach/client confidentiality, not-professional-advice disclaimer
* `LegalPage` shared shell in `src/components/ui/legal/` — semantic tokens, `prose prose-neutral dark:prose-invert`, cross-linking footer
* `siteConfig.legal` — `entity`, `contactEmail`, `governingState`; pages read it as top-level containers
* Subprocessors described by category rather than by name, with Google named explicitly

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: `/privacy` and `/terms` at desktop and mobile widths, in both light and dark mode.

### Testing Strategy
* `npx tsc --noEmit` and `npx eslint` clean
* `curl http://localhost:3000/terms` and `/privacy` → 200, no auth redirect, full text present without JS (this is how Google's checks will hit them)
* Verify the login page links now resolve instead of 404ing

### Concerns
* **One claim is not yet true.** The policy states that disconnecting revokes tokens with Google. `revoke_token()` exists in the backend but has no callers — disconnect only deletes the DB row. Tracked on the coordination board as `oauth_disconnect_must_revoke_token`. **This must ship before the policy is published.**
* Not reviewed by counsel. The Google-facing sections I'd defend as review-ready; the liability cap, indemnification, and governing-law sections are boilerplate that should get a real read.
* Retention windows ("up to 90 days" for logs) and "salted hash" were written from reasonable assumption, not verified against production config.
* Unrelated observation: the root layout mounts the SSE provider on every route, so logged-out visitors to these public pages open failing SSE reconnects against the backend. Filed on the board as `sse_connects_on_public_unauthenticated_pages`; fix is FE-side and out of scope here.
