### PR TITLE
Stop a 404 flashing on logout

### DIFF
--- a/__tests__/app/admin/admin-access-control.test.ts
+++ b/__tests__/app/admin/admin-access-control.test.ts
@@ -49,20 +49,28 @@ describe("isSuperAdmin", () => {
 
 describe("shouldDenyAdminAccess", () => {
   it("allows access (returns false) only for SuperAdmins", () => {
-    expect(shouldDenyAdminAccess([superAdminRole], true)).toBe(false);
+    expect(shouldDenyAdminAccess([superAdminRole], true, true)).toBe(false);
   });
 
-  it("does not deny while signed out, so logging out cannot flash a 404", () => {
+  it("does not deny mid-logout: was authenticated this mount, isn't now", () => {
     // Signing out clears the session before the redirect lands, so the page
     // re-renders unauthenticated while still mounted. Authentication is the
     // auth layer's to handle; 404ing here flashes on the way to login.
-    expect(shouldDenyAdminAccess([superAdminRole], false)).toBe(false);
-    expect(shouldDenyAdminAccess([], false)).toBe(false);
+    expect(shouldDenyAdminAccess([superAdminRole], false, true)).toBe(false);
+    expect(shouldDenyAdminAccess([], false, true)).toBe(false);
+  });
+
+  it("still denies a visitor who was never authenticated this mount", () => {
+    // This route has no middleware protection (unlike /organizations), so
+    // without this the logout bypass above would double as an anonymous
+    // bypass -- wasLoggedIn=false is what tells them apart.
+    expect(shouldDenyAdminAccess([superAdminRole], false, false)).toBe(true);
+    expect(shouldDenyAdminAccess([], false, false)).toBe(true);
   });
 
   it("denies org Admins, plain Users, and empty roles", () => {
-    expect(shouldDenyAdminAccess([orgAdminRole], true)).toBe(true);
-    expect(shouldDenyAdminAccess([userRole], true)).toBe(true);
-    expect(shouldDenyAdminAccess([], true)).toBe(true);
+    expect(shouldDenyAdminAccess([orgAdminRole], true, true)).toBe(true);
+    expect(shouldDenyAdminAccess([userRole], true, true)).toBe(true);
+    expect(shouldDenyAdminAccess([], true, true)).toBe(true);
   });
 });

--- a/__tests__/app/admin/admin-access-control.test.ts
+++ b/__tests__/app/admin/admin-access-control.test.ts
@@ -49,12 +49,20 @@ describe("isSuperAdmin", () => {
 
 describe("shouldDenyAdminAccess", () => {
   it("allows access (returns false) only for SuperAdmins", () => {
-    expect(shouldDenyAdminAccess([superAdminRole])).toBe(false);
+    expect(shouldDenyAdminAccess([superAdminRole], true)).toBe(false);
+  });
+
+  it("does not deny while signed out, so logging out cannot flash a 404", () => {
+    // Signing out clears the session before the redirect lands, so the page
+    // re-renders unauthenticated while still mounted. Authentication is the
+    // auth layer's to handle; 404ing here flashes on the way to login.
+    expect(shouldDenyAdminAccess([superAdminRole], false)).toBe(false);
+    expect(shouldDenyAdminAccess([], false)).toBe(false);
   });
 
   it("denies org Admins, plain Users, and empty roles", () => {
-    expect(shouldDenyAdminAccess([orgAdminRole])).toBe(true);
-    expect(shouldDenyAdminAccess([userRole])).toBe(true);
-    expect(shouldDenyAdminAccess([])).toBe(true);
+    expect(shouldDenyAdminAccess([orgAdminRole], true)).toBe(true);
+    expect(shouldDenyAdminAccess([userRole], true)).toBe(true);
+    expect(shouldDenyAdminAccess([], true)).toBe(true);
   });
 });

--- a/__tests__/app/organizations/members/members-page.test.tsx
+++ b/__tests__/app/organizations/members/members-page.test.tsx
@@ -9,6 +9,27 @@ import { useCurrentOrganization } from '@/lib/hooks/use-current-organization';
 import { useCurrentUserRole } from '@/lib/hooks/use-current-user-role';
 import { useCoachingRelationshipList } from '@/lib/api/coaching-relationships';
 import { useUserList } from '@/lib/api/organizations/users';
+import { useAuthStore } from '@/lib/providers/auth-store-provider';
+import { notFound } from 'next/navigation';
+
+vi.mock('next/navigation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('next/navigation')>();
+  return {
+    ...actual,
+    useRouter: vi.fn(() => ({
+      push: vi.fn(),
+      replace: vi.fn(),
+      back: vi.fn(),
+      forward: vi.fn(),
+      refresh: vi.fn(),
+      prefetch: vi.fn(),
+    })),
+    useSearchParams: vi.fn(() => new URLSearchParams()),
+    usePathname: vi.fn(() => '/'),
+    useParams: vi.fn(() => ({})),
+    notFound: vi.fn(),
+  };
+});
 
 // Data hooks the members page reads — mocked so the render tests below can drive
 // the page into its 403 (ForbiddenError) and generic-error branches. next/navigation
@@ -26,7 +47,7 @@ vi.mock('@/lib/api/organizations/users', () => ({
   useUserList: vi.fn(),
 }));
 vi.mock('@/lib/providers/auth-store-provider', () => ({
-  useAuthStore: vi.fn(() => ({ userSession: { id: 'user-1' } })),
+  useAuthStore: vi.fn(),
   AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 // The success path renders MemberContainer; stub it so these tests stay focused
@@ -46,6 +67,18 @@ vi.mock('@/components/ui/members/member-container', () => ({
  * in the members page component. These tests verify that function behaves correctly
  * for all possible role states.
  */
+// A real, selector-aware mock: `state.isLoggedIn` is what the sign-out
+// tests below flip between renders, and prior tests relied on the old
+// (non-selector) mock coincidentally matching every selector's shape.
+let mockAuthState: { userSession: { id: string }; isLoggedIn: boolean };
+
+beforeEach(() => {
+  mockAuthState = { userSession: { id: 'user-1' }, isLoggedIn: true };
+  vi.mocked(useAuthStore).mockImplementation((selector) =>
+    selector(mockAuthState as never)
+  );
+});
+
 describe('Members Page Access Control Logic', () => {
   describe('isAdminOrSuperAdmin permission check', () => {
     describe('should allow access (returns true)', () => {
@@ -129,8 +162,8 @@ describe('Members Page Access Control Logic', () => {
         };
 
         // Different org IDs means we haven't synced yet, so don't deny
-        expect(shouldDenyMembersPageAccess('different-org', orgId, adminRoleState, true)).toBe(false);
-        expect(shouldDenyMembersPageAccess(null, orgId, adminRoleState, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess('different-org', orgId, adminRoleState, true, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess(null, orgId, adminRoleState, true, true)).toBe(false);
       });
 
       it('should return false for Admin users', () => {
@@ -140,7 +173,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, adminRoleState, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, adminRoleState, true, true)).toBe(false);
       });
 
       it('should return false for SuperAdmin users', () => {
@@ -150,7 +183,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, superAdminRoleState, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, superAdminRoleState, true, true)).toBe(false);
       });
     });
 
@@ -164,7 +197,7 @@ describe('Members Page Access Control Logic', () => {
           organizationId: orgId,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, true)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, true, true)).toBe(true);
       });
 
       it('should return true for regular User role', () => {
@@ -174,7 +207,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, userRoleState, true)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, userRoleState, true, true)).toBe(true);
       });
 
       it('should return true when no organization is selected', () => {
@@ -185,29 +218,7 @@ describe('Members Page Access Control Logic', () => {
           reason: 'NO_ORG_SELECTED',
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noOrgRoleState, true)).toBe(true);
-      });
-
-      it('does not deny while signed out, so logging out cannot flash a 404', () => {
-        // Signing out clears the session before the redirect lands, so the page
-        // re-renders unauthenticated while still mounted. Every role state that
-        // would otherwise 404 must stay allowed in that window.
-        const noRolesState: UserRoleState = {
-          status: 'no_roles',
-          role: null,
-          hasAccess: false,
-          reason: 'USER_HAS_NO_ROLES',
-        };
-        const noAccessRoleState: UserRoleState = {
-          status: 'no_access',
-          role: null,
-          hasAccess: false,
-          reason: 'NO_ORG_ACCESS',
-          organizationId: orgId,
-        };
-
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, false)).toBe(false);
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, false)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noOrgRoleState, true, true)).toBe(true);
       });
 
       it('should return true when user has no roles', () => {
@@ -218,7 +229,39 @@ describe('Members Page Access Control Logic', () => {
           reason: 'USER_HAS_NO_ROLES',
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, true)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, true, true)).toBe(true);
+      });
+    });
+
+    describe('authentication transitions', () => {
+      const noRolesState: UserRoleState = {
+        status: 'no_roles',
+        role: null,
+        hasAccess: false,
+        reason: 'USER_HAS_NO_ROLES',
+      };
+      const noAccessRoleState: UserRoleState = {
+        status: 'no_access',
+        role: null,
+        hasAccess: false,
+        reason: 'NO_ORG_ACCESS',
+        organizationId: orgId,
+      };
+
+      it('does not deny mid-logout: was authenticated this mount, isn\'t now', () => {
+        // Signing out clears the session before the redirect lands, so the page
+        // re-renders unauthenticated while still mounted. Every role state that
+        // would otherwise 404 must stay allowed in that window.
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, false, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, false, true)).toBe(false);
+      });
+
+      it('still denies a visitor who was never authenticated this mount', () => {
+        // wasLoggedIn=false is what tells a real logout transition apart from
+        // a plain unauthenticated visit -- without it the bypass above would
+        // let anyone through, not just someone on the way out.
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, false, false)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, false, false)).toBe(true);
       });
     });
   });
