### PR TITLE
fix(nav): keep the session browser inside the current organization

### DIFF
--- a/__tests__/components/ui/join-session-popover.test.tsx
+++ b/__tests__/components/ui/join-session-popover.test.tsx
@@ -572,4 +572,62 @@ describe("JoinSessionPopover", () => {
       expect(screen.getByText("Select a coachee...")).toBeInTheDocument();
     });
   });
+
+  describe("organization scoping", () => {
+    const inOrgRelationship = {
+      id: "rel-1",
+      coach_id: "user-1",
+      coachee_id: "other-1",
+      organization_id: "org-1",
+      coach_first_name: "Coach",
+      coach_last_name: "Smith",
+      coachee_first_name: "Alice",
+      coachee_last_name: "Doe",
+      created_at: DateTime.now(),
+      updated_at: DateTime.now(),
+    };
+
+    function openBrowseWith(defaultRelationshipId: string) {
+      vi.mocked(useCoachingRelationshipList).mockReturnValue({
+        relationships: [inOrgRelationship],
+        isLoading: false,
+        isError: false,
+        refresh: vi.fn(),
+      });
+
+      render(
+        <TestProviders>
+          <JoinSessionPopover defaultRelationshipId={defaultRelationshipId} />
+        </TestProviders>
+      );
+
+      fireEvent.click(screen.getByText("Switch Session"));
+    }
+
+    it("ignores a relationship preselected from another organization", () => {
+      openBrowseWith("rel-from-another-org");
+
+      expect(screen.getByText("Select a coachee...")).toBeInTheDocument();
+      expect(
+        vi.mocked(useEnrichedCoachingSessionsForUser)
+      ).not.toHaveBeenCalled();
+    });
+
+    it("keeps a relationship preselected from this organization", () => {
+      openBrowseWith("rel-1");
+
+      expect(screen.getByText("Alice Doe")).toBeInTheDocument();
+    });
+
+    it("scopes the session query to the current organization", () => {
+      openBrowseWith("rel-1");
+
+      const calls = vi.mocked(useEnrichedCoachingSessionsForUser).mock.calls;
+      const lastCall = calls[calls.length - 1];
+
+      expect(lastCall[6]).toBe("rel-1");
+      expect(lastCall[8]).toBe("org-1");
+    });
+  });
+
 });

--- a/src/components/ui/join-session-popover.tsx
+++ b/src/components/ui/join-session-popover.tsx
@@ -204,7 +204,14 @@ function RelationshipSessionBrowser({
 
   // Only use the parent-provided value — no automatic fallback so the user
   // must explicitly pick a relationship to avoid confusion with Today's Sessions.
-  const selectedRelationshipId = browsingRelationshipIdProp;
+  // It survives an organization switch, so honor it only while it belongs to the
+  // organization in view; otherwise we would list sessions that cannot be opened
+  // from here.
+  const selectedRelationshipId =
+    browsingRelationshipIdProp &&
+    sortedRelationships.some((rel) => rel.id === browsingRelationshipIdProp)
+      ? browsingRelationshipIdProp
+      : undefined;
 
   const { from, to } = getDateRange(dateFilter);
 
@@ -251,6 +258,7 @@ function RelationshipSessionBrowser({
         <RelationshipSessionList
           userId={userId}
           relationshipId={selectedRelationshipId}
+          organizationId={currentOrganizationId ?? ""}
           fromDate={from}
           toDate={to}
           timezone={timezone}
@@ -264,6 +272,7 @@ function RelationshipSessionBrowser({
 function RelationshipSessionList({
   userId,
   relationshipId,
+  organizationId,
   fromDate,
   toDate,
   timezone,
@@ -271,6 +280,7 @@ function RelationshipSessionList({
 }: {
   userId: string;
   relationshipId: string;
+  organizationId: string;
   fromDate: DateTime;
   toDate: DateTime;
   timezone: string;
@@ -284,7 +294,9 @@ function RelationshipSessionList({
       [CoachingSessionInclude.Goal],
       "date",
       "desc",
-      relationshipId
+      relationshipId,
+      undefined,
+      organizationId
     );
 
   if (isLoading) {


### PR DESCRIPTION
## Description
The session browser in the Switch Session popover could offer sessions from an organization other than the one in view, which is how a user reaches a session the session page cannot open.

#### GitHub Issue: Fixes #457 (part 2; parts 1 and 3 are in #458)

### Changes
* Honor the preselected relationship only while it belongs to the organization in view. It is stored in sessionStorage and survives an organization switch, so it could otherwise point somewhere else entirely.
* Pass the organization to the browser's session query, so the request is explicitly scoped rather than relying on the relationship alone.

### Screenshots / Videos Showing UI Changes (if applicable)
Helpful: the browse dropdown showing its placeholder (rather than a name from another organization) right after switching organizations.

### Testing Strategy
Unit: 3 cases in `__tests__/components/ui/join-session-popover.test.tsx`. Two of them fail against the previous code, verified by reverting the fix and re-running.

Verified live against a local backend: seeded the store with a BigTable relationship, then opened the popover under Acme Corp. The dropdown shows its placeholder and requests no session list; picking an Acme relationship still lists that relationship's sessions.

Confirmed the added organization filter does not change results for a relationship that already belongs to that organization: identical counts with and without it (0 for the month in view, 2 over a wide range).

### Concerns
* While relationships load, the list is briefly empty, so a valid preselection resolves a moment later. The dropdown is disabled during load, so it reads as loading rather than as a cleared choice.
* This stops the popover from offering the link. #458 is what makes the session page refuse it if a user arrives by another route, such as a pasted URL.
