### PR TITLE
Hide the session switcher when there is nothing to switch to

### DIFF
--- a/__tests__/hooks/use-show-session-switcher.test.tsx
+++ b/__tests__/hooks/use-show-session-switcher.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useShowSessionSwitcher } from "@/lib/hooks/use-show-session-switcher";
 import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { defaultInitState, type AuthStore } from "@/lib/stores/auth-store";
 import { useUserCoachingRoles } from "@/lib/api/user-coaching-relationships";
 
 vi.mock("@/lib/providers/auth-store-provider");
@@ -10,6 +11,19 @@ vi.mock("@/lib/api/user-coaching-relationships");
 describe("useShowSessionSwitcher", () => {
   const mockUseAuthStore = vi.mocked(useAuthStore);
   const mockUseUserCoachingRoles = vi.mocked(useUserCoachingRoles);
+
+  const authStore = (overrides: Partial<AuthStore> = {}): AuthStore => ({
+    ...defaultInitState,
+    syncUserSession: vi.fn(),
+    login: vi.fn(),
+    logout: vi.fn(),
+    setTimezone: vi.fn(),
+    setIsCurrentCoach: vi.fn(),
+    getIsCurrentCoach: vi.fn(() => false),
+    setIsACoach: vi.fn(),
+    getIsACoach: vi.fn(() => false),
+    ...overrides,
+  });
 
   const mockRoles = (overrides: Partial<ReturnType<typeof useUserCoachingRoles>>) => {
     mockUseUserCoachingRoles.mockReturnValue({
@@ -23,13 +37,13 @@ describe("useShowSessionSwitcher", () => {
       isError: false,
       refresh: vi.fn(),
       ...overrides,
-    } as ReturnType<typeof useUserCoachingRoles>);
+    });
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseAuthStore.mockImplementation((selector: any) =>
-      selector({ userId: "user-1" })
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector(authStore({ userId: "user-1" }))
     );
   });
 

--- a/__tests__/hooks/use-show-session-switcher.test.tsx
+++ b/__tests__/hooks/use-show-session-switcher.test.tsx
@@ -1,0 +1,111 @@
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useShowSessionSwitcher } from "@/lib/hooks/use-show-session-switcher";
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useUserCoachingRoles } from "@/lib/api/user-coaching-relationships";
+
+vi.mock("@/lib/providers/auth-store-provider");
+vi.mock("@/lib/api/user-coaching-relationships");
+
+describe("useShowSessionSwitcher", () => {
+  const mockUseAuthStore = vi.mocked(useAuthStore);
+  const mockUseUserCoachingRoles = vi.mocked(useUserCoachingRoles);
+
+  const mockRoles = (overrides: Partial<ReturnType<typeof useUserCoachingRoles>>) => {
+    mockUseUserCoachingRoles.mockReturnValue({
+      isCoach: false,
+      isCoachee: false,
+      coachRelationshipCount: 0,
+      coacheeRelationshipCount: 0,
+      participantRelationshipCount: 0,
+      relationships: [],
+      isLoading: false,
+      isError: false,
+      refresh: vi.fn(),
+      ...overrides,
+    } as ReturnType<typeof useUserCoachingRoles>);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuthStore.mockImplementation((selector: any) =>
+      selector({ userId: "user-1" })
+    );
+  });
+
+  it("shows the switcher for a coach with more than one coachee", () => {
+    mockRoles({
+      isCoach: true,
+      coachRelationshipCount: 3,
+      participantRelationshipCount: 3,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("hides the switcher for a coach with a single coachee", () => {
+    mockRoles({
+      isCoach: true,
+      coachRelationshipCount: 1,
+      participantRelationshipCount: 1,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("hides the switcher for a coachee with a single coach", () => {
+    mockRoles({
+      isCoachee: true,
+      coacheeRelationshipCount: 1,
+      participantRelationshipCount: 1,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("shows the switcher for a single-coachee coach who is also coached", () => {
+    mockRoles({
+      isCoach: true,
+      isCoachee: true,
+      coachRelationshipCount: 1,
+      coacheeRelationshipCount: 1,
+      participantRelationshipCount: 2,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("hides the switcher while relationships are loading", () => {
+    mockRoles({
+      isCoach: true,
+      coachRelationshipCount: 3,
+      participantRelationshipCount: 3,
+      isLoading: true,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("hides the switcher when the relationship fetch fails", () => {
+    mockRoles({
+      isCoach: true,
+      coachRelationshipCount: 3,
+      participantRelationshipCount: 3,
+      isError: true,
+    });
+
+    const { result } = renderHook(() => useShowSessionSwitcher());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/components/ui/join-session-popover.tsx
+++ b/src/components/ui/join-session-popover.tsx
@@ -49,8 +49,7 @@ import {
 import { getDateTimeFromString } from "@/types/general";
 
 import {
-  getRelationshipsAsCoach,
-  getRelationshipsAsCoachee,
+  getRelationshipsForUser,
   getOtherPersonName,
   sortRelationshipsByParticipantName,
 } from "@/types/coaching-relationship";
@@ -198,20 +197,10 @@ function RelationshipSessionBrowser({
   const { relationships, isLoading: isLoadingRels } =
     useCoachingRelationshipList(currentOrganizationId ?? "");
 
-  // Filter to relationships where current user is a participant
-  const userRelationships = userId
-    ? [
-        ...getRelationshipsAsCoach(userId, relationships),
-        ...getRelationshipsAsCoachee(userId, relationships),
-      ]
-    : [];
-
-  // Deduplicate (a user could theoretically appear in both arrays if data is odd)
-  const uniqueRelationships = Array.from(
-    new Map(userRelationships.map((r) => [r.id, r])).values()
+  const sortedRelationships = sortRelationshipsByParticipantName(
+    userId ? getRelationshipsForUser(userId, relationships) : [],
+    userId
   );
-
-  const sortedRelationships = sortRelationshipsByParticipantName(uniqueRelationships, userId);
 
   // Only use the parent-provided value — no automatic fallback so the user
   // must explicitly pick a relationship to avoid confusion with Today's Sessions.

--- a/src/components/ui/site-header.tsx
+++ b/src/components/ui/site-header.tsx
@@ -6,11 +6,13 @@ import { ModeToggle } from "@/components/ui/mode-toggle";
 import { JoinSessionPopover } from "@/components/ui/join-session-popover";
 import { UserNav } from "@/components/ui/user-nav";
 import { useCoachingRelationshipStateStore } from "@/lib/providers/coaching-relationship-state-store-provider";
+import { useShowSessionSwitcher } from "@/lib/hooks/use-show-session-switcher";
 
 export function SiteHeader() {
   const currentCoachingRelationshipId = useCoachingRelationshipStateStore(
     (state) => state.currentCoachingRelationshipId
   );
+  const showSessionSwitcher = useShowSessionSwitcher();
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
@@ -21,8 +23,12 @@ export function SiteHeader() {
             <CommandMenu />
           </div> */}
           <nav className="flex items-center gap-1">
-            <JoinSessionPopover defaultRelationshipId={currentCoachingRelationshipId || undefined} />
-            <div className="w-2" />
+            {showSessionSwitcher && (
+              <>
+                <JoinSessionPopover defaultRelationshipId={currentCoachingRelationshipId || undefined} />
+                <div className="w-2" />
+              </>
+            )}
             <ModeToggle />
             <UserNav />
           </nav>

--- a/src/lib/api/user-coaching-relationships.ts
+++ b/src/lib/api/user-coaching-relationships.ts
@@ -22,6 +22,8 @@ export interface UserCoachingRolesSummary {
   isCoachee: boolean;
   coachRelationshipCount: number;
   coacheeRelationshipCount: number;
+  /** Distinct relationships the user participates in, in either role. */
+  participantRelationshipCount: number;
 }
 
 /**
@@ -38,11 +40,17 @@ export function deriveRolesSummary(
   const coachRelationships = getRelationshipsAsCoach(userId, relationships);
   const coacheeRelationships = getRelationshipsAsCoachee(userId, relationships);
 
+  // Deduplicate by id: a user can hold both roles in the same relationship.
+  const participantIds = new Set(
+    [...coachRelationships, ...coacheeRelationships].map((r) => r.id)
+  );
+
   return {
     isCoach: coachRelationships.length > 0,
     isCoachee: coacheeRelationships.length > 0,
     coachRelationshipCount: coachRelationships.length,
     coacheeRelationshipCount: coacheeRelationships.length,
+    participantRelationshipCount: participantIds.size,
   };
 }
 
@@ -68,6 +76,7 @@ export const useUserCoachingRoles = (userId: Id | null) => {
           isCoachee: false,
           coachRelationshipCount: 0,
           coacheeRelationshipCount: 0,
+          participantRelationshipCount: 0,
         };
 
   return {

--- a/src/lib/api/user-coaching-relationships.ts
+++ b/src/lib/api/user-coaching-relationships.ts
@@ -10,6 +10,7 @@ import {
   CoachingRelationshipWithUserNames,
   getRelationshipsAsCoach,
   getRelationshipsAsCoachee,
+  getRelationshipsForUser,
 } from "@/types/coaching-relationship";
 import { useCoachingRelationshipList } from "./coaching-relationships";
 import { useCurrentOrganization } from "@/lib/hooks/use-current-organization";
@@ -40,17 +41,12 @@ export function deriveRolesSummary(
   const coachRelationships = getRelationshipsAsCoach(userId, relationships);
   const coacheeRelationships = getRelationshipsAsCoachee(userId, relationships);
 
-  // Deduplicate by id: a user can hold both roles in the same relationship.
-  const participantIds = new Set(
-    [...coachRelationships, ...coacheeRelationships].map((r) => r.id)
-  );
-
   return {
     isCoach: coachRelationships.length > 0,
     isCoachee: coacheeRelationships.length > 0,
     coachRelationshipCount: coachRelationships.length,
     coacheeRelationshipCount: coacheeRelationships.length,
-    participantRelationshipCount: participantIds.size,
+    participantRelationshipCount: getRelationshipsForUser(userId, relationships).length,
   };
 }
 

--- a/src/lib/hooks/use-show-session-switcher.ts
+++ b/src/lib/hooks/use-show-session-switcher.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useAuthStore } from "@/lib/providers/auth-store-provider";
+import { useUserCoachingRoles } from "@/lib/api/user-coaching-relationships";
+
+/**
+ * Whether the global nav should offer the session switcher.
+ *
+ * Useful only once the user has somewhere to switch to: two or more coaching
+ * relationships, in either role. Hidden while loading so it never flashes in
+ * and out.
+ */
+export const useShowSessionSwitcher = (): boolean => {
+  const userId = useAuthStore((state) => state.userId);
+  const { participantRelationshipCount, isLoading, isError } =
+    useUserCoachingRoles(userId ? userId : null);
+
+  if (isLoading || isError) return false;
+
+  return participantRelationshipCount > 1;
+};

--- a/src/types/coaching-relationship.ts
+++ b/src/types/coaching-relationship.ts
@@ -174,6 +174,21 @@ export function getRelationshipsAsCoachee(
 }
 
 /**
+ * Returns every relationship the user participates in, in either role.
+ * Deduplicated by id: a user can hold both roles in the same relationship.
+ */
+export function getRelationshipsForUser(
+  userId: Id,
+  relationships: CoachingRelationshipWithUserNames[]
+): CoachingRelationshipWithUserNames[] {
+  const participants = [
+    ...getRelationshipsAsCoach(userId, relationships),
+    ...getRelationshipsAsCoachee(userId, relationships),
+  ];
+  return Array.from(new Map(participants.map((r) => [r.id, r])).values());
+}
+
+/**
  * Returns the display name of the other participant in a relationship
  * relative to the given user.
  */


### PR DESCRIPTION
## Description
The "Switch Session" control in the global nav is only useful when the user has somewhere to switch to. It now renders only when the signed-in user participates in two or more coaching relationships in the current organization, in either role.

### Changes
* New `useShowSessionSwitcher` hook gating `JoinSessionPopover` in `SiteHeader`.
* `deriveRolesSummary` gains `participantRelationshipCount` (distinct relationships, either role).
* Extract `getRelationshipsForUser` and use it in both the new hook's data path and `JoinSessionPopover`, which was deriving the same deduped list inline.

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: the global nav for a user with several relationships (switcher present) and for a user with one (switcher absent, Mode toggle and avatar sit flush).

### Testing Strategy
Unit: `__tests__/hooks/use-show-session-switcher.test.tsx` covers multi-coachee coach, single-coachee coach, single-coach coachee, a single-coachee coach who is also coached, loading, and error.

Verified live against a local backend, switching orgs to hit each shape:

| Account | Org | Relationships (either role) | Switcher |
| --- | --- | --- | --- |
| user | Refactor Group | 3 (2 coach, 1 coachee) | shown |
| user | BigTable | 1 (coachee only) | hidden |
| user | Acme Corp | 2 (1 coach, 1 coachee) | shown |
| org admin | Refactor Group | 2 of 4 visible rows | shown, popover lists 2 |

The org-admin row matters: the backend returns every org relationship to an admin, so the participation filter is what keeps the popover to their own 2.

### Concerns
* Counts are scoped to the current organization, matching what the popover browses. A coach with one coachee in each of two orgs sees no switcher in either.
* A coachee with two coaches now sees the switcher. That follows from the "more than one relationship" rule but departs from a strict "never for coachees" reading.
* Hidden while relationships load or if the fetch fails, so it fades in once rather than flashing out.
* Not covered live: a coach with exactly one coachee and no other relationships. No account in the dev dataset has that shape, so that path is unit-tested only.
