### PR TITLE
Show full product name from site config

### DIFF
--- a/__tests__/components/ui/app-sidebar.test.tsx
+++ b/__tests__/components/ui/app-sidebar.test.tsx
@@ -360,6 +360,44 @@ describe('AppSidebar Permission Logic', () => {
     });
   });
 
+  describe('Product name branding', () => {
+    // Deliberately not siteConfig.name, so a hard-coded string would fail here.
+    const productName = 'Acme Coach';
+
+    beforeEach(() => {
+      mockUseCurrentUserRole.mockReturnValue({
+        status: 'success',
+        role: Role.User,
+        hasAccess: true,
+      });
+    });
+
+    it('should render productName as the sidebar heading', () => {
+      render(
+        <TestWrapper>
+          <AppSidebar productName={productName} />
+        </TestWrapper>
+      );
+
+      expect(
+        screen.getByRole('heading', { level: 2, name: productName })
+      ).toBeInTheDocument();
+    });
+
+    it('should label the logo link with productName for screen readers', () => {
+      render(
+        <TestWrapper>
+          <AppSidebar productName={productName} />
+        </TestWrapper>
+      );
+
+      expect(screen.getByRole('link', { name: productName })).toHaveAttribute(
+        'href',
+        '/dashboard'
+      );
+    });
+  });
+
   describe('Members link URL', () => {
     it('should have correct href with current organization ID', async () => {
       const adminRoleState: UserRoleState = {

--- a/__tests__/components/ui/app-sidebar.test.tsx
+++ b/__tests__/components/ui/app-sidebar.test.tsx
@@ -167,7 +167,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -184,7 +184,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -201,7 +201,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -220,7 +220,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -238,7 +238,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -257,7 +257,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -274,7 +274,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -299,7 +299,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -316,7 +316,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -335,7 +335,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 
@@ -376,7 +376,7 @@ describe('AppSidebar Permission Logic', () => {
 
       render(
         <TestWrapper>
-          <AppSidebar />
+          <AppSidebar productName="Refactor Coach" />
         </TestWrapper>
       );
 

--- a/src/app/actions/layout.tsx
+++ b/src/app/actions/layout.tsx
@@ -19,7 +19,7 @@ export default function ActionsLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset className="min-w-0">
           <SiteHeader />
           <main className="flex-1 p-6 min-w-0">{children}</main>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -21,7 +21,7 @@ export default function AdminLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset className="min-w-0">
           <SiteHeader />
           <main className="flex-1 p-6 min-w-0">

--- a/src/app/coaching-sessions/[id]/layout.tsx
+++ b/src/app/coaching-sessions/[id]/layout.tsx
@@ -18,7 +18,7 @@ export default function CoachingSessionLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen md:h-screen w-full md:overflow-hidden">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset className="min-w-0">
           <SiteHeader />
           <main className="min-w-0 flex-1 flex flex-col md:overflow-hidden">{children}</main>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -19,7 +19,7 @@ export default function DashboardLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset className="min-w-0">
           <SiteHeader />
           <main className="flex-1 p-6 min-w-0">{children}</main>

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -76,7 +76,7 @@ export default function ForgotPasswordPage() {
                                 )}
                             >
                                 <Icons.refactor_logo className="h-7 w-7" />
-                                <span className="sr-only">Refactor</span>
+                                <span className="sr-only">{siteConfig.name}</span>
                             </div>
                         </Link>
                         {siteConfig.name}
@@ -103,7 +103,7 @@ export default function ForgotPasswordPage() {
                                     )}
                                 >
                                     <Icons.refactor_logo className="h-7 w-7" />
-                                    <span className="sr-only">Refactor</span>
+                                    <span className="sr-only">{siteConfig.name}</span>
                                 </div>
                             </Link>
                             <h1 className="text-2xl font-semibold tracking-tight">

--- a/src/app/members/[id]/profile/layout.tsx
+++ b/src/app/members/[id]/profile/layout.tsx
@@ -19,7 +19,7 @@ export default function MembersLayout({
     return (
         <SidebarProvider>
             <div className="flex min-h-screen min-w-full">
-                <AppSidebar />
+                <AppSidebar productName={siteConfig.name} />
                 <SidebarInset>
                     <SiteHeader />
                     <main className="flex-1 p-6">{children}</main>

--- a/src/app/organizations/[id]/members/layout.tsx
+++ b/src/app/organizations/[id]/members/layout.tsx
@@ -19,7 +19,7 @@ export default function MembersLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen min-w-full">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset>
           <SiteHeader />
           <main className="flex-1 p-6">{children}</main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import { siteConfig } from "@/site.config";
 import { Icons } from "@/components/ui/icons";
 
 export const metadata: Metadata = {
-  title: "Welcome to Refactor Coaching",
+  title: `Welcome to ${siteConfig.name}`,
   description: siteConfig.description,
 };
 
@@ -44,7 +44,7 @@ export default function LoginPage() {
                 )}
               >
                 <Icons.refactor_logo className="h-7 w-7" />
-                <span className="sr-only">Refactor</span>
+                <span className="sr-only">{siteConfig.name}</span>
               </div>
             </Link>
             {siteConfig.name}
@@ -73,11 +73,11 @@ export default function LoginPage() {
                   )}
                 >
                   <Icons.refactor_logo className="h-7 w-7" />
-                  <span className="sr-only">Refactor</span>
+                  <span className="sr-only">{siteConfig.name}</span>
                 </div>
               </Link>
               <h1 className="text-2xl font-semibold tracking-tight">
-                Sign in to Refactor
+                Sign in to {siteConfig.name}
               </h1>
             </div>
             <p className="text-sm text-muted-foreground">

--- a/src/app/reset-password/[token]/page.tsx
+++ b/src/app/reset-password/[token]/page.tsx
@@ -157,7 +157,7 @@ export default function ResetPasswordPage() {
                                 )}
                             >
                                 <Icons.refactor_logo className="h-7 w-7" />
-                                <span className="sr-only">Refactor</span>
+                                <span className="sr-only">{siteConfig.name}</span>
                             </div>
                         </Link>
                         {siteConfig.name}
@@ -184,7 +184,7 @@ export default function ResetPasswordPage() {
                                     )}
                                 >
                                     <Icons.refactor_logo className="h-7 w-7" />
-                                    <span className="sr-only">Refactor</span>
+                                    <span className="sr-only">{siteConfig.name}</span>
                                 </div>
                             </Link>
                             <h1 className="text-2xl font-semibold tracking-tight">

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -22,7 +22,7 @@ export default function SettingsLayout({
   return (
     <SidebarProvider>
       <div className="flex min-h-screen w-full">
-        <AppSidebar />
+        <AppSidebar productName={siteConfig.name} />
         <SidebarInset className="min-w-0">
           <SiteHeader />
           <main className="flex-1 p-6 min-w-0">

--- a/src/app/setup/[token]/page.tsx
+++ b/src/app/setup/[token]/page.tsx
@@ -104,7 +104,7 @@ export default function SetupPage() {
                                 )}
                             >
                                 <Icons.refactor_logo className="h-7 w-7" />
-                                <span className="sr-only">Refactor</span>
+                                <span className="sr-only">{siteConfig.name}</span>
                             </div>
                         </Link>
                         {siteConfig.name}
@@ -131,7 +131,7 @@ export default function SetupPage() {
                                     )}
                                 >
                                     <Icons.refactor_logo className="h-7 w-7" />
-                                    <span className="sr-only">Refactor</span>
+                                    <span className="sr-only">{siteConfig.name}</span>
                                 </div>
                             </Link>
                             <h1 className="text-2xl font-semibold tracking-tight">

--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -46,7 +46,11 @@ const menuButtonStyles = {
   iconWrapper: "flex items-center justify-center w-9",
 };
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
+  productName: string;
+}
+
+export function AppSidebar({ productName, ...props }: AppSidebarProps) {
   const { currentOrganizationId } = useCurrentOrganization();
   const currentUserRoleState = useCurrentUserRole();
   const isSuperAdmin = useIsSuperAdmin();
@@ -82,7 +86,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible={SidebarCollapsible.Icon} {...props}>
       <SidebarHeader className="h-16 flex flex-col justify-between pb-0">
-        {/* Logo and Refactor text */}
         <div className="flex items-center px-3 h-full transition-all duration-200 group-data-[collapsible=icon]:justify-center">
           <Link href="/dashboard" className="flex items-center">
             <div
@@ -94,11 +97,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               )}
             >
               <Icons.refactor_logo className="h-5 w-5" />
-              <span className="sr-only">Refactor</span>
+              <span className="sr-only">{productName}</span>
             </div>
           </Link>
           <h2 className="text-lg font-semibold ml-2 transition-all duration-200 group-data-[collapsible=icon]:hidden">
-            Refactor
+            {productName}
           </h2>
         </div>
 


### PR DESCRIPTION
## Description
The sidebar and auth pages hard-coded the product name as "Refactor" rather than the configured "Refactor Coach" in `siteConfig.name`.

### Changes
* `AppSidebar` takes a required `productName: string` prop (new `AppSidebarProps`); renders it in the header `<h2>` and the logo's `sr-only` label
* All 7 layouts rendering `AppSidebar` pass `productName={siteConfig.name}` — they already imported `siteConfig` for their metadata
* Auth pages (`/`, `/forgot-password`, `/reset-password/[token]`, `/setup/[token]`): `sr-only` logo labels now use `siteConfig.name`
* `/` page: metadata title is now `Welcome to ${siteConfig.name}`; heading reads "Sign in to {siteConfig.name}"
* Test call sites updated to pass `productName`

Config is threaded via props rather than imported into the component, per the coding standards.

### Screenshots / Videos Showing UI Changes (if applicable)
Sidebar header expanded and collapsed (icon mode) — the name string is longer now and the header is fixed-height.

### Testing Strategy
Log in and confirm the sidebar reads "Refactor Coach" expanded, and collapses cleanly to icon mode. Check the login, forgot-password, reset-password, and setup pages. `npx tsc --noEmit` and `npx vitest run __tests__/components/ui/app-sidebar.test.tsx` (16/16) both pass.

### Concerns
`productName` is required, so any future `AppSidebar` call site must supply it — intentional, to keep the value explicit rather than defaulting.
