### PR TITLE
Pin the Docker base image by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 # Stage 0: Base image
-FROM node:24-alpine AS base
+# Pinned by digest, not by the floating `node:24-alpine` tag. A Docker Hub push
+# to that tag can otherwise change the build environment with no commit on our
+# side, which turned a green branch red on PR #449: 13 Turbopack errors
+# (`__turbopack_context__.a is not a function`) evaluating postcss.config.js,
+# where the same `npm run build` had passed on the runner in the same workflow
+# run and a plain re-run went green. This is the multi-arch index digest, so
+# both the amd64 and the ARM64 self-hosted runner still resolve correctly.
+# To bump: docker manifest inspect node:24-alpine  (take the index digest)
+FROM node:24-alpine@sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43 AS base
 
 # BuildKit Platform Context (used for metadata, not to alter FROM)
 ARG BUILDPLATFORM


### PR DESCRIPTION
## Description

`FROM node:24-alpine` is a floating tag, so a Docker Hub push can change the build environment with
no commit on our side. That is what turned a green branch red on #449.

### Changes

* Pin stage 0 to the **multi-arch index digest**
  `sha256:d32cdf619f63fe0471182d08996dd516c6275bb5fd31ae06e55a570bd9e1ad43`, so both amd64 and the
  ARM64 self-hosted runner (`neo`) still resolve. Only stage 0 needed it — `deps`, `builder` and
  `runner` all derive from `base`.
* A comment records why, and the one-liner to bump it:
  `docker manifest inspect node:24-alpine`.

### Testing Strategy

This only takes effect in CI, so the real test is this PR's own "Build & Push Docker Image" job
going green.

Evidence the original failure was environmental rather than code:

* `npm run build` passed locally at the failing commit with a clean `.next`
* "Build & Test", which also runs `npm run build`, passed in the **same** workflow run
* all 13 errors were `.scss.css` files failing inside `postcss.config.js` evaluation with
  `TypeError: __turbopack_context__.a is not a function`, with import traces through tiptap
  primitives — nothing that PR touched
* `npm ci` installs devDependencies, so the postcss plugins were present
* a plain re-run of the identical commit went green

### Concerns

* **This may not be the cause.** The job also uses `cache-from: type=gha,scope=frontend-nonprod`, and
  a partially-stale layer cache can produce the same class of Turbopack chunk-mismatch error. I could
  not reproduce it in a container locally (no Docker daemon on that machine), so which of the two it
  was is unproven. If a non-deterministic failure recurs after this lands, that implicates the cache
  and the fix is a cache-scope bump.
* Pinning means security patches to the base image no longer arrive silently. That is the intended
  trade — reproducible builds over automatic drift — but it does need an occasional deliberate bump.
