### PR TITLE
fix(api): keep useEntity's fallback referentially stable

### DIFF
--- a/src/lib/api/entity-api.ts
+++ b/src/lib/api/entity-api.ts
@@ -1,5 +1,5 @@
 import { Id, EntityApiError, EMPTY_ARRAY } from "@/types/general";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   KeyedMutator,
   ScopedMutator,
@@ -425,6 +425,11 @@ export namespace EntityApi {
     defaultValue: T,
     options?: SWRConfiguration
   ) => {
+    // Callers build this inline (`defaultUser()`), so holding the first one keeps
+    // `entity` referentially stable while a fetch is pending or failed. Without it
+    // a 404 hands every render a new object and loops any effect that depends on it.
+    const fallback = useRef(defaultValue);
+
     const { data, error, isLoading, mutate } = useApiSWR<T>(url, fetcher, {
       revalidateIfStale: false,
       revalidateOnFocus: false,
@@ -433,7 +438,7 @@ export namespace EntityApi {
     });
 
     return {
-      entity: data || defaultValue,
+      entity: data || fallback.current,
       isLoading,
       isError: error,
       refresh: mutate,


### PR DESCRIPTION
## Description
A coaching session whose relationship did not resolve under the selected organization locked the page in an infinite render loop: `Maximum update depth exceeded`, no participant names, dead breadcrumb.

#### GitHub Issue: Part of #457

### Changes
* `useEntity` holds its fallback in a ref. Every caller constructs the default inline, so a pending or failed fetch handed each render a new object, and anything depending on that identity re-ran forever.

### Testing Strategy
Verified live against a local backend on the session that triggered it: `Maximum update depth exceeded` errors went from 115 and climbing to 0.

Audited all 9 `useEntity` call sites first. Each passes a freshly built `defaultX()` placeholder and none varies its default over time, so holding the first one is safe across the board. A future caller wanting a changing default would need a different approach.

### Concerns
* This stops the lockup but does not make a cross-org session usable. Opening one still renders without participant names, because the relationship is fetched scoped to the selected organization. Joining across organizations is a feature (a coach's day can interleave sessions from several), so the fix there is to resolve the session's own organization, not to block it. Tracked separately in #457.