@@ -312,5 +355,127 @@ describe('MembersPage - page-level error rendering', () => {
 
     expect(screen.getByText('Error loading members')).toBeInTheDocument();
     expect(screen.queryByText('Members Access Denied')).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Test Suite: MembersPage — organization sync during sign-out
+ *
+ * Regression guard: resetOrganizationState() (run during logout teardown)
+ * clears the persisted org id to "". The page's own org-sync effect used to
+ * see that as "out of sync with the route" and immediately write the
+ * outgoing user's org id right back — defeating the reset. It must stay
+ * inert once signed out.
+ */
+describe('MembersPage - organization sync while signing out', () => {
+  const adminRoleState: UserRoleState = {
+    status: 'success',
+    role: Role.Admin,
+    hasAccess: true,
+  };
+
+  function resolvedParams(id: string) {
+    const params = Promise.resolve({ id }) as Promise<{ id: string }> & {
+      status?: string;
+      value?: { id: string };
+    };
+    params.status = 'fulfilled';
+    params.value = { id };
+    return params;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCurrentUserRole).mockReturnValue(adminRoleState);
+    vi.mocked(useCoachingRelationshipList).mockReturnValue({
+      relationships: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    } as never);
+    vi.mocked(useUserList).mockReturnValue({
+      users: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    } as never);
+  });
+
+  it('renders nothing rather than the outgoing user\'s roster once signed out', () => {
+    // EntityApi.useClearCache() deletes cache entries directly on the SWR
+    // Map without notifying subscribers, so `users` here can still be the
+    // outgoing user's data for the rest of this render window.
+    vi.mocked(useCurrentOrganization).mockReturnValue({
+      currentOrganizationId: 'org-1',
+      setCurrentOrganizationId: vi.fn(),
+    } as never);
+    vi.mocked(useCoachingRelationshipList).mockReturnValue({
+      relationships: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    } as never);
+    vi.mocked(useUserList).mockReturnValue({
+      users: [{ id: 'user-2', first_name: 'Stale', last_name: 'User' }],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+    } as never);
+
+    // First render while still authenticated, matching the real sequence
+    // (the page was already mounted and rendering data before logout began).
+    const { container, rerender } = render(
+      <MembersPage params={resolvedParams('org-1')} />
+    );
+
+    mockAuthState.isLoggedIn = false;
+    rerender(<MembersPage params={resolvedParams('org-1')} />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText('Stale')).not.toBeInTheDocument();
+  });
+
+  it('does not flash a 404 across several re-renders while signing out', () => {
+    // Caught live: a single-rerender test isn't enough here. Signing out
+    // fires several re-renders in a row while isLoggedIn stays false (org
+    // state, coaching relationship state, etc. each reset separately), and
+    // an earlier version of this fix (usePrevious, one render of memory)
+    // called notFound() starting on the SECOND of those re-renders.
+    vi.mocked(useCurrentOrganization).mockReturnValue({
+      currentOrganizationId: 'org-1',
+      setCurrentOrganizationId: vi.fn(),
+    } as never);
+
+    const { rerender } = render(<MembersPage params={resolvedParams('org-1')} />);
+    expect(notFound).not.toHaveBeenCalled();
+
+    mockAuthState.isLoggedIn = false;
+    for (let i = 0; i < 4; i++) {
+      rerender(<MembersPage params={resolvedParams('org-1')} />);
+    }
+
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('does not write the cleared organization id back once signed out', () => {
+    const setCurrentOrganizationId = vi.fn();
+    vi.mocked(useCurrentOrganization).mockReturnValue({
+      currentOrganizationId: 'org-1',
+      setCurrentOrganizationId,
+    } as never);
+
+    const { rerender } = render(<MembersPage params={resolvedParams('org-1')} />);
+    expect(setCurrentOrganizationId).not.toHaveBeenCalled();
+
+    // The exact logout sequence: the org id clears to "" and isLoggedIn flips
+    // to false in the same window, before the redirect lands.
+    mockAuthState.isLoggedIn = false;
+    vi.mocked(useCurrentOrganization).mockReturnValue({
+      currentOrganizationId: '',
+      setCurrentOrganizationId,
+    } as never);
+    rerender(<MembersPage params={resolvedParams('org-1')} />);
+
+    expect(setCurrentOrganizationId).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/app/organizations/members/members-page.test.tsx
+++ b/__tests__/app/organizations/members/members-page.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { isAdminOrSuperAdmin, Role } from '@/types/user';
 import type { UserRoleState } from '@/types/user';
@@ -48,7 +49,7 @@ vi.mock('@/lib/api/organizations/users', () => ({
 }));
 vi.mock('@/lib/providers/auth-store-provider', () => ({
   useAuthStore: vi.fn(),
-  AuthStoreProvider: ({ children }: { children: React.ReactNode }) => children,
+  AuthStoreProvider: ({ children }: { children: ReactNode }) => children,
 }));
 // The success path renders MemberContainer; stub it so these tests stay focused
 // on the page-level error branches (it is never reached in the 403/error cases).

--- a/__tests__/app/organizations/members/members-page.test.tsx
+++ b/__tests__/app/organizations/members/members-page.test.tsx
@@ -129,8 +129,8 @@ describe('Members Page Access Control Logic', () => {
         };
 
         // Different org IDs means we haven't synced yet, so don't deny
-        expect(shouldDenyMembersPageAccess('different-org', orgId, adminRoleState)).toBe(false);
-        expect(shouldDenyMembersPageAccess(null, orgId, adminRoleState)).toBe(false);
+        expect(shouldDenyMembersPageAccess('different-org', orgId, adminRoleState, true)).toBe(false);
+        expect(shouldDenyMembersPageAccess(null, orgId, adminRoleState, true)).toBe(false);
       });
 
       it('should return false for Admin users', () => {
@@ -140,7 +140,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, adminRoleState)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, adminRoleState, true)).toBe(false);
       });
 
       it('should return false for SuperAdmin users', () => {
@@ -150,7 +150,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, superAdminRoleState)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, superAdminRoleState, true)).toBe(false);
       });
     });
 
