### PR TITLE
Allow a single-org admin re-add a former member

### DIFF
--- a/__tests__/components/members/add-member-dialog-existing.test.tsx
+++ b/__tests__/components/members/add-member-dialog-existing.test.tsx
@@ -5,6 +5,7 @@ import { http, HttpResponse } from "msw";
 import { server } from "@/test-utils/msw-server";
 import { AddMemberDialog } from "@/components/ui/members/add-member-dialog";
 import { Role, type User, type UserRoleState } from "@/types/user";
+import { USER_LOOKUP_RATE_LIMITED_MESSAGE } from "@/lib/api/users";
 import { toast } from "sonner";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
@@ -135,6 +136,43 @@ describe("AddMemberDialog – existing member lookup", () => {
     expect(
       await screen.findByText("No user found with that email.")
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Add to organization" })
+    ).toBeDisabled();
+  });
+
+  it("blames the searcher, not the address, when the lookup is throttled", async () => {
+    // UserLookupEndpoint v2: the throttle is the only 429 this endpoint sends,
+    // and the generic fallback would wrongly imply the email is at fault.
+    server.use(
+      http.get("*/users", () =>
+        HttpResponse.json(
+          {
+            error: "user_lookup_rate_limited",
+            message: "Too many user lookups. Please wait before trying again.",
+            status_code: 429,
+          },
+          { status: 429 }
+        )
+      )
+    );
+    const user = userEvent.setup();
+    renderDialog(adminRole);
+
+    await user.click(screen.getByRole("tab", { name: "Add existing member" }));
+    await user.type(screen.getByLabelText("Email"), "ada@example.com");
+    await user.click(screen.getByRole("button", { name: "Find" }));
+
+    expect(
+      await screen.findByText(USER_LOOKUP_RATE_LIMITED_MESSAGE)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("There was an error looking up that email.")
+    ).not.toBeInTheDocument();
+    // The backend's own prose names neither the limit nor a retry time.
+    expect(
+      screen.queryByText(/Too many user lookups/)
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Add to organization" })
     ).toBeDisabled();
@@ -451,9 +489,9 @@ describe("AddMemberDialog – attaching an existing member", () => {
 });
 
 describe("AddMemberDialog – gating the existing-member tab", () => {
-  it("hides the tab from an admin who administers only one organization", () => {
-    // They would be able to open it and look people up, but every result is
-    // already a member, so the tab can only lead to a conflict.
+  it("hides the tab when the caller has no candidates to look up", () => {
+    // The predicate deciding this lives in canAddExistingMembers; here we only
+    // assert the dialog honours its answer.
     renderDialog(adminRole, [GRACE], false);
 
     expect(

--- a/__tests__/lib/api/users-lookup-errors.test.ts
+++ b/__tests__/lib/api/users-lookup-errors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { EntityApiError } from "@/types/entity-api-error";
+import {
+  USER_LOOKUP_RATE_LIMITED_MESSAGE,
+  userLookupRateLimitedMessage,
+} from "@/lib/api/users";
+
+/** Mirrors the sibling organization-errors suite so both read the same way. */
+function apiError(status: number, data?: unknown): EntityApiError {
+  const axiosLike = Object.assign(new Error("Request failed"), {
+    isAxiosError: true,
+    response: { status, statusText: "Too Many Requests", data },
+  });
+  return new EntityApiError("GET", "/users", axiosLike);
+}
+
+describe("userLookupRateLimitedMessage", () => {
+  it("matches a 429 carrying the backend's slug and message", () => {
+    // The shape measured off the wire for UserLookupEndpoint v2.
+    expect(
+      userLookupRateLimitedMessage(
+        apiError(429, {
+          error: "user_lookup_rate_limited",
+          message: "Too many user lookups. Please wait before trying again.",
+          status_code: 429,
+        })
+      )
+    ).toBe(USER_LOOKUP_RATE_LIMITED_MESSAGE);
+  });
+
+  it("still matches a 429 with no slug, or no body at all", () => {
+    // The platform's other 429 (password reset) answers in plain text. If this
+    // endpoint ever follows suit, the admin must still get the real reason.
+    expect(userLookupRateLimitedMessage(apiError(429))).toBe(
+      USER_LOOKUP_RATE_LIMITED_MESSAGE
+    );
+    expect(
+      userLookupRateLimitedMessage(apiError(429, "TOO MANY REQUESTS"))
+    ).toBe(USER_LOOKUP_RATE_LIMITED_MESSAGE);
+  });
+
+  it("declines the endpoint's other failures, which are bare strings", () => {
+    // 400/401/403 carry no slug, so status is the only discriminator and it
+    // must not over-match.
+    expect(userLookupRateLimitedMessage(apiError(400, "BAD REQUEST"))).toBeNull();
+    expect(userLookupRateLimitedMessage(apiError(403, "FORBIDDEN"))).toBeNull();
+  });
+
+  it("declines a non-API error", () => {
+    expect(userLookupRateLimitedMessage(new Error("network down"))).toBeNull();
+    expect(userLookupRateLimitedMessage(undefined)).toBeNull();
+  });
+
+  it("states the cause without backend policy or a retry time", () => {
+    // No cap and no duration: the first is policy the reader cannot act on, the
+    // second would be a guess, since the window is a rolling count and the
+    // backend sends no Retry-After.
+    expect(USER_LOOKUP_RATE_LIMITED_MESSAGE).toMatch(/searches/);
+    expect(USER_LOOKUP_RATE_LIMITED_MESSAGE).not.toMatch(/\d/);
+  });
+});

--- a/__tests__/types/user.test.ts
+++ b/__tests__/types/user.test.ts
@@ -163,10 +163,10 @@ describe('canAddExistingMembers', () => {
     updated_at: '2026-01-01T00:00:00Z',
   });
 
-  it('is false for an admin of a single organization', () => {
-    // Everyone they can look up is already a member there, so the flow can only
-    // ever return "already a member".
-    expect(canAddExistingMembers([role(Role.Admin, 'org-1')])).toBe(false);
+  it('is true for an admin of a single organization', () => {
+    // The lookup surfaces former members of an administered organization, so one
+    // is enough: this admin can recover someone they removed.
+    expect(canAddExistingMembers([role(Role.Admin, 'org-1')])).toBe(true);
   });
 
   it('is true for an admin of two organizations', () => {
@@ -175,17 +175,19 @@ describe('canAddExistingMembers', () => {
     ).toBe(true);
   });
 
-  it('does not count organizations where the user is only a member', () => {
-    // Visibility requires Admin in the shared organization, not membership.
+  it('requires Admin, not mere membership, in the administered organization', () => {
     expect(
       canAddExistingMembers([role(Role.Admin, 'org-1'), role(Role.User, 'org-2')])
+    ).toBe(true);
+    expect(
+      canAddExistingMembers([role(Role.User, 'org-1'), role(Role.User, 'org-2')])
     ).toBe(false);
   });
 
-  it('counts distinct organizations, not role rows', () => {
-    expect(
-      canAddExistingMembers([role(Role.Admin, 'org-1'), role(Role.Admin, 'org-1')])
-    ).toBe(false);
+  it('ignores an Admin row with no organization scope', () => {
+    // Org-scoped admin is what grants lookup reach; an unscoped Admin row is not
+    // a SuperAdmin and administers nothing.
+    expect(canAddExistingMembers([role(Role.Admin, null)])).toBe(false);
   });
 
   it('is true for a super admin holding no organization roles', () => {

--- a/src/components/ui/members/add-member-dialog.tsx
+++ b/src/components/ui/members/add-member-dialog.tsx
@@ -23,12 +23,12 @@ import {
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useUserMutation } from "@/lib/api/organizations/users";
-import { UserApi } from "@/lib/api/users";
 import {
   organizationArchivedMessage,
   userAlreadyInOrganizationMessage,
   USER_ALREADY_IN_ORGANIZATION_MESSAGE,
 } from "@/lib/api/organization-errors";
+import { UserApi, userLookupRateLimitedMessage } from "@/lib/api/users";
 import {
   NewUser,
   Role,
@@ -176,10 +176,13 @@ export function AddMemberDialog({
     } catch (error) {
       if (lookupRequest.current !== request) return;
       console.error("Error looking up user:", error);
+      // The throttle first: its generic fallback blames the address, when the
+      // limit is on the admin doing the searching.
       setLookupMessage(
-        isForbiddenError(error)
-          ? PERMISSION_DENIED_MESSAGE
-          : "There was an error looking up that email.",
+        userLookupRateLimitedMessage(error) ??
+          (isForbiddenError(error)
+            ? PERMISSION_DENIED_MESSAGE
+            : "There was an error looking up that email."),
       );
     } finally {
       if (lookupRequest.current === request) setIsLookingUp(false);

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -3,6 +3,7 @@
 import { siteConfig } from "@/site.config";
 import { Id } from "@/types/general";
 import { EntityApi } from "./entity-api";
+import { EntityApiError } from "@/types/entity-api-error";
 import {
   User,
   NewUserPassword,
@@ -121,3 +122,44 @@ export const useUserPasswordMutation = () => {
       EntityApi.updateFn<NewUserPassword, User>(`${USERS_BASEURL}/${id}/password`, data),
   });
 };
+
+/**
+ * Errors from the email lookup above (board contract `UserLookupEndpoint` v2).
+ *
+ * Only the 429 carries an `error` slug on that endpoint; its 400/401/403 are
+ * bare strings. So these branch on status, not on the body.
+ */
+
+/**
+ * Deliberately ours rather than the backend's prose. Theirs, "Too many user
+ * lookups. Please wait before trying again.", names neither the cause nor what
+ * to do, unlike `last_organization_admin`, which we do render verbatim.
+ *
+ * States neither the cap (30 per hour, backend-side policy the reader cannot
+ * act on) nor a retry time. The window is a rolling count rather than a bucket
+ * that empties on the hour, and the backend sends no `Retry-After`, so any
+ * duration would be a guess that reads as a promise.
+ *
+ * "searches" is exact: every authorized lookup counts, including ones that find
+ * nobody, which is the common case when recovering several removed members.
+ */
+export const USER_LOOKUP_RATE_LIMITED_MESSAGE =
+  "You've made too many searches. Wait a few minutes and try again.";
+
+/**
+ * The lookup throttle, keyed on status alone. Returns the message when the
+ * error is one, otherwise null — so callers can write
+ * `userLookupRateLimitedMessage(error) ?? fallback`.
+ *
+ * Matching the status and ignoring the `user_lookup_rate_limited` slug is
+ * intentional: the slug adds nothing (the throttle is this endpoint's only 429),
+ * and the platform's other 429 — password reset — answers in plain text with no
+ * slug at all. Should this one ever follow suit, the message still lands.
+ *
+ * The limit is per authenticated requester, not per IP, so the copy can blame
+ * the reader without being wrong about a colleague's searches.
+ */
+export const userLookupRateLimitedMessage = (error: unknown): string | null =>
+  EntityApiError.isEntityApiError(error) && error.status === 429
+    ? USER_LOOKUP_RATE_LIMITED_MESSAGE
+    : null;

--- a/src/lib/api/users.ts
+++ b/src/lib/api/users.ts
@@ -123,41 +123,15 @@ export const useUserPasswordMutation = () => {
   });
 };
 
-/**
- * Errors from the email lookup above (board contract `UserLookupEndpoint` v2).
- *
- * Only the 429 carries an `error` slug on that endpoint; its 400/401/403 are
- * bare strings. So these branch on status, not on the body.
- */
-
-/**
- * Deliberately ours rather than the backend's prose. Theirs, "Too many user
- * lookups. Please wait before trying again.", names neither the cause nor what
- * to do, unlike `last_organization_admin`, which we do render verbatim.
- *
- * States neither the cap (30 per hour, backend-side policy the reader cannot
- * act on) nor a retry time. The window is a rolling count rather than a bucket
- * that empties on the hour, and the backend sends no `Retry-After`, so any
- * duration would be a guess that reads as a promise.
- *
- * "searches" is exact: every authorized lookup counts, including ones that find
- * nobody, which is the common case when recovering several removed members.
- */
+/** Ours, not the backend's: its 429 prose names neither the cause nor what to do. */
 export const USER_LOOKUP_RATE_LIMITED_MESSAGE =
   "You've made too many searches. Wait a few minutes and try again.";
 
 /**
- * The lookup throttle, keyed on status alone. Returns the message when the
- * error is one, otherwise null — so callers can write
- * `userLookupRateLimitedMessage(error) ?? fallback`.
- *
- * Matching the status and ignoring the `user_lookup_rate_limited` slug is
- * intentional: the slug adds nothing (the throttle is this endpoint's only 429),
- * and the platform's other 429 — password reset — answers in plain text with no
- * slug at all. Should this one ever follow suit, the message still lands.
- *
- * The limit is per authenticated requester, not per IP, so the copy can blame
- * the reader without being wrong about a colleague's searches.
+ * The lookup throttle (board contract `UserLookupEndpoint` v2), matched on
+ * status alone. The `user_lookup_rate_limited` slug adds nothing, since the
+ * throttle is this endpoint's only 429, and the platform's other 429 answers in
+ * plain text with no slug at all.
  */
 export const userLookupRateLimitedMessage = (error: unknown): string | null =>
   EntityApiError.isEntityApiError(error) && error.status === 429

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -195,12 +195,15 @@ export function isSuperAdmin(roles: UserRole[]): boolean {
  * Whether adding an *existing* account to an organization can do anything for
  * this user.
  *
- * The lookup behind that flow only returns users who belong to an organization
- * the requester administers, and adding someone to an organization they are
- * already in is rejected. An admin of a single organization therefore has a
- * visible set that is exactly their existing members, so the flow can only ever
- * conflict. Two or more administered organizations gives them somewhere to move
- * people from; a SuperAdmin sees every account.
+ * The lookup behind that flow returns users who belong to an organization the
+ * requester administers, and — since backend `feat/readd-former-organization-member`
+ * — also users with a prior recorded role change in one. That second half is why
+ * a single administered organization is enough: it makes former members findable,
+ * so an admin can recover someone they removed. Adding a *current* member is
+ * still rejected as a conflict. A SuperAdmin sees every account.
+ *
+ * Removals predating the backend's `user_role_changes` history are not
+ * recoverable this way and still need a SuperAdmin.
  *
  * @param roles - Every role assignment the user holds, across all organizations
  * @returns true when the add-existing-member flow has candidates to offer
@@ -208,13 +211,7 @@ export function isSuperAdmin(roles: UserRole[]): boolean {
 export function canAddExistingMembers(roles: UserRole[]): boolean {
   if (isSuperAdmin(roles)) return true;
 
-  const administered = new Set(
-    roles
-      .filter((r) => r.role === Role.Admin && r.organization_id != null)
-      .map((r) => r.organization_id)
-  );
-
-  return administered.size > 1;
+  return roles.some((r) => r.role === Role.Admin && r.organization_id != null);
 }
 
 /**


### PR DESCRIPTION
## Description
Removing a member from an organization used to be a one-way door for an admin with a single organization: the backend lookup could no longer see them, so re-adding was impossible without a super admin. Backend PR refactor-platform-rs#394 fixes the lookup; this makes the fix reachable in the UI, and stops the lookup's rate limit from blaming the email address.

### Changes
* `canAddExistingMembers` now returns true for an admin of **one** organization, not two. Its premise (every visible user is already a member, so the flow can only conflict) stopped being true once the lookup began surfacing former members.
* The lookup's `429` renders its own message instead of falling through to "There was an error looking up that email.", which pointed at the address when the limit is on the admin searching.
* Rate-limit helper lives in `src/lib/api/users.ts` next to `lookupByEmail`.

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: the **Add existing member** tab visible on Members while signed in as an admin of a single organization, and the inline throttle message after exceeding the lookup limit.

### Testing Strategy
Verified in the browser against a backend on `feat/readd-former-organization-member` with real Postgres:
1. As an admin of one organization, open **Members → Add Member**. The **Add existing member** tab is present.
2. Remove a member, then search their email on that tab. Their card appears where it previously said "No user found with that email." Re-add them; their prior coaching relationship survives.
3. Exceed the lookup limit, then search a valid address. The inline message names the searching as the cause rather than the address, and **Add to organization** stays disabled.

Automated: 165 test files / 1764 tests, `tsc --noEmit` and ESLint clean.

### Concerns
* **Removals predating 2026-08-16 stay invisible.** The backend reads `user_role_changes`, which did not exist before then, so those members still need a super admin. Likely cause if someone reports "I removed them last month and can't find them."
* The tab is mostly-conflicting for a single-org admin: searching a current member reports the conflict inline. That was already true for multi-org admins, and it buys the one capability of recovering a removed member.
* No `Retry-After` from the backend, and the window is a rolling count rather than an hourly bucket, so the message gives no retry time. Adding the header is tracked backend-side.
