### PR TITLE
Show "Super Admin" rather than the raw enum value

### DIFF
--- a/docs/test-plans/member_role_change_manual_testing.md
+++ b/docs/test-plans/member_role_change_manual_testing.md
@@ -66,9 +66,9 @@ organization admin access"** on an admin's. Never both, and never the role alrea
 scoped to the organization in wording, so neither is mistaken for global SuperAdmin. A success toast confirms the
 change ("{name} is now an organization Admin" / "…is no longer an organization Admin").
 
-The row's `Roles:` line separately carries Coach/Coachee and SuperAdmin. It renders the plain
-organization role as **"Member"** — the same word the menu and the add-member dialog use — rather
-than the raw `User` enum value.
+The row's `Roles:` line separately carries Coach/Coachee and Super Admin. It renders roles by their
+recipient-facing names rather than raw enum values: `User` shows as **"Member"** (the same word the
+menu and the add-member dialog use) and `SuperAdmin` as **"Super Admin"**.
 
 ---
 

--- a/src/lib/utils/__tests__/user-roles.test.ts
+++ b/src/lib/utils/__tests__/user-roles.test.ts
@@ -57,7 +57,7 @@ describe('getUserDisplayRoles', () => {
     const user = createUser([{ role: Role.SuperAdmin, organization_id: null }]);
     const roles = getUserDisplayRoles(user, organizationId, []);
 
-    expect(roles).toEqual(['SuperAdmin']);
+    expect(roles).toEqual(['Super Admin']);
   });
 
   it('should combine organization role and coaching roles', () => {
@@ -79,6 +79,14 @@ describe('getUserDisplayRoles', () => {
     expect(roles).toEqual(['Coach', 'Coachee', 'Member']);
   });
 
+  it('renders Role.SuperAdmin as "Super Admin", not the raw enum value', () => {
+    const user = createUser([{ role: Role.SuperAdmin, organization_id: null }]);
+    const roles = getUserDisplayRoles(user, organizationId, []);
+
+    expect(roles).toEqual(['Super Admin']);
+    expect(roles).not.toContain('SuperAdmin');
+  });
+
   it('renders Role.User as "Member", the word the rest of the UI uses', () => {
     const user = createUser([{ role: Role.User, organization_id: organizationId }]);
     const roles = getUserDisplayRoles(user, organizationId, []);
@@ -98,7 +106,7 @@ describe('getUserDisplayRoles', () => {
     ];
     const roles = getUserDisplayRoles(user, organizationId, relationships);
 
-    expect(roles).toEqual(['Admin', 'Coach', 'Coachee', 'SuperAdmin']);
+    expect(roles).toEqual(['Admin', 'Coach', 'Coachee', 'Super Admin']);
   });
 
   it('should not duplicate roles', () => {

--- a/src/lib/utils/__tests__/user-roles.test.ts
+++ b/src/lib/utils/__tests__/user-roles.test.ts
@@ -53,11 +53,12 @@ describe('getUserDisplayRoles', () => {
     expect(roles).toEqual(['Admin']);
   });
 
-  it('should return SuperAdmin role when organization_id is null', () => {
+  it('should return SuperAdmin role when organization_id is null, labelled not raw', () => {
     const user = createUser([{ role: Role.SuperAdmin, organization_id: null }]);
     const roles = getUserDisplayRoles(user, organizationId, []);
 
     expect(roles).toEqual(['Super Admin']);
+    expect(roles).not.toContain('SuperAdmin');
   });
 
   it('should combine organization role and coaching roles', () => {
@@ -77,14 +78,6 @@ describe('getUserDisplayRoles', () => {
     const roles = getUserDisplayRoles(user, organizationId, relationships);
 
     expect(roles).toEqual(['Coach', 'Coachee', 'Member']);
-  });
-
-  it('renders Role.SuperAdmin as "Super Admin", not the raw enum value', () => {
-    const user = createUser([{ role: Role.SuperAdmin, organization_id: null }]);
-    const roles = getUserDisplayRoles(user, organizationId, []);
-
-    expect(roles).toEqual(['Super Admin']);
-    expect(roles).not.toContain('SuperAdmin');
   });
 
   it('renders Role.User as "Member", the word the rest of the UI uses', () => {

--- a/src/lib/utils/user-roles.ts
+++ b/src/lib/utils/user-roles.ts
@@ -11,15 +11,8 @@ import { type Option, Some, None } from "@/types/option";
 
 export type DisplayRole = Role | RelationshipRole
 
-/**
- * Recipient-facing names for roles whose enum value is not what we want to show
- * a user. `Role.Admin` and the relationship roles already read correctly, so
- * they are absent and fall through unchanged.
- *
- * "Member" matches the add-member dialog and the row's actions menu; rendering
- * the raw "User" here taught a second name for the same role.
- */
-const ROLE_DISPLAY_NAMES: Record<string, string> = {
+/** Roles whose enum value differs from the word shown to a user; anything absent falls through. */
+const ROLE_DISPLAY_NAMES: Partial<Record<DisplayRole, string>> = {
   [Role.User]: "Member",
   [Role.SuperAdmin]: "Super Admin",
 };
@@ -61,7 +54,7 @@ export function getUserDisplayRoles(
   }
 
   return Array.from(roles)
-    .map(role => ROLE_DISPLAY_NAMES[role] ?? (role as string))
+    .map(role => ROLE_DISPLAY_NAMES[role] ?? role)
     .sort();
 }
 

--- a/src/lib/utils/user-roles.ts
+++ b/src/lib/utils/user-roles.ts
@@ -12,6 +12,19 @@ import { type Option, Some, None } from "@/types/option";
 export type DisplayRole = Role | RelationshipRole
 
 /**
+ * Recipient-facing names for roles whose enum value is not what we want to show
+ * a user. `Role.Admin` and the relationship roles already read correctly, so
+ * they are absent and fall through unchanged.
+ *
+ * "Member" matches the add-member dialog and the row's actions menu; rendering
+ * the raw "User" here taught a second name for the same role.
+ */
+const ROLE_DISPLAY_NAMES: Record<string, string> = {
+  [Role.User]: "Member",
+  [Role.SuperAdmin]: "Super Admin",
+};
+
+/**
  * Gets display roles for a user combining organization roles and coaching relationship roles
  * @param user - The user to get roles for
  * @param organizationId - The current organization ID
@@ -47,11 +60,8 @@ export function getUserDisplayRoles(
     roles.add(RelationshipRole.Coachee);
   }
 
-  // "Member" is the recipient-facing word for Role.User, matching the add-member
-  // dialog and the row's actions menu. Showing the raw "User" here taught a
-  // different name for the same role.
   return Array.from(roles)
-    .map(role => (role === Role.User ? "Member" : (role as string)))
+    .map(role => ROLE_DISPLAY_NAMES[role] ?? (role as string))
     .sort();
 }
 


### PR DESCRIPTION
## Description

The member row's `Roles:` line rendered `SuperAdmin` verbatim — the last place a raw enum value
still reached a user after #449 started showing `Role.User` as "Member".

### Changes

* `SuperAdmin` now displays as **"Super Admin"** on the `Roles:` line.
* Replaces the inline ternary in `getUserDisplayRoles` with a `ROLE_DISPLAY_NAMES` lookup, so the
  two mappings live together and a third costs one line. `Role.Admin` and the relationship roles
  (Coach/Coachee) are deliberately absent and fall through unchanged.

### Screenshots / Videos Showing UI Changes

Helpful to attach: a members list viewed as a global super admin, showing the `Roles:` line.

### Testing Strategy

`npm run test:run` (163 files / 1746 tests), `npx tsc --noEmit`, `npm run lint`, and the chromium
Playwright suite all pass.

Two existing assertions were updated from the raw enum, and a dedicated case was added asserting
`Role.SuperAdmin` renders as "Super Admin" and never as "SuperAdmin". Verified the tests have teeth:
removing the mapping fails three of them.

`getUserDisplayRoles` is the only place a raw role value is shown to a user — everywhere else uses
the `isAdminOrSuperAdmin` / `isSuperAdmin` predicates — so this completes the sweep.

### Concerns

None. Display-only; no API, permission or behaviour change.