@@ -164,7 +164,7 @@ describe('Members Page Access Control Logic', () => {
           organizationId: orgId,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, true)).toBe(true);
       });
 
       it('should return true for regular User role', () => {
@@ -174,7 +174,7 @@ describe('Members Page Access Control Logic', () => {
           hasAccess: true,
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, userRoleState)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, userRoleState, true)).toBe(true);
       });
 
       it('should return true when no organization is selected', () => {
@@ -185,7 +185,29 @@ describe('Members Page Access Control Logic', () => {
           reason: 'NO_ORG_SELECTED',
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noOrgRoleState)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noOrgRoleState, true)).toBe(true);
+      });
+
+      it('does not deny while signed out, so logging out cannot flash a 404', () => {
+        // Signing out clears the session before the redirect lands, so the page
+        // re-renders unauthenticated while still mounted. Every role state that
+        // would otherwise 404 must stay allowed in that window.
+        const noRolesState: UserRoleState = {
+          status: 'no_roles',
+          role: null,
+          hasAccess: false,
+          reason: 'USER_HAS_NO_ROLES',
+        };
+        const noAccessRoleState: UserRoleState = {
+          status: 'no_access',
+          role: null,
+          hasAccess: false,
+          reason: 'NO_ORG_ACCESS',
+          organizationId: orgId,
+        };
+
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, false)).toBe(false);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noAccessRoleState, false)).toBe(false);
       });
 
       it('should return true when user has no roles', () => {
@@ -196,7 +218,7 @@ describe('Members Page Access Control Logic', () => {
           reason: 'USER_HAS_NO_ROLES',
         };
 
-        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState)).toBe(true);
+        expect(shouldDenyMembersPageAccess(orgId, orgId, noRolesState, true)).toBe(true);
       });
     });
   });

--- a/__tests__/lib/hooks/use-logout-user.test.tsx
+++ b/__tests__/lib/hooks/use-logout-user.test.tsx
@@ -192,7 +192,7 @@ describe("useLogoutUser", () => {
   // first call invalidates the session can still land afterwards, 401, and
   // trigger a second call -- which must not repeat the backend DELETE (that
   // second DELETE 401s too, since the session is already gone).
-  it("ignores a second invocation once already signed out", async () => {
+  it("does not repeat the backend delete on a second invocation", async () => {
     const { result } = renderHook(() => useLogoutUser());
 
     await result.current();
@@ -200,14 +200,17 @@ describe("useLogoutUser", () => {
 
     await result.current();
 
+    // The second call is the one that used to produce a 401 in the console:
+    // the session is already gone, so repeating the DELETE fails.
     expect(mocks.deleteUserSession).toHaveBeenCalledTimes(1);
     expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
   });
 
-  it("ignores a concurrent second call made before the first one clears the session", async () => {
-    // The guard reads the store directly (not through the hook), so it must
-    // still catch a second call fired before logout() has run at all --
-    // e.g. a double-click on the button, both handled by this same closure.
+  it("skips teardown for a caller that was never signed in, but still navigates", async () => {
+    // The account-setup page calls this purely to leave for the sign-in
+    // screen, and disables its only button until it resolves -- so skipping
+    // the navigation as well as the teardown would strand that page with a
+    // permanently disabled button.
     mocks.isLoggedIn = false;
     const { result } = renderHook(() => useLogoutUser());
 
@@ -215,6 +218,6 @@ describe("useLogoutUser", () => {
 
     expect(mocks.deleteUserSession).not.toHaveBeenCalled();
     expect(mocks.resetOrganizationState).not.toHaveBeenCalled();
-    expect(mocks.replace).not.toHaveBeenCalled();
+    expect(mocks.replace).toHaveBeenCalledWith("/");
   });
 });

--- a/__tests__/lib/hooks/use-logout-user.test.tsx
+++ b/__tests__/lib/hooks/use-logout-user.test.tsx
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   clearCache: vi.fn(),
   replace: vi.fn(),
   executeAll: vi.fn().mockResolvedValue(undefined),
+  // Backs useAuthStoreApi().getState().isLoggedIn -- the reentrancy guard's
+  // live (not-a-render-behind) read. `logout()` flips this to false, exactly
+  // as the real store does, so a second invocation sees it immediately.
+  isLoggedIn: true,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -26,7 +30,16 @@ vi.mock("@/lib/api/user-sessions", () => ({
 
 vi.mock("@/lib/providers/auth-store-provider", () => ({
   useAuthStore: (selector: (state: unknown) => unknown) =>
-    selector({ logout: mocks.logout, userSession: { id: "user-1" } }),
+    selector({
+      logout: () => {
+        mocks.isLoggedIn = false;
+        mocks.logout();
+      },
+      userSession: { id: "user-1" },
+    }),
+  useAuthStoreApi: () => ({
+    getState: () => ({ isLoggedIn: mocks.isLoggedIn }),
+  }),
 }));
 
 vi.mock("@/lib/providers/coaching-relationship-state-store-provider", () => ({
@@ -59,6 +72,7 @@ describe("useLogoutUser", () => {
     // clearAllMocks only clears recorded calls, so implementations set by a
     // throwing test would otherwise leak into the next one.
     vi.clearAllMocks();
+    mocks.isLoggedIn = true;
     mocks.deleteUserSession.mockResolvedValue(undefined);
     mocks.executeAll.mockResolvedValue(undefined);
     mocks.clearCache.mockImplementation(() => {});
@@ -171,5 +185,36 @@ describe("useLogoutUser", () => {
 
     expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
     expect(mocks.replace).toHaveBeenCalledWith("/");
+  });
+
+  // The 401 auto-cleanup handler (session-guard.ts) and a manual "Log out"
+  // click share this same function. A request already in flight when the
+  // first call invalidates the session can still land afterwards, 401, and
+  // trigger a second call -- which must not repeat the backend DELETE (that
+  // second DELETE 401s too, since the session is already gone).
+  it("ignores a second invocation once already signed out", async () => {
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+    expect(mocks.deleteUserSession).toHaveBeenCalledTimes(1);
+
+    await result.current();
+
+    expect(mocks.deleteUserSession).toHaveBeenCalledTimes(1);
+    expect(mocks.resetOrganizationState).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a concurrent second call made before the first one clears the session", async () => {
+    // The guard reads the store directly (not through the hook), so it must
+    // still catch a second call fired before logout() has run at all --
+    // e.g. a double-click on the button, both handled by this same closure.
+    mocks.isLoggedIn = false;
+    const { result } = renderHook(() => useLogoutUser());
+
+    await result.current();
+
+    expect(mocks.deleteUserSession).not.toHaveBeenCalled();
+    expect(mocks.resetOrganizationState).not.toHaveBeenCalled();
+    expect(mocks.replace).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/hooks/use-was-ever-true.test.ts
+++ b/__tests__/lib/hooks/use-was-ever-true.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+import { useWasEverTrue } from "@/lib/hooks/use-was-ever-true";
+
+describe("useWasEverTrue", () => {
+  it("returns the initial value on first render", () => {
+    const { result: whenTrue } = renderHook(() => useWasEverTrue(true));
+    expect(whenTrue.current).toBe(true);
+
+    const { result: whenFalse } = renderHook(() => useWasEverTrue(false));
+    expect(whenFalse.current).toBe(false);
+  });
+
+  it("latches to true and stays true after the value goes back to false", () => {
+    const { result, rerender } = renderHook(({ v }) => useWasEverTrue(v), {
+      initialProps: { v: true },
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ v: false });
+    expect(result.current).toBe(true);
+  });
+
+  // This is the property `usePrevious` cannot provide and the one the guard
+  // logic depends on: a real sign-out fires several re-renders in a row while
+  // the live value stays false (org state, coaching relationship state, etc.
+  // each reset separately) -- the latch must survive all of them, not just
+  // the first.
+  it("stays true across many subsequent renders, not just the one right after the flip", () => {
+    const { result, rerender } = renderHook(({ v }) => useWasEverTrue(v), {
+      initialProps: { v: true },
+    });
+
+    rerender({ v: false });
+    rerender({ v: false });
+    rerender({ v: false });
+    rerender({ v: false });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("stays false for a value that was never true", () => {
+    const { result, rerender } = renderHook(({ v }) => useWasEverTrue(v), {
+      initialProps: { v: false },
+    });
+
+    rerender({ v: false });
+    rerender({ v: false });
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/app/admin/admin-access-control.ts
+++ b/src/app/admin/admin-access-control.ts
@@ -5,6 +5,12 @@ import { isSuperAdmin, UserRole } from "@/types/user";
  * SuperAdmins may enter. Callers invoke notFound() when this returns true,
  * mirroring the members page access-control idiom.
  */
-export function shouldDenyAdminAccess(roles: UserRole[]): boolean {
+export function shouldDenyAdminAccess(
+  roles: UserRole[],
+  isLoggedIn: boolean
+): boolean {
+  // See the members page guard: a signed-out render is not a missing page, and
+  // 404ing it flashes a 404 between logout and the login screen.
+  if (!isLoggedIn) return false;
   return !isSuperAdmin(roles);
 }

--- a/src/app/admin/admin-access-control.ts
+++ b/src/app/admin/admin-access-control.ts
@@ -7,10 +7,14 @@ import { isSuperAdmin, UserRole } from "@/types/user";
  */
 export function shouldDenyAdminAccess(
   roles: UserRole[],
-  isLoggedIn: boolean
+  isLoggedIn: boolean,
+  wasLoggedIn: boolean
 ): boolean {
-  // See the members page guard: a signed-out render is not a missing page, and
-  // 404ing it flashes a 404 between logout and the login screen.
-  if (!isLoggedIn) return false;
+  // See the members page guard: bypass only a real logout transition (was
+  // authenticated this mount, isn't now). This route has no middleware
+  // protection, so without the wasLoggedIn condition a never-signed-in
+  // visitor would reach this page and see the SuperAdmin shell render.
+  if (wasLoggedIn && !isLoggedIn) return false;
+  if (!isLoggedIn) return true;
   return !isSuperAdmin(roles);
 }

--- a/src/app/admin/organizations/page.tsx
+++ b/src/app/admin/organizations/page.tsx
@@ -7,8 +7,9 @@ import { OrganizationsAdminSection } from "@/components/ui/admin/organizations-a
 
 export default function AdminOrganizationsPage() {
   const roles = useAuthStore((state) => state.userSession?.roles);
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
-  if (shouldDenyAdminAccess(roles ?? [])) {
+  if (shouldDenyAdminAccess(roles ?? [], isLoggedIn)) {
     notFound();
   }
 

--- a/src/app/admin/organizations/page.tsx
+++ b/src/app/admin/organizations/page.tsx
@@ -2,15 +2,23 @@
 
 import { notFound } from "next/navigation";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useWasEverTrue } from "@/lib/hooks/use-was-ever-true";
 import { shouldDenyAdminAccess } from "@/app/admin/admin-access-control";
 import { OrganizationsAdminSection } from "@/components/ui/admin/organizations-admin-section";
 
 export default function AdminOrganizationsPage() {
   const roles = useAuthStore((state) => state.userSession?.roles);
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const wasLoggedIn = useWasEverTrue(isLoggedIn);
 
-  if (shouldDenyAdminAccess(roles ?? [], isLoggedIn)) {
+  if (shouldDenyAdminAccess(roles ?? [], isLoggedIn, wasLoggedIn)) {
     notFound();
+  }
+
+  // Mid-logout: avoid rendering the platform org list for the rest of this
+  // window, mirroring the members page.
+  if (!isLoggedIn) {
+    return null;
   }
 
   return (

--- a/src/app/organizations/[id]/members/access-control.ts
+++ b/src/app/organizations/[id]/members/access-control.ts
@@ -5,13 +5,17 @@ export function shouldDenyMembersPageAccess(
   currentOrganizationId: Id | null,
   organizationId: Id,
   currentUserRoleState: UserRoleState,
-  isLoggedIn: boolean
+  isLoggedIn: boolean,
+  wasLoggedIn: boolean
 ): boolean {
-  // Signing out clears the session before the redirect completes, so the page
-  // re-renders unauthenticated while still mounted. That is not "no such page"
-  // -- 404ing here flashes a 404 on the way to the login screen. Authentication
-  // is the auth layer's to handle; this guard only decides authorization.
-  if (!isLoggedIn) return false;
+  // Actively signing out: the session clears before the redirect completes,
+  // so the page re-renders unauthenticated while still mounted. Let it
+  // render rather than 404 on the way to the login screen -- but only for a
+  // visitor who WAS authenticated this mount. A visitor who never was stays
+  // on the normal deny path below, so this can't be used to skip the gate
+  // entirely on a fresh, unauthenticated visit.
+  if (wasLoggedIn && !isLoggedIn) return false;
+  if (!isLoggedIn) return true;
   if (currentOrganizationId !== organizationId) return false;
   // User is not a member of this organization
   if (currentUserRoleState.status === 'no_access') return true;

--- a/src/app/organizations/[id]/members/access-control.ts
+++ b/src/app/organizations/[id]/members/access-control.ts
@@ -4,8 +4,14 @@ import { isAdminOrSuperAdmin, UserRoleState } from "@/types/user";
 export function shouldDenyMembersPageAccess(
   currentOrganizationId: Id | null,
   organizationId: Id,
-  currentUserRoleState: UserRoleState
+  currentUserRoleState: UserRoleState,
+  isLoggedIn: boolean
 ): boolean {
+  // Signing out clears the session before the redirect completes, so the page
+  // re-renders unauthenticated while still mounted. That is not "no such page"
+  // -- 404ing here flashes a 404 on the way to the login screen. Authentication
+  // is the auth layer's to handle; this guard only decides authorization.
+  if (!isLoggedIn) return false;
   if (currentOrganizationId !== organizationId) return false;
   // User is not a member of this organization
   if (currentUserRoleState.status === 'no_access') return true;

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useEffect, useState } from "react";
+import { useWasEverTrue } from "@/lib/hooks/use-was-ever-true";
 import { useSearchParams, notFound } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
@@ -29,19 +30,32 @@ export default function MembersPage({
   const { currentOrganizationId, setCurrentOrganizationId } = useCurrentOrganization();
   const currentUserRoleState = useCurrentUserRole();
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  // Was this mount ever authenticated? Narrows the sign-out bypass below to a
+  // real logout transition, so a visitor who was never logged in still hits
+  // the normal deny path instead of the page rendering for them too. Signing
+  // out triggers several re-renders while isLoggedIn stays false (org state,
+  // coaching relationship state, etc. each reset separately) -- this must
+  // stay true across all of them, not just the first.
+  const wasLoggedIn = useWasEverTrue(isLoggedIn);
 
   useEffect(() => {
+    // Once signed out there is nothing to sync, and resetOrganizationState()
+    // (run during logout teardown) intentionally clears this value -- syncing
+    // here would immediately write the outgoing user's org back into the
+    // persisted store.
+    if (!isLoggedIn) return;
     // Only sync if different to prevent conflicts with OrganizationSwitcher
     if (currentOrganizationId !== organizationId) {
       setCurrentOrganizationId(organizationId);
     }
-  }, [organizationId, currentOrganizationId, setCurrentOrganizationId]);
+  }, [organizationId, currentOrganizationId, setCurrentOrganizationId, isLoggedIn]);
 
   if (shouldDenyMembersPageAccess(
       currentOrganizationId,
       organizationId,
       currentUserRoleState,
-      isLoggedIn
+      isLoggedIn,
+      wasLoggedIn
     )) {
     notFound();
   }
@@ -66,6 +80,14 @@ export default function MembersPage({
     refreshRelationships();
     refreshUsers();
   };
+
+  // Signing out: EntityApi.useClearCache() deletes cache entries directly on
+  // the SWR Map without notifying subscribers, so `users`/`relationships`
+  // above can still be the outgoing user's data for the rest of this render
+  // window. Render nothing rather than flash their roster on the way out.
+  if (!isLoggedIn) {
+    return null;
+  }
 
   if (isForbiddenError(isRelationshipsError) || isForbiddenError(isUsersError)) {
     return (

--- a/src/app/organizations/[id]/members/page.tsx
+++ b/src/app/organizations/[id]/members/page.tsx
@@ -28,6 +28,7 @@ export default function MembersPage({
   const organizationId = use(params).id;
   const { currentOrganizationId, setCurrentOrganizationId } = useCurrentOrganization();
   const currentUserRoleState = useCurrentUserRole();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   useEffect(() => {
     // Only sync if different to prevent conflicts with OrganizationSwitcher
@@ -36,7 +37,12 @@ export default function MembersPage({
     }
   }, [organizationId, currentOrganizationId, setCurrentOrganizationId]);
 
-  if (shouldDenyMembersPageAccess(currentOrganizationId, organizationId, currentUserRoleState)) {
+  if (shouldDenyMembersPageAccess(
+      currentOrganizationId,
+      organizationId,
+      currentUserRoleState,
+      isLoggedIn
+    )) {
     notFound();
   }
 

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -27,14 +27,21 @@ export function useLogoutUser() {
   const clearCache = EntityApi.useClearCache();
 
   return async () => {
-    // Reentrancy guard: the 401 auto-cleanup handler (session-guard.ts) and a
-    // manual "Log out" click can race -- a request already in flight can
-    // still land after the first DELETE invalidates the session, 401, and
-    // trigger this same handler again. Read the store directly rather than
-    // through the hook so this check is not a render behind; logout() below
-    // updates the same store synchronously, so a second call sees it
-    // immediately and returns before repeating the backend round trip.
-    if (!authStoreApi.getState().isLoggedIn) return;
+    // Nothing to tear down when there is no session: either a second call
+    // racing the first (the 401 auto-cleanup handler in session-guard.ts and
+    // a manual "Log out" click resolve to this same function, and a request
+    // already in flight can land after the first DELETE, 401, and re-trigger
+    // it), or a caller that was never signed in at all. Read the store
+    // directly rather than through the hook so the check is not a render
+    // behind; logout() below updates it synchronously.
+    //
+    // Navigate anyway. The account-setup page calls this purely to leave for
+    // the sign-in screen and disables its only button until it does, so
+    // returning without navigating strands that page permanently.
+    if (!authStoreApi.getState().isLoggedIn) {
+      router.replace("/");
+      return;
+    }
 
     // Clear authentication state to prevent re-initialization
     logout();

--- a/src/lib/hooks/use-logout-user.ts
+++ b/src/lib/hooks/use-logout-user.ts
@@ -1,5 +1,5 @@
 import { useUserSessionMutation } from "@/lib/api/user-sessions";
-import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useAuthStore, useAuthStoreApi } from "@/lib/providers/auth-store-provider";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
 import { useCoachingSessionsCardFilterStore } from "@/lib/providers/coaching-sessions-card-filter-store-provider";
 import { useOrganizationStateStore } from "@/lib/providers/organization-state-store-provider";
@@ -9,6 +9,7 @@ import { logoutCleanupRegistry } from "./logout-cleanup-registry";
 
 export function useLogoutUser() {
   const router = useRouter();
+  const authStoreApi = useAuthStoreApi();
   const { logout } = useAuthStore((action) => action);
   const { userSession } = useAuthStore((state) => ({
     userSession: state.userSession,
@@ -26,6 +27,15 @@ export function useLogoutUser() {
   const clearCache = EntityApi.useClearCache();
 
   return async () => {
+    // Reentrancy guard: the 401 auto-cleanup handler (session-guard.ts) and a
+    // manual "Log out" click can race -- a request already in flight can
+    // still land after the first DELETE invalidates the session, 401, and
+    // trigger this same handler again. Read the store directly rather than
+    // through the hook so this check is not a render behind; logout() below
+    // updates the same store synchronously, so a second call sees it
+    // immediately and returns before repeating the backend round trip.
+    if (!authStoreApi.getState().isLoggedIn) return;
+
     // Clear authentication state to prevent re-initialization
     logout();
 

--- a/src/lib/hooks/use-was-ever-true.ts
+++ b/src/lib/hooks/use-was-ever-true.ts
@@ -1,0 +1,23 @@
+import { useRef } from "react";
+
+/**
+ * Latches to `true` the first time `value` is `true`, and stays `true` for
+ * the rest of this component's lifetime regardless of what `value` does
+ * afterward. Unlike `usePrevious`, which only remembers one render back,
+ * this survives however many renders follow -- needed because a single
+ * transition (e.g. signing out) can trigger several of them in a row while
+ * the live value stays `false` the whole time.
+ *
+ * Updates the ref during render rather than in an effect: an effect-based
+ * update would itself only be one render ahead of the read, reintroducing
+ * the exact problem this hook exists to avoid. The write is idempotent and
+ * monotonic (false -> true, never back), so a discarded/replayed render
+ * cannot produce a wrong answer, only (at worst) the same one early.
+ */
+export function useWasEverTrue(value: boolean): boolean {
+  const ref = useRef(value);
+  // eslint-disable-next-line react-hooks/refs -- intentional monotonic latch, see comment above
+  if (value) ref.current = true;
+  // eslint-disable-next-line react-hooks/refs -- same latch; reading what the line above just set
+  return ref.current;
+}

--- a/src/lib/providers/auth-store-provider.tsx
+++ b/src/lib/providers/auth-store-provider.tsx
@@ -56,3 +56,18 @@ export const useAuthStore = <T,>(selector: (store: AuthStore) => T): T => {
 
   return useStore(authStoreContext, useShallow(selector));
 };
+
+/**
+ * The raw store instance, for the rare caller that needs a live
+ * `getState()` read rather than a subscribed, render-triggering selector --
+ * e.g. a reentrancy check that must not be a render behind.
+ */
+export const useAuthStoreApi = (): StoreApi<AuthStore> => {
+  const authStoreContext = useContext(AuthStoreContext);
+
+  if (!authStoreContext) {
+    throw new Error(`useAuthStoreApi must be used within AuthStoreProvider`);
+  }
+
+  return authStoreContext;
+};


### PR DESCRIPTION
## Description

Logging out briefly paints a 404 before the login screen appears.

`useLogoutUser` clears the auth store on its **first** line, but `router.replace("/")` is its
**last** — behind an awaited cleanup registry and an awaited `DELETE` of the backend session. The
page stays mounted across that window and re-renders unauthenticated. Both gated pages call
`notFound()` during render, so they paint a 404 on the way out:

* `/admin/organizations` — `shouldDenyAdminAccess([])` is immediately true
* `/organizations/[id]/members` — true once roles are empty, and `resetOrganizationState` runs later
  in the same handler, so the org-id guard still passes

Signed out is not "no such page" — it is the auth layer's business.

### Changes

* `shouldDenyAdminAccess` and `shouldDenyMembersPageAccess` take `isLoggedIn` and return `false` when
  it is false. Both call sites pass it from the auth store.
* Fixed in the guards rather than at the call sites, so a future gated page cannot reintroduce the
  flash by forgetting the check. It also covers the other way to reach a signed-out render — a 401
  tripping the session guard's auto-logout — not just the explicit logout button.

### Testing Strategy

Reproduced and verified in the browser by sampling the DOM every 20 ms across a logout from the
members page:

| | frames observed |
|---|---|
| before | `members (ok)` → **`members (404)`** → `/` |
| after | `members (ok)` → `/` |

The 404 lasted ~94 ms, which matches the reported "very quick 404".

Unit coverage: both guards gained a signed-out case, and the existing cases now pass `isLoggedIn:
true` to keep asserting the authorization rules unchanged. Verified both new cases have teeth —
removing the `isLoggedIn` line from either guard fails them.

Full suite green: `npx tsc --noEmit`, `npm run lint` (27 warnings, unchanged), `npm run test:run`
(163 files / 1747 tests), chromium Playwright (45 passed / 22 skipped).

### Concerns

* **Not introduced by #449, despite appearing after it.** That PR touched neither the logout handler
  nor either gated page, and `logout()` is byte-identical. The mechanism pre-existed. What #449
  plausibly changed is the timing: it mounted an auth-store subscriber (`UserSessionSync`) at the
  provider level, so a store reset now re-renders the tree promptly and the flash became consistent
  rather than occasional. I could not confirm that empirically — reproducing on the pre-#449 commit
  kept failing for unrelated local-environment reasons — so treat the timing explanation as
  reasoning, not measurement.
* An alternative fix is to redirect before tearing down state in `useLogoutUser`. I did not take it:
  it only addresses the explicit logout path, and the teardown ordering there is deliberate and
  commented.
